### PR TITLE
Webhook admission KEP updates

### DIFF
--- a/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
+++ b/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
@@ -204,6 +204,8 @@ This feature will add a port field to service based webhooks and allows specifyi
 other than 443 for service based webhooks. Specifying port should already be available for 
 URL based webhooks.
 
+The following field will be added to the `ServiceReference` types used by admission webhooks, `APIService`, and `AuditSink` configurations:
+
 ```golang
 type ServiceReference struct {
     ...

--- a/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
+++ b/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
@@ -12,8 +12,8 @@ approvers:
   - "@deads2k"
 editor: TBD
 creation-date: 2019-01-27
-last-updated: 2019-01-29
-status: provisional
+last-updated: 2019-02-04
+status: implementable
 see-also:
   - [Admission Control Webhook Beta Design Doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/admission-control-webhooks.md)
 ---
@@ -744,6 +744,6 @@ These are related Post-GA tasks:
 ## Implementation History
 
 * First version of the KEP being merged: Jan 29th, 2019
-* The proposal being approved: TBD
-* Implementation start for all approved changes: Jan 29th, 2019
+* The set of features for GA approved, initial set of features marked implementable: Feb 4th, 2019
+* Implementation start for all approved changes: Feb 4th, 2019
 * Target Kubernetes version for GA: TBD

--- a/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
+++ b/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
@@ -130,11 +130,18 @@ type Webhook struct {
 ### Scope
 
 Current webhook Rules applies to objects of all scopes. That means a Rule can use wildcards 
-to target both namespaced and cluster-scoped objects. The proposal is to add a scope field 
-to Admission Webhook configuration to limit webhook target on namespaced object or cluster 
-scoped objects. This enables webhook developers to target all namespaced objects or all 
-cluster-scoped objects. Namespace objects themselves are cluster-scoped.
+to target both namespaced and cluster-scoped objects. 
+
+An evaluation of the targeting capabilities required by in-tree admission plugins showed that
+some plugins (like NamespaceLifecycle and ResourceQuota) require the ability to intercept
+all namespaced resources. This selection is currently inexpressible for webhook admission.
+
+The proposal is to add a scope field to Admission Webhook configuration to limit webhook 
+targeting to namespaced or cluster-scoped objects. This enables webhook developers to 
+target only namespaced objects or cluster-scoped objects, just like in-tree admission plugins can.
+
 The field will be added to both v1 and v1beta1.
+
 The field is optional and defaults to "*", meaning no scope restriction.
 
 ```golang


### PR DESCRIPTION
follow up to https://github.com/kubernetes/enhancements/pull/736#issuecomment-459623154

* include "convert to requested-version capability" in planned for GA list, along with motivation (https://github.com/kubernetes/enhancements/pull/736#discussion_r252396191), indicates design is still in progress and will be updated/approved in the KEP prior to implementation
* include "mutating plugin ordering" in planned for GA list, along with motivation (https://github.com/kubernetes/enhancements/pull/736#discussion_r252396191), indicates design is still in progress and will be updated/approved in the KEP prior to implementation
* resolve unset vs `*` for scope field (https://github.com/kubernetes/enhancements/pull/736#discussion_r252246860)
* mention the service port capability will be added to APIService and audit webhook structs as well (https://github.com/kubernetes/enhancements/pull/736#discussion_r252080525)

Marks as implementable overall since there is implementation work that can begin on many of the items (the "convert-to-requested version" and "plugin ordering / re-call" subparts are explicitly noted to require that designs are to be merged to this doc before they will be considered implementable)

/sig api-machinery
/assign @lavalamp @deads2k @mbohlool 