### PR TITLE
Add stage graduation to the list of issues that require a KEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An enhancement is anything that:
 
 - a blog post would be written about after its release (ex. [minikube](https://kubernetes.io/blog/2016/07/minikube-easily-run-kubernetes-locally/), [StatefulSets](https://kubernetes.io/blog/2016/07/thousand-instances-of-cassandra-using-kubernetes-pet-set/), [rkt container runtime](https://kubernetes.io/blog/2016/07/rktnetes-brings-rkt-container-engine-to-kubernetes/))
 - requires multiple parties/SIGs/owners participating to complete (ex. GPU scheduling [API, Core, & Node], StatefulSets [Storage & API])
+- will be graduating from one stage to another (ex. alpha to beta, beta to GA)
 - needs significant effort or changes Kubernetes in a significant way (ex. something that would take 10 person-weeks to implement, introduce or redesign a system component, or introduces API changes)
 - impacts the UX or operation of Kubernetes substantially such that engineers using Kubernetes will need retraining
 - users will notice and come to rely on


### PR DESCRIPTION
This PR adds a bullet to the "an enhancement is anything that" list in the README which establishes that the act of graduating a thing from A to B requires a KEP (which should contain an articulated graduation criteria and test plan). The reason for tracking this information in KEPs is so that we can minimize our dependence on external tools by centralizing information about the Enhancement into the KEP itself.

/assign @spiffxp @justaugustus 