### PR TITLE
add a kep to wrap already existing event design

### DIFF
--- a/keps/sig-instrumentation/0035-20190131-event-series.md
+++ b/keps/sig-instrumentation/0035-20190131-event-series.md
@@ -1,0 +1,58 @@
+---
+kep-number: 35
+title: Event series API
+authors:
+  - "@gmarek"
+owning-sig: sig-instrumentation
+participating-sigs:
+  - sig-instrumentation
+  - sig-scalability
+  - sig-architecture
+reviewers:
+  - "@wojtekt"
+  - "@bgrant0607"
+approvers:
+  - "@wojtekt"
+  - "@bgrant0607"
+editor: TBD
+creation-date: 2019-1-31
+last-updated: 2019-1-31
+status: implementable
+see-also:
+  - n/a
+replaces:
+  - n/a
+superseded-by:
+  - n/a
+---
+
+# Title
+
+Event series API
+
+## Table of Contents
+
+* [Graduation Criteria](#graduation-criteria)
+* [Implementation History](#implementation-history)
+
+
+This KEP wraps the already merged design doc under [kubernetes/community](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md)
+
+## Graduation Criteria
+
+Beta:
+
+- Ensure we do not have any performance regression compared to the orignal API
+- test coverage for edge-cases
+
+
+GA:
+
+- Update Event semantics such that they'll be considered useful by app developers
+- Reduce impact that Events have on the system's performance and stability
+- Switch all the controllers to use the new Event API
+
+## Implementation History
+
+- 2017-10-7 design proposal merged under [kubernetes/community](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md)
+- 2017-11-23 Event API group is [merged](https://github.com/kubernetes/kubernetes/pull/49112)


### PR DESCRIPTION
this is wraps kubernetes/community#1141 on a KEP, adds implementation history and graduation criteria.

/assign @wojtek-t @bgrant0607 
/sig instrumentation
/sig scalability