### PR TITLE
Mark Publish CRD OpenAPI KEP as implementable

### DIFF
--- a/keps/sig-api-machinery/00xx-publish-crd-openapi.md
+++ b/keps/sig-api-machinery/00xx-publish-crd-openapi.md
@@ -14,8 +14,8 @@ approvers:
   - "@sttts"
 editor: TBD
 creation-date: 2019-02-07
-last-updated: 2019-02-11
-status: provisional
+last-updated: 2019-02-13
+status: implementable
 see-also:
   - [Validation for CustomResources design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresources-validation.md)
 ---


### PR DESCRIPTION
We didn't change the status from `provisional` to `implementable` before merging the KEP. There is no open question left. This PR changes the status.

/assign @deads2k @lavalamp 
for approval