### PR TITLE
CSI inline volume support KEP with suggested updates

### DIFF
--- a/keps/sig-storage/20190122-csi-inline-volumes.md
+++ b/keps/sig-storage/20190122-csi-inline-volumes.md
@@ -1,23 +1,22 @@
 ---
-title: Inline CSI Volumes
+title: Ephemeral Inline CSI Volumes
 authors:
   - "@vladimirvivien"
 owning-sig: sig-storage
 participating-sigs:
   - sig-storage
 reviewers:
-  - "@thockin"
-  - "@saad-ali"
   - "@msau42"
   - "@jsafrane"
-  - "@liggit"
+  - "@liggitt"
 approvers:
-  - TBD
+  - "@thockin"
+  - "@saad-ali"
 creation-date: 2019-01-22
 status: implementable
 ---
 
-# Inline CSI volumes
+# Ephemeral Inline CSI volumes
 
 ## Table of Contents
 
@@ -28,32 +27,28 @@ status: implementable
     * [Non-Goals](#non-goals)
 * [User Stories](#user-stories)
     * [Examples](#examples)
-* [Proposal](#proposal)
-    * [VolumeSource API](#volumesource-api)
-    * [Secret references](#secret-references)
-    * [Specifying allowed inline drivers with PodSecurityPolicy](#specifying-allowed-inline-drivers-with-podSecuritypolicy)
-    * [Persistent vs ephemeral lifecycle setting](#persistent-vs-ephemeral-lifecycle-setting)
+* [Ephemeral inline volume proposal](#ephemeral-inline-volume-proposal)
     * [VolumeHandle generation](#volumehandle-generation)
-    * [Inline CSI volume operation stages](#inline-csi-volume-operation-stages)
-    * [Security considerations](#security-considerations)
+    * [API updates](#api-updates)
+    * [Secret reference](#secret-reference)
+    * [Specifying allowed inline drivers with PodSecurityPolicy](#specifying-allowed-inline-drivers-with-podSecuritypolicy)
+    * [Ephemeral inline volume operations](#ephemeral-inline-volume-operations)
+* [Test plans](#test-plans) 
 
 ## Summary
-Currently, volumes that are backed by CSI drivers can only be used with the `PersistentVolume` and `PersistentVolumeClaim` objects. This proposal is to implement support for the ability to nest CSI volume declarations within pod specs, as is supported already by existing in-tree storage providers.
+Currently, volumes that are backed by CSI drivers can only be used with the `PersistentVolume` and `PersistentVolumeClaim` objects. This proposal is to implement support for the ability to nest CSI volume declarations within pod specs for ephemeral-style drivers.
 
 This KEP started life as [feature #2273](https://github.com/kubernetes/community/pull/2273).  Please follow that link for historical context.
 
 
 ## Motivation
-Implementing support for embedding volumes directly in pod specs would allow external CSI drivers to have feature parity with their in-tree counter parts.  There are several reasons why this is desirable:
-* It provides the community a path to move away from in-tree volume plugins to CSI, as designed in a separate proposal https://github.com/kubernetes/community/pull/2199/. 
-* This feature would make it possible to create new types of CSI drivers such as ephemeral volume drivers.  They can be used to inject arbitrary states such as configuration, secrets, identity, variables or similar information inside pods. 
-* This can also provide a migration path for older Flex-style drivers (allowing the deprecation of Flex.)
+Implementing support for embedding volumes directly in pod specs would allow driver developers to create new types of CSI drivers such as ephemeral volume drivers.  They can be used to inject arbitrary states, such as configuration, secrets, identity, variables or similar information, directly inside pods using a mounted volume. 
+
 
 ### Goals 
-* Provide a high level design for inline CSI volumes support
+* Provide a high level design for ephemeral inline CSI volumes support
 * Define API changes needed to support this feature
-* Inline CSI volumes should work with existing CSI drivers
-* Design for ephemeral inline CSI volumes support
+* Outlines how ephemeral inline CSI volumes would work 
 * Ensure that inline CSI volumes usage is secure
 
 ### Non-goals
@@ -62,36 +57,14 @@ The followings will not be addressed by this KEP:
 * Introduce required changes to existing CSI drivers for this feature
 * Support for topology or pod placement scheme for ephemeral inline volumes
 * Support for PV/PVC related features such as topology, raw block, mount options, and resizing
+* Support for inline pod specs backed by a persistent volumes
 
 ## User stories
-* As a storage provider, I want to be able to create CSI drivers that support persistent volumes that can be nested within pod specs.  These volumes would work similarly to how my current in-tree drivers work (with minor limitations addressed later).
-* As a storage provider, I want to use the CSI API to develop drivers that can mount ephemeral volumes that follow the lifecycles of pods where they are embedded.   This feature would allow me to create drivers that work similarly to how the in-tree Secrets or ConfigMaps driver works.  My ephemeral CSI driver should allow me to inject arbitrary data into a pod using a volume mount point. 
-* As a user, I want to be able to deploy pods, with persistent CSI volumes embedded in their specs, without the use of PV/PVC.  
+* As a storage provider, I want to use the CSI API to develop drivers that can mount ephemeral volumes that follow the lifecycles of pods where they are embedded.   This feature would allow me to create drivers that work similarly to how the in-tree Secrets or ConfigMaps driver works.  My ephemeral CSI driver should allow me to inject arbitrary data into a pod using a volume mount point inside the pod. 
 * As a user I want to be able to define pod specs with embedded ephemeral CSI volumes that are created/mounted when the pod is deployed and are deleted when the pod goes away.
 
 ### Examples
 
-**Example 1**
-A pod spec with a persistent inline CSI volume.  Note that the `volumeHandle` is required and refers to a pre-existing volume.
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: testpod
-spec:
-  containers:
-    ...
-  volumes:
-      - name: vol
-        csi:
-          driver: mock.storage.kubernetes.io
-          volumeAttributes:
-              name: "Mock Volume 1"
-          volumeHandle: "1"
-```
-
-**Example 2**
 A pod spec with an ephemeral inline CSI volume.  Note that because the volume is expected to be ephemeral, the `volumeHandle` is not provided.  Instead a CSI-generated ID will be submitted to the driver.
 
 ```yaml
@@ -110,51 +83,19 @@ spec:
               foo: bar
 ```
 
-## Proposal
-This proposal introduces the support of both persistent and ephemeral-style volumes nested within a pod spec definition. The following highlights the major themes of this proposal:
-
-* Support for both persistent and ephemeral volumes
-* Propose a way to clearly distinguish between persistent and ephemeral volumes.
-* Persistent inline CSI volumes must be pre-provisioned and manually de-provisioned.
-* Persistent inline CSI volumes will participate in storage flows including attach, stage, mount, unmount, unstage, and detach.
-* Persistent inline volumes must use the handle of pre-provisioned volumes
-* An ephemeral volume is created and deleted automatically following its pod's lifecycle
-* Inline ephemeral volumes receive a generated volume handle
-
-### Inline volumes
-Normally, volume operations can be triggered from PV/PVC or when from a pod spec.  Currently, CSI only supports volumes that originate from PV/PVC. When a volume is embedded inside a pod spec, it will be referred to as `inline` in this document.  Volumes that originates from inline pod specs can support two modes:
-
-* Persistent mode - the volume follows a persistent lifecycle independent of the pod where it is used.
-* Ephemeral mode - the volume follows the lifecycle of the pod where it is used.
-
-A driver may be able to support either PV/PVC-originated or pod spec originated volumes (inline).  The following is important to keep in mind:
-* When a volume originates from PV/PVC, the driver will receive all volume related CSI calls (normal operation).
-* When a volume originates from a pod spec (inline), the CSI driver will only receive a limited number of calls (see below).
-
-### Inline CSI lifecycle setting
-A CSI driver will have to indicate the inline volume lifecycle, that it supports, as either `persistent` or `ephemeral`.  This setting will be stored in a [`CSIDriver` configuration CRD](https://github.com/kubernetes/enhancements/issues/594) and will be checked at runtime by Kubelet and external CSI components for enforcement.  The setting is to inform the Kubelet and other CSI components how to process inline volume information for proper setup.
-
-#### Persistent inline mode
-For CSI drivers that indicate they support persistent inline volumes, the `CSIDriver.lifecycle` value should be set to `persistent` (default of if not provided).  When a driver is used to handle volumes from an inline context: 
-* Volumes are assumed to be originated from an inline pod spec.
-* The `volumeHandle` value must be generated ahead of time and manually entered in the pod spec.
-* The driver will only receive CSI calls related to storage opearations for *attach*, *mount*, *unmount*, *detach*.
-* The driver will not receive CSI calls for *porovision* and *deletion* of volumes.
-
-#### Ephemeral inline mode
-Ephemeral inline volumes are more restricted than their persistent counterparts.  The `CSIDriver.lifecycle = ephemeral` must be set to indicate support for inline ephemeral volumes which will follow the lifecycle of its pod.  For drivers indicating support for ephemral mode: 
-* Volumes are assumed to be originated from an inline pod spec.
-* The `volumeHandle` is not required and is ignored if provided in the pod spec.
-* CSI will internally generate a `volumeHandle` value which is passed to the driver.
-* Ephemeral volumes will only make CSI calls for *mount* and *unmount* volume operations.
-
-#### Omitting inline mode
-Omitting `CSIDriver.lifecycle` is an indication:
-* The driver can support PV/PVC originated volume (normal operation).
-* If the volume originates from a pod spec, it is assumed that its lifecycle is `persistent`.
+## Ephemeral inline volume proposal
+A CSI driver may be able to support either PV/PVC-originated or pod spec originated volumes. When a volume definition is embedded inside a pod spec, it is considered to be an `ephemeral inline` volume request and can only participate in *mount/unmount* volume operation calls.  Ephemeral inline volume requests have the following characteristics: 
+* The inline volume spec will not contain nor require a `volumeHandle`.
+* The CSI Kubelet plugin will internally generate a `volumeHandle` which is passed to the driver.
+* Using existing strategy, the volumeHandle will be cached for future volume operations (i.e. unmount).
+* The Kubelet will send mount related calls to CSI drivers:
+  * Kubelet will have access to both podUID and pod namespace during mount/Setup operations.
+  * Secrets references can be fully realized during mount/Setup phase and sent to driver.
+* The Kubelet will send unmount related calls to CSI drivers:
+  * The cached volumeHandle will be sent to the driver during unmount/Teardown phase.
 
 ### VolumeHandle generation
-When a driver has its lifecycle set to `ephemeral` (see above), the Kubelet (internal CSI code) will employ a naming strategy to generate the value for the volumeHandle.  The generated value will be a combination of `podUID` and `pod.spec.Volume[x].name` to guarantee uniqueness.
+During mount operation, the Kubelet (internal CSI code) will employ a naming strategy to generate the value for the `volumeHandle`.  The generated value will be a combination of `podUID` and `pod.spec.Volume[x].name` to guarantee uniqueness.  The generated value will be stable and the Kubelet will be able to regenerate the value, if needed, during different phases of storage operations.
 
 This approach provides several advantages:
 * It makes sure that each pod can use a different volume handle ID for its ephemeral volumes.  
@@ -163,14 +104,12 @@ This approach provides several advantages:
 
 Without an auto-generated naming strategy for the `volumeHandle` during an ephemeral lifecycle, a user could guess the volume handle ID of another user causing a security risk. Having a strategy that generates consistent volume handle names, will ensure that drivers obeying idempotency will always return the same volume associated with the podUID. 
 
-### VolumeSource API
+### API updates
 
-The design defines several objects needed to implement this feature:
-* `VolumeSource` - Object that represents a pod's volume.  Modified to include CSI volume source.
-* `CSIVolumeSource` - object representing the inline volume data
+There are couple of objects needed to implement this feature:
+* `VolumeSource` - object that represents a pod's volume. It will be modified to include CSI volume source.
+* `CSIVolumeSource` - a new object representing the inline volume data coming from the pod.
 
-
-`VolumeSource` needs to be extended with CSI volume source:
 ```go
 type VolumeSource struct {
     // <snip>
@@ -179,28 +118,20 @@ type VolumeSource struct {
     CSI *CSIVolumeSource
 }
 
+// Represents a source location of a volume to mount, managed by an external CSI driver
 type CSIVolumeSource struct {
 	// Driver is the name of the driver to use for this volume.
 	// Required.
 	Driver string
 
-	// VolumeHandle is the unique volume name returned by the CSI volume
-	// plugin’s CreateVolume to refer to the volume on all subsequent calls.
-	// If not provided, that handle will be auto-generated.
-	//
-	// +optional
-	VolumeHandle *string
-
-	// ReadOnly is the value to pass to ControllerPublishVolumeRequest.
+	// Optional: The value to pass to ControllerPublishVolumeRequest.
 	// Defaults to false (read/write).
-	// 
 	// +optional
 	ReadOnly *bool
 
 	// Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
 	// If not provided, the empty value is passed to the associated CSI driver
 	// which will determine the default filesystem to apply.
-	//
 	// +optional
 	FSType *string
 
@@ -209,44 +140,40 @@ type CSIVolumeSource struct {
 	// +optional
 	VolumeAttributes map[string]string
 
-	// ControllerPublishSecretRef is a reference to the secret object containing
-	// sensitive information to pass to the CSI driver to complete the CSI
-	// ControllerPublishVolume and ControllerUnpublishVolume calls.
-	// This field is optional, and  may be empty if no secret is required. If the
-	// secret object contains more than one secret, all secret references are passed.
-	// 
-	// +optional
-	ControllerPublishSecretRef *LocalObjectReference
-
-	// NodeStageSecretRef is a reference to the secret object containing sensitive
-	// information to pass to the CSI driver to complete the CSI NodeStageVolume
-	// and NodeStageVolume and NodeUnstageVolume calls.
-	// This field is optional, and  may be empty if no secret is required. If the
-	// secret object contains more than one secret, all secret references are passed.
-	// 
-	// +optional
-	NodeStageSecretRef *LocalObjectReference
-
 	// NodePublishSecretRef is a reference to the secret object containing
 	// sensitive information to pass to the CSI driver to complete the CSI
 	// NodePublishVolume and NodeUnpublishVolume calls.
 	// This field is optional, and  may be empty if no secret is required. If the
 	// secret object contains more than one secret, all secret references are passed.
-	// 
 	// +optional
 	NodePublishSecretRef *LocalObjectReference
 }
 ```
 
-### Secret references
-Secret references declared in an inline CSI volume can only be used with namespaces from pods where they are referenced .  For inline usage, secret references are stored in `LocalObjectReference` values:
-* `LocalObjectReference` do not include a namespace reference.  This is to prevent reference to arbitrary namespace values.
-* The namespace reference will be extracted from the the pod spec at different phases of storage lifecycle by the Kubelet or external CSI compoennts.
-* The Kubelet and external CSI components must ensure secret references can only be used with the namespace from inline pod spec.
+### Driver mode
+To indicate that the driver will support ephemeral inline volume requests, the existing `CSIDriver` object will be extended to include attribute `Mode`.  Currently the only modes that will be supported are `persistent` and `ephemeral`.  
 
+When `CSIDriver.Mode == <not specified>` or when `CSIDriver.Mode == persistent`, the driver will function as normal supporting only PV/PVC-requested volumes and
+will receive all persistent volume operation calls (i.e. provision/delete, attach/detach, mount/unmount, etc).
+
+When `CSIDriver.Mode == ephemeral` the followings are assumed:
+* Volume requests will originate from pod specs.
+* The driver will only receive volume operation calls during mount/unmount phase.
+* The driver will not receive separate gRPC calls for provisioning, attaching, detaching, and deleting of volumes.
+* The driver is responsible for implementing steps to ensure the volume is created and made available to the pod during mount call.
+* The Kubelet may attempt to mount a path, with the same generated volumeHandle, more than once. If that happens, the driver should be able to handle such cases gracefully.
+* The driver is responsible for implementing steps to delete and clean up any volume and resources during the unmount call.
+* The Kubelet may attempt to call unmount, with the same generated volumeHandle, more than once. If that happens, the driver should be able to handle such cases gracefully.
+
+A misconfigured driver (i.e. a persistent PV/PVC-supported driver with `Mode==ephemeral` or an inline driver with `Mode == persistent`) will not work properly and may cause the driver to fail during operations.  
+
+### Secret reference
+The secret reference declared in an ephemeral inline volume can only be used with namespaces from pods where it is referenced.  The `NodePublishSecretRef` is stored in a `LocalObjectReference` value:
+* `LocalObjectReference` do not include a namespace reference.  This is to prevent reference to arbitrary namespace values.
+* The namespace needed will be extracted from the the pod spec by the Kubelet code during mount.
 
 ### Specifying allowed inline drivers with `PodSecurityPolicy`
-To control which driver is allowed to be used within a pod spec, this design will update the `PodSecurityPolicy` to introduce `AllowedCSIDrivers` as shown below:
+To control which CSI driver is allowed to be use ephemeral inline volumes within a pod spec, a new `PodSecurityPolicy` called `AllowedCSIDrivers` is introduced as shown below:
 
 ```go
   type PodSecurityPolicySpec struct {
@@ -268,96 +195,34 @@ To control which driver is allowed to be used within a pod spec, this design wil
 
 Value `PodSecurityPolicy.AllowedCSIDrivers` must be explicitly set with the names of CSI drivers that are allowed to be embedded within a pod spec.  An empty value means no CSI drivers are allowed to be specified inline inside a pod spec.
 
-### Inline CSI volume operation stages
-When a CSI driver is used in an inline context, it works slightly differently then when originated from PV/PVC.  As mentioned earlier, the inline volumes will participate in some, but not all volume operation stages with some limitations discussed here.
-
-#### Provision/deletion
-Volume provision and deletion will work differently for inline volumes. For persistent inline volumes, provision/deletion is handled as follows:
-* Persistent inline volumes do not participate in the provision and deletion phases.
-* Persistent inline volumes expect provision and deletion to be handled outside of the driver.
-
-For ephemeral CSI drivers:
-* Ephemeral drivers will not receive provision/deletion API calls (since these stages are driven by a PV/PVC/StorageClass).
-* Ephemeral CSI drivers will have to delay or combine any provisioning/deprovisioning operation during different phase.
-
-#### Attach/detach
-CSI uses API object `storage.VolumeAttachment` to track and manage attach/detach storage operation. Currently that object contains reference to an associated PV when the driver is not used inline.  However,  it must be extended to support information from `CSIVolumeSource` (see above) when an inline volume is being attached.
-
-```go
-// VolumeAttachmentSpec is the specification of a VolumeAttachment request.
-type VolumeAttachmentSpec struct {
-    // <snip>
-
-	// Source represents the volume that should be attached.
-	Source VolumeAttachmentSource
-}
-
-// VolumeAttachmentSource represents a volume that should be attached, either
-// PersistentVolume or a volume in-lined in a Pod.
-// Exactly one member can be set.
-type VolumeAttachmentSource struct {
-	// Name of the persistent volume to attach.
-	// +optional
-	PersistentVolumeName *string
-
-	// InlineVolumeSource represents the source location of a in-line volume in a pod to attach.
-	// +optional
-    InlineVolumeSource *InlineVolumeSource
-}
-
-// InlineVolumeSource represents the source location of a in-line volume in a pod.
-type InlineVolumeSource struct {
-	// VolumeSource is copied from the pod. It ensures that attacher has enough
-	// information to detach a volume when the pod is deleted before detaching.
-	// Only CSIVolumeSource can be set.
-	// Required.
-	CSIVolumeSource v1.VolumeSource
-
-	// Namespace of the pod with in-line volume. It is used to resolve
-	// references to Secrets in VolumeSource.
-	// Required.
-	Namespace string
-}
-```
-The following steps outline how the API is used to track attachment and detachment of volumes:
-* The external CSI A/D controller **copies whole `VolumeSource`**  from `Pod` into `VolumeAttachment`. This allows external CSI attacher to detach volumes for deleted pods without keeping any internal database of attached VolumeSources.
-* Validation of `VolumeSource` will ensure that only `CSIVolumeSource` is being copied.  
-* External CSI attacher must be extended to  process either `PersistentVolumeName` or `VolumeSource`.
-* **External attacher may need permission to access secrets in any pod namespace** where inline volume is specified.
-* CSI `ControllerUnpublishVolume` call (~ volume detach) will require the secrets to be available at detach time. 
-* If user deletes secrets in a pod's namespace that was used to attach an inline volume, the external attacher will fail during detach (volume will remain attached), reporting errors about missing secrets to user.
-
-For persistent inline drivers:
-* Attachment will require a volumeHandle
-* As stated, volumeHandle must refer to a pre-existing provisioned volume
-
-For ephemeral inline drivers:
-* Ephemeral inline drivers must ignore attachment requests
-* Attachment requires a volumeHandle value which could be generated at that stage by Kubernetes
-* For security reason, however, autogenerated volumeHandle must include distinctive values such as `podUID` and `pod.spec.volume[x].name`, which are not available during the Attach stage
-
-### Mount/Unmount
-This phase happens in the Kubelet and is responsible for mounting/unmounting device and/or filesystem mount points.  At this stage, volume operations have access to pod information such as podUID.  The volume information will come from `volume.Spec` which contains either `v1.CSIVolumeSource` (for volume originated from pod specs) or `v1.CSIPersistentVolume` for volume originating from PV/PVC.
-
-In-tree CSI volume plugin calls in kubelet, get universal `volume.Spec`, which contains either `v1.VolumeSource` from Pod (for inline volumes) or `v1.PersistentVolume` (originated from PV/PVC). The code will check for presence of `CSIVolumeSource` or `CSIPersistentVolume` and read NodeStage/NodePublish secrets from appropriate source. Kubelet does not need any new permissions, it already can read secrets for pods that it handles. These secrets are needed only for `MountDevice/SetUp` calls and don't need to be cached until `TearDown`/`UnmountDevice`.
-
-For persistent inline drivers:
-
-* The Kubelet code will follow the natural volume operation phases supported by CSI PV/PVC volumes
-* The Kubelet code will extract volume information from `v1.CSIVolumeSource` including `volumeHandle`.
-* Kubelet will delegate storage operations (mount, unmount, etc) to external CSI driver calls respectively
-
-
-For ephemeral inline drivers:
-* During the Setup/Mount stage, `podUID` and `pod.spec.volume[x].name` will be available
+### Ephemeral inline volume operations
+Inline volume requests can only participate in mount/unmount volume operations. This phase is handled by the Kubelet which is responsible for mounting/unmounting device and/or filesystem mount points inside a pod. At mount time, the internal API will pass the volume information via parameter of `volume.Spec` which will contain a value of either type `v1.CSIVolumeSource` (for volume originated from pod specs) or `v1.CSIPersistentVolume` for volume originating from PV/PVC.  The code will check for the presence of a `v1.CSIVolumeSource` or `v1.CSIPersistentVolume` value.  If a `v1.CSIPersistentVolume` is found, the operation is considered non-ephemeral and follows regular PV/PVC execution flow.  If, however, the internal volume API passes a `v1.CSIVolumeSource`:
 * The Kubelet will create necessary mount point paths
-* Kubelet will auto-generate a volumeHandle based on `podUID` and `pod.spec.volume[x].name` (see above for detail)
-* Ephemeral drivers will receive mount-like calls (NodePublish) with generated paths and volumeHandle
-* Ephemeral drivers are responsible for handling volume operations (create, mount, unmount, delete) during this stage
+* Kubelet will auto-generate a volumeHandle based on `podUID` and `pod.spec.volume[x].name` (see above for detail).
+* CSI driver will receive mount-like calls (NodePublish) with generated paths and generated volumeHandle.
 
-## Security considerations
-As written above, external attacher may require permissions to read Secrets in any namespace. It is up to CSI driver author to document if the driver needs such permission (i.e. access to Secrets at attach/detach time) and up to cluster admin to deploy the driver with these permissions or restrict external attacher to access secrets only in some namespaces.
+Since ephemeral volume requests will participate in only the mount/unmount volume operation phase, CSI drivers are responsible for implementing all necessary operations during that phase (i.e. create, mount, unmount, delete, etc).  For instance, a driver would be responsible for provisioning any new volume resource during `NodePublish` and for tearing down these resources during the `NodeUnpublish` calls.
 
-* Since access to in-line volumes can be configured by `PodSecurityPolicy` (see above), we expect that cluster admin gives access to CSI drivers that require secrets at detach time only to educated users that know they should not delete Secrets used in volumes.
-* Number of CSI drivers that require Secrets on detach is probably very limited. No in-tree Kubernetes volume plugin requires them on detach.
-* We will provide clear documentation that using in-line volumes drivers that require credentials on detach may leave orphaned attached volumes that Kubernetes is not able to detach. It's up to the cluster admin to decide if using such CSI driver is worth it.
+
+## Test plans
+
+### All unit tests
+* Volume operation that use CSIVolumeSource can only work with proper feature gate enabled
+
+### Ephemeral inline volumes unit tests
+* Ensure required fields are provided
+* Mount/Unmount should be triggered with CSIVolumeSource
+* Expected generated volumeHandle is created properly
+* Ensure volumeHandle conforms to resource naming format
+* CSIVolumeSource info persists in CSI json file during mount/unmount
+* Ensure Kubelet skips attach/detach when `CSIDriver.Mode = ephemeral`
+* Ensure Kubelet skips inline logic when `CSIDriver.Mode = persistent` or `CSIDriver.Mode is empty` 
+
+### E2E tests
+* Pod spec with an ephemeral inline volume request can be mounted/unmounted
+* Two pods accessing the same ephemeral inline volumes
+* Single pod referencing two distinct inline volume request from the same driver 
+* CSI Kubelet code invokes driver operations during mount for ephemeral volumes
+* CSI Kubelet code invokes driver operation during unmount of ephemeral volumes
+* CSI Kubelet cleans up ephemeral volume paths once pod goes away
+* Apply PodSecurity settings for allowed CSI drivers


### PR DESCRIPTION
This is to add changes suggested by @liggitt after KEP merged.
These are mostly cosmetic with design updates that still keep the KEP status implementable.

Original KEP - https://github.com/kubernetes/enhancements/pull/716


