### PR TITLE
Remove sig/{architecture,pm} labels from KEP directory

### DIFF
--- a/keps/OWNERS
+++ b/keps/OWNERS
@@ -8,7 +8,5 @@ reviewers:
   - kep-process-reviewers
 labels:
   - kind/kep
-  - sig/architecture
-  - sig/pm
 options:
   no_parent_owners: true


### PR DESCRIPTION
After scrolling some of the open PRs, seems redundant to tag KEP changes as `kind/kep`, `sig/architecture`, and `sig/pm`.

`kind/kep` should suffice. This removes the SIG labels.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>