### PR TITLE
Add test plan to pod DNS config KEP

### DIFF
--- a/keps/sig-network/20190118-pod-dns-config.md
+++ b/keps/sig-network/20190118-pod-dns-config.md
@@ -29,6 +29,7 @@ status: implementable
 * [Proposal](#proposal)
     * [Pod API examples](#pod-api-examples)
     * [API changes](#api-changes)
+    * [Test Plan](#test-plan)
 * [Graduation Criteria](#graduation-criteria)
 * [Implementation History](#implementation-history)
 
@@ -230,6 +231,14 @@ The follow configurations will result in an invalid Pod spec:
 * Nameservers or search paths exceed system limits. (Three nameservers, six
   search paths, 256 characters for `glibc`).
 * Invalid option appears for the given platform.
+
+### Test Plan
+
+The following end-to-end test is implemented in addition to unit tests:
+- Create a pod with dns config setup, including nameserver, search path and option.
+- Check if the `resolv.conf` file within the pod is configured properly per the given setup.
+- Send DNS request from the pod and make sure the customized nameserver and
+search path are taking effect.
 
 ## Graduation Criteria
 


### PR DESCRIPTION
Per https://github.com/kubernetes/enhancements/issues/504#issuecomment-466557563, retrospectively adding test plan to the pod DNS config KEP.

/assign @thockin @bowei 
cc @claurence