### PR TITLE
Rename KEP template file name to follow KEP template

### DIFF
--- a/keps/0001-kubernetes-enhancement-proposal-process.md
+++ b/keps/0001-kubernetes-enhancement-proposal-process.md
@@ -139,7 +139,7 @@ These KEPs will be owned by SIG-architecture and should be seen as a way to comm
 
 ### KEP Template
 
-The template for a KEP is precisely defined [here](0000-kep-template.md)
+The template for a KEP is precisely defined [here](YYYYMMDD-kep-template.md)
 
 ### KEP Metadata
 

--- a/keps/README.md
+++ b/keps/README.md
@@ -9,7 +9,7 @@ This process is still in a _beta_ state and is opt-in for those that want to pro
 
 1. Socialize an idea with a sponsoring SIG.
    Make sure that others think the work is worth taking up and will help review the KEP and any code changes required.
-2. Follow the process outlined in the [KEP template](0000-kep-template.md)
+2. Follow the process outlined in the [KEP template](YYYYMMDD-kep-template.md)
 
 ## FAQs
 

--- a/keps/YYYYMMDD-kep-template.md
+++ b/keps/YYYYMMDD-kep-template.md
@@ -53,7 +53,7 @@ To get started with this template:
   Aim for single topic PRs to keep discussions focused.
   If you disagree with what is already in a document, open a new PR with suggested changes.
 
-The canonical place for the latest set of instructions (and the likely source of this file) is [here](/keps/0000-kep-template.md).
+The canonical place for the latest set of instructions (and the likely source of this file) is [here](/keps/YYYYMMDD-kep-template.md).
 
 The `Metadata` section above is intended to support the creation of tooling around the KEP process.
 This will be a YAML section that is fenced as a code block.

--- a/keps/sig-release/20190121-artifact-management.md
+++ b/keps/sig-release/20190121-artifact-management.md
@@ -33,7 +33,7 @@ see-also:
   Aim for single topic PRs to keep discussions focused.
   If you disagree with what is already in a document, open a new PR with suggested changes.
 
-The canonical place for the latest set of instructions (and the likely source of this file) is [here](/keps/0000-kep-template.md).
+The canonical place for the latest set of instructions (and the likely source of this file) is [here](/keps/YYYYMMDD-kep-template.md).
 
 The `Metadata` section above is intended to support the creation of tooling around the KEP process.
 This will be a YAML section that is fenced as a code block.


### PR DESCRIPTION
Updates KEP template and meta KEP to follow the `YYYYMMDD-kep-name.md` file name format.

Wasn't sure if the filenames were intentionally left like this or just forgotten, figured I'd open a PR anyways :). 

/assign @justaugustus @calebamiles 