### PR TITLE
RuntimeClass Beta criteria

### DIFF
--- a/keps/sig-node/0014-runtime-class.md
+++ b/keps/sig-node/0014-runtime-class.md
@@ -307,29 +307,33 @@ RuntimeClasses.
 
 Alpha:
 
-- Everything described in the current proposal:
-  - Introduce the RuntimeClass API resource
-  - Add a RuntimeClassName field to the PodSpec
-  - Add a RuntimeHandler field to the CRI `RunPodSandboxRequest`
-  - Lookup the RuntimeClass for pods & plumb through the RuntimeHandler in the Kubelet (feature
+- [x] Everything described in the current proposal:
+  - [x] Introduce the RuntimeClass API resource
+  - [x] Add a RuntimeClassName field to the PodSpec
+  - [x] Add a RuntimeHandler field to the CRI `RunPodSandboxRequest`
+  - [x] Lookup the RuntimeClass for pods & plumb through the RuntimeHandler in the Kubelet (feature
     gated)
-- RuntimeClass support in at least one CRI runtime & dockershim
-  - Runtime Handlers can be statically configured by the runtime, and referenced via RuntimeClass
-  - An error is reported when the handler or is unknown or unsupported
-- Testing
-  - [CRI validation tests][cri-validation]
-  - Kubernetes E2E tests (only validating single runtime handler cases)
-
-[cri-validation]: https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md
+- [x] RuntimeClass support in at least one CRI runtime & dockershim
+  - [x] Runtime Handlers can be statically configured by the runtime, and referenced via RuntimeClass
+  - [x] An error is reported when the handler or is unknown or unsupported
+- [x] Testing
+  - [x] Kubernetes E2E tests (only validating single runtime handler cases)
 
 Beta:
 
-- Most runtimes support RuntimeClass, and the current [untrusted annotations](#runtime-handler) are
+- [x] Several major runtimes support RuntimeClass, and the current [untrusted annotations](#runtime-handler) are
   deprecated.
-- RuntimeClasses are configured in the E2E environment with test coverage of a non-legacy RuntimeClass
-- The update & upgrade story is revisited, and a longer-term approach is implemented as necessary.
-- The cluster admin can choose which RuntimeClass is the default in a cluster.
-- Additional requirements TBD
+  - [x] [containerd](https://github.com/containerd/cri/pull/891)
+  - [x] [CRI-O](https://github.com/kubernetes-sigs/cri-o/pull/1847)
+  - [x] [dockershim](https://github.com/kubernetes/kubernetes/pull/67909)
+- [ ] Comprehensive test coverage
+  - [ ] [CRI validation tests][cri-validation]
+  - [ ] RuntimeClasses are configured in the E2E environment with test coverage of a non-default
+    RuntimeClass
+- [ ] Comprehensive coverage of RuntimeClass metrics. Details TBD. [#73058](http://issue.k8s.io/73058)
+- [ ] The update & upgrade story is revisited, and a longer-term approach is implemented as necessary.
+
+[cri-validation]: https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md
 
 ## Implementation History
 

--- a/keps/sig-node/0014-runtime-class.md
+++ b/keps/sig-node/0014-runtime-class.md
@@ -72,31 +72,6 @@ cluster-scoped resource tied to the runtime that can help solve these problems i
 - RuntimeClass is NOT "NodeClass". Although different nodes may run different runtimes, in general
   RuntimeClass should not be a cross product of runtime properties and node properties.
 
-The following goals are out-of-scope for the initial implementation, but may be explored in a future
-iteration:
-
-- Surfacing support for optional features by runtimes, and surfacing errors caused by
-  incompatible features & runtimes earlier.
-- Automatic runtime or feature discovery - initially RuntimeClasses are manually defined (by the
-  cluster admin or provider), and are asserted to be an accurate representation of the runtime.
-- Scheduling in heterogeneous clusters - it is possible to operate a heterogeneous cluster
-  (different runtime configurations on different nodes) through scheduling primitives like
-  `NodeAffinity` and `Taints+Tolerations`, but the user is responsible for setting these up and
-  automatic runtime-aware scheduling is out-of-scope.
-- Define standardized or conformant runtime classes - although I would like to declare some
-  predefined RuntimeClasses with specific properties, doing so is out-of-scope for this initial KEP.
-- [Pod Overhead][] - Although RuntimeClass is likely to be the configuration mechanism of choice,
-  the details of how pod resource overhead will be implemented is out of scope for this KEP.
-- Provide a mechanism to dynamically register or provision additional runtimes.
-- Requiring specific RuntimeClasses according to policy. This should be addressed by other
-  cluster-level policy mechanisms, such as PodSecurityPolicy.
-- "Fitting" a RuntimeClass to pod requirements - In other words, specifying runtime properties and
-  letting the system match an appropriate RuntimeClass, rather than explicitly assigning a
-  RuntimeClass by name. This approach can increase portability, but can be added seamlessly in a
-  future iteration.
-
-[Pod Overhead]: https://docs.google.com/document/d/1EJKT4gyl58-kzt2bnwkv08MIUZ6lkDpXcxkHqCvvAp4/edit
-
 ### User Stories
 
 - As a cluster operator, I want to provide multiple runtime options to support a wide variety of
@@ -162,21 +137,8 @@ type PodSpec struct {
 }
 ```
 
-The `legacy` RuntimeClass name is reserved. The legacy RuntimeClass is defined to be fully backwards
-compatible with current Kubernetes. This means that the legacy runtime does not specify any
-RuntimeHandler or perform any feature validation (all features are "supported").
-
-```go
-const (
-    // RuntimeClassNameLegacy is a reserved RuntimeClass name. The legacy
-    // RuntimeClass does not specify a runtime handler or perform any
-    // feature validation.
-    RuntimeClassNameLegacy = "legacy"
-)
-```
-
-An unspecified RuntimeClassName `""` is equivalent to the `legacy` RuntimeClass, though the field is
-not defaulted to `legacy` (to leave room for configurable defaults in a future update).
+An unspecified `nil` or empty `""` RuntimeClassName is equivalent to the backwards-compatible
+default behavior as if the RuntimeClass feature is disabled.
 
 #### Examples
 
@@ -371,10 +333,38 @@ Beta:
 
 ## Implementation History
 
+- 2018-09-27: RuntimeClass released as alpha with Kubernetes v1.12
 - 2018-06-11: SIG-Node decision to move forward with proposal
 - 2018-06-19: Initial KEP published.
 
 ## Appendix
+
+### Proposed Future Enhancements
+
+The following ideas may be explored in a future iteration:
+
+- Surfacing support for optional features by runtimes, and surfacing errors caused by
+  incompatible features & runtimes earlier.
+- Automatic runtime or feature discovery - initially RuntimeClasses are manually defined (by the
+  cluster admin or provider), and are asserted to be an accurate representation of the runtime.
+- Scheduling in heterogeneous clusters - it is possible to operate a heterogeneous cluster
+  (different runtime configurations on different nodes) through scheduling primitives like
+  `NodeAffinity` and `Taints+Tolerations`, but the user is responsible for setting these up and
+  automatic runtime-aware scheduling is out-of-scope.
+- Define standardized or conformant runtime classes - although I would like to declare some
+  predefined RuntimeClasses with specific properties, doing so is out-of-scope for this initial KEP.
+- [Pod Overhead][] - Although RuntimeClass is likely to be the configuration mechanism of choice,
+  the details of how pod resource overhead will be implemented is out of scope for this KEP.
+- Provide a mechanism to dynamically register or provision additional runtimes.
+- Requiring specific RuntimeClasses according to policy. This should be addressed by other
+  cluster-level policy mechanisms, such as PodSecurityPolicy.
+- "Fitting" a RuntimeClass to pod requirements - In other words, specifying runtime properties and
+  letting the system match an appropriate RuntimeClass, rather than explicitly assigning a
+  RuntimeClass by name. This approach can increase portability, but can be added seamlessly in a
+  future iteration.
+- The cluster admin can choose which RuntimeClass is the default in a cluster.
+
+[Pod Overhead]: https://docs.google.com/document/d/1EJKT4gyl58-kzt2bnwkv08MIUZ6lkDpXcxkHqCvvAp4/edit
 
 ### Examples of runtime variation
 

--- a/keps/sig-node/runtime-class.md
+++ b/keps/sig-node/runtime-class.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 14
 title: Runtime Class
 authors:
   - "@tallclair"


### PR DESCRIPTION
Cleanup RuntimeClass KEP to match the alpha implementation:
- Removed the references to the `legacy` RuntimeClass. This didn't end up getting implemented, and I think it just adds unnecessary complexity.
- Moved enhancement ideas from non-goals to their own section at the end

Enumerated beta criteria, please LMK if you think anything is missing!
- Added monitoring criteria
- Removed default selection. I think this is better handled by a cluster policy mechanism (e.g. PodSecurityPolicy)

/sig node
/kind design
/priority important-soon
/milestone v1.14