### PR TITLE
keps/sig-instrumentation: Update status of 0031 to "implementable"

### DIFF
--- a/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
+++ b/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
@@ -5,9 +5,6 @@ authors:
   - "@brancz"
   - "@ehashman"
 owning-sig: sig-instrumentation
-participating-sigs:
-  - sig-aaa
-  - sig-bbb
 reviewers:
   - "@piosz"
   - "@DirectXMan12"

--- a/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
+++ b/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
@@ -3,6 +3,7 @@ kep-number: 0031
 title: Kubernetes Metrics Overhaul
 authors:
   - "@brancz"
+  - "@ehashman"
 owning-sig: sig-instrumentation
 participating-sigs:
   - sig-aaa
@@ -16,7 +17,7 @@ approvers:
 editor: @DirectXMan12
 creation-date: 2018-11-06
 last-updated: 2018-11-06
-status: provisional
+status: implementable
 ---
 
 # Kubernetes Metrics Overhaul


### PR DESCRIPTION
As discussed at the informal SIG meeting today, this KEP's status should be "implementable" now that it's been merged. Follow up to https://github.com/kubernetes/community/pull/2909

Also added myself as a coauthor of this KEP for the work I did on the google doc version and removed some non-existent participating SIGs that seemed to have slipped past the first draft :)

/sig instrumentation
/assign @brancz @DirectXMan12 