### PR TITLE
Added Windows KEP clarification on ICMP protocol support.

### DIFF
--- a/keps/sig-windows/20190103-windows-node-support.md
+++ b/keps/sig-windows/20190103-windows-node-support.md
@@ -158,6 +158,7 @@ Note that some features are plain unsupported while some will not work without u
     - ICMP packets directed to destinations within the same network (e.g. pod to pod communication via ping) will work as expected and without any limitations
     - TCP/UDP packets will work as expected and without any limitations
     - ICMP packets directed to pass through a remote network (e.g. pod to external internet communication via ping) cannot be transposed and thus will *not* be routed back to their source
+      - Since TCP/UDP packets can still be transposed, one can substitute `ping <destination>` with `curl <destination>` to be able to debug connectivity to the outside world.
 
 ### Windows Container Compatibility
 As noted above, there are compatibility issues enforced by Microsoft where the host OS version must match the container base image OS. Changes to this compatibility policy must come from Microsoft. For GA, since we will only support Windows Server 2019 (aka 1809), both `container host OS` and `container OS` must be running the same version of Windows, 1809. 

--- a/keps/sig-windows/20190103-windows-node-support.md
+++ b/keps/sig-windows/20190103-windows-node-support.md
@@ -154,9 +154,9 @@ Note that some features are plain unsupported while some will not work without u
 - Not all features of shared namespaces are supported. This is clarified in the API section below
 - The existing node problem detector is Linux-only and requires privileged containers. In general, we don't expect these to be used on Windows because there's no privileged support
 - Overlay networking support in Windows Server 1803 is not fully functional using the `win-overlay` CNI plugin. Specifically service IPs do not work on Windows nodes. This is currently specific to `win-overlay`; other CNI plugins (OVS, AzureCNI) work. Since Windows Server 1803 is not supported for GA, this is mostly not applicable. We left it here since it impacts beta
-- Outbound communication using the ICMP protocol via the `win-overlay`, `win-bridge`, and `Azure-CNI` plugin. Specifically, the Windows datapath (VFP) doesn't support ICMP packet transpositions. This means:
-    - ICMP packets directed to addressses within the same network (e.g. pod to pod communication via ping) will work as expected and without any limitations
-    - TCP/UDP packets will work as expected and without limitations
+- Outbound communication using the ICMP protocol via the `win-overlay`, `win-bridge`, and `Azure-CNI` plugin. Specifically, the Windows data plane ([VFP](https://www.microsoft.com/en-us/research/project/azure-virtual-filtering-platform/)) doesn't support ICMP packet transpositions. This means:
+    - ICMP packets directed to destinations within the same network (e.g. pod to pod communication via ping) will work as expected and without any limitations
+    - TCP/UDP packets will work as expected and without any limitations
     - ICMP packets directed to pass through a remote network (e.g. pod to external internet communication via ping) cannot be transposed and thus will *not* be routed back to their source
 
 ### Windows Container Compatibility

--- a/keps/sig-windows/20190103-windows-node-support.md
+++ b/keps/sig-windows/20190103-windows-node-support.md
@@ -5,6 +5,7 @@ authors:
   - "@benmoss"
   - "@patricklang"
   - "@michmike"
+  - "@daschott"
 owning-sig: sig-windows
 participating-sigs:
   - sig-architecture
@@ -21,7 +22,7 @@ approvers:
   - "@spiffxp"
 editor: TBD
 creation-date: 2018-11-29
-last-updated: 2019-01-29
+last-updated: 2019-02-11
 status: implementable
 ---
 
@@ -153,6 +154,10 @@ Note that some features are plain unsupported while some will not work without u
 - Not all features of shared namespaces are supported. This is clarified in the API section below
 - The existing node problem detector is Linux-only and requires privileged containers. In general, we don't expect these to be used on Windows because there's no privileged support
 - Overlay networking support in Windows Server 1803 is not fully functional using the `win-overlay` CNI plugin. Specifically service IPs do not work on Windows nodes. This is currently specific to `win-overlay`; other CNI plugins (OVS, AzureCNI) work. Since Windows Server 1803 is not supported for GA, this is mostly not applicable. We left it here since it impacts beta
+- Outbound communication using the ICMP protocol via the `win-overlay`, `win-bridge`, and `Azure-CNI` plugin. Specifically, the Windows datapath (VFP) doesn't support ICMP packet transpositions. This means:
+    - ICMP packets directed to addressses within the same network (e.g. pod to pod communication via ping) will work as expected and without any limitations
+    - TCP/UDP packets will work as expected and without limitations
+    - ICMP packets directed to pass through a remote network (e.g. pod to external internet communication via ping) cannot be transposed and thus will *not* be routed back to their source
 
 ### Windows Container Compatibility
 As noted above, there are compatibility issues enforced by Microsoft where the host OS version must match the container base image OS. Changes to this compatibility policy must come from Microsoft. For GA, since we will only support Windows Server 2019 (aka 1809), both `container host OS` and `container OS` must be running the same version of Windows, 1809. 


### PR DESCRIPTION
Some common network utilities (e.g. ping, traceroute) used for troubleshooting and diagnosis are based on ICMP messaging. This commit is adding a clarification on what network flows can be expected to work are on Windows containers using the ICMP protocol.