### PR TITLE
Add additional metrics guideline violations to metrics overhaul

### DIFF
--- a/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
+++ b/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
@@ -98,7 +98,7 @@ https://github.com/kubernetes/kubernetes/pull/63924
 
 #### Prober metrics
 
-Make proper metrics introduced in https://github.com/kubernetes/kubernetes/pull/61369 conform to the Kubernetes instrumentation guidelines.
+Make prober metrics introduced in https://github.com/kubernetes/kubernetes/pull/61369 conform to the [Kubernetes instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md).
 
 ### Risks and Mitigations
 

--- a/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
+++ b/keps/sig-instrumentation/0031-kubernetes-metrics-overhaul.md
@@ -96,6 +96,10 @@ https://github.com/kubernetes/kubernetes/issues/68522
 
 https://github.com/kubernetes/kubernetes/pull/63924
 
+#### Prober metrics
+
+Make proper metrics introduced in https://github.com/kubernetes/kubernetes/pull/61369 conform to the Kubernetes instrumentation guidelines.
+
 ### Risks and Mitigations
 
 Risks include users upgrading Kubernetes, but not updating their usage of Kubernetes exposed metrics in alerting and dashboarding potentially causing incidents to go unnoticed.


### PR DESCRIPTION
While looking into the kubelet API, I noticed the existance of the `/metrics/probes` endpoint, and noticed it violates the instrumentation guidelines in the same way as the cAdvisor labels do. Therefore adding those to the metrics overhaul KEP.

@DirectXMan12 @ehashman @mxinden @piosz @coffeepac @s-urbaniak @metalmatze 