### PR TITLE
Update 0031-kustomize-integration.md

### DIFF
--- a/keps/sig-cli/0031-kustomize-integration.md
+++ b/keps/sig-cli/0031-kustomize-integration.md
@@ -19,7 +19,7 @@ creation-date: 2018-11-07
 last-updated: yyyy-mm-dd
 status: pending
 see-also:
-  - [KEP-0008](https://github.com/kubernetes/community/blob/master/keps/sig-cli/0008-kustomize.md)
+  - "[KEP-0008](https://github.com/kubernetes/community/blob/master/keps/sig-cli/0008-kustomize.md)"
 replaces:
   - n/a
 superseded-by:


### PR DESCRIPTION
- fix YAML front matter rendering by quoting the embedded markdown of `see-also:` as mentioned in a comment to PR #680 

For reviewers. compare these renderings:

Good: https://github.com/kubernetes/enhancements/blob/1db7af14fadfcb72dbdb51475b116de4eda0ff9d/keps/sig-cli/0031-kustomize-integration.md
Bad: https://github.com/kubernetes/enhancements/blob/e03cd8525b7226359303705c356bf98bdbca2e6d/keps/sig-cli/0031-kustomize-integration.md