### PR TITLE
Revisit RuntimeClass upgrade story

### DIFF
--- a/keps/sig-node/runtime-class.md
+++ b/keps/sig-node/runtime-class.md
@@ -245,16 +245,24 @@ types (e.g. `kata-containers` or `gvisor` RuntimeClasses).
 
 ### Versioning, Updates, and Rollouts
 
-Getting upgrades and rollouts right is a very nuanced and complicated problem. For the initial alpha
-implementation, we will kick the can down the road by making the `RuntimeClassSpec` **immutable**,
-thereby requiring changes to be pushed as a newly named RuntimeClass instance. This means that pods
-must be updated to reference the new RuntimeClass, and comes with the advantage of native support
-for rolling updates through the same mechanisms as any other application update. The
-`RuntimeClassName` pod field is also immutable post scheduling.
+Runtimes are expected to be managed by the cluster administrator (or provisioner). In most cases,
+runtime upgrades (and downgrades) should be handled by the administrator, without requiring any
+interaction from the user. In these cases, the runtimes can be treated the same way we treat other
+node components such as the Kubelet, node OS, and CRI runtime. In other words, the upgrade process
+means rolling out nodes with the updated runtime, and gradually draining and removing old nodes from
+the pool. For more details, see [Maintenance on a
+Node](https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#maintenance-on-a-node).
 
-This conservative approach is preferred since it's much easier to relax constraints in a backwards
-compatible way than tighten them. We should revisit this decision prior to graduating RuntimeClass
-to beta.
+If the upgraded runtime includes new features that users wish to take advantage of immediately, then
+node labels can be used to select nodes supporting the updated runtime. In the uncommon scenario
+where substantial changes to the runtime are made and application changes may be required, we
+recommend that the updated runtime be treated as a _new_ runtime, with a separate RuntimeClass
+(e.g. `sandboxed-v2`). This approach has the advantage of native support for rolling updates through
+the same mechanisms as any other application update, so the updated applications can be carefully
+rolled out to the new runtime.
+
+Runtime upgrades will benefit from better scheduling support, which is a feature we plan to add in a
+future release.
 
 ### Implementation Details
 
@@ -357,7 +365,7 @@ Beta:
   - [ ] RuntimeClasses are configured in the E2E environment with test coverage of a non-default
     RuntimeClass
 - [x] Comprehensive coverage of RuntimeClass metrics. [#73058](http://issue.k8s.io/73058)
-- [ ] The update & upgrade story is revisited, and a longer-term approach is implemented as necessary.
+- [x] The update & upgrade story is revisited, and a longer-term approach is implemented as necessary.
 
 [cri-validation]: https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md
 


### PR DESCRIPTION
Follow up from the recommendations in this document:
https://docs.google.com/document/d/1hH99thfjpVDG77GgBUT0yXtHb1u8E0zcT_kviwjG1k8/edit

TL;DR is that we won't make any code changes for RuntimeClass upgrades in the beta release, although I am refining the recommended approach to upgrades: only create a new RuntimeClass when there are user-facing changes and applications need to be modified.

/sig node
/priority important-longterm
/milestone v1.14
/assign @dchen1107 