### PR TITLE
Updating OWNERS for sig-architecture

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,8 @@ aliases:
     - bgrant0607
     - jdumars
     - mattfarina
+    - derekwaynecarr
+    - dims
   sig-auth-leads:
     - mikedanese
     - enj

--- a/keps/sig-architecture/OWNERS
+++ b/keps/sig-architecture/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-architecture-leads
+approvers:
+  - sig-architecture-leads
+labels:
+  - sig/architecture


### PR DESCRIPTION
This adds an OWNERS file to the sig arch kep directory and updates the list of sig arch chairs to match what's in community.

/cc @bgrant0607 @jdumars 
/sig architecture