### PR TITLE
Clarify that colocating CSI code with CCM is optional

### DIFF
--- a/keps/sig-cloud-provider/20180530-cloud-controller-manager.md
+++ b/keps/sig-cloud-provider/20180530-cloud-controller-manager.md
@@ -316,7 +316,7 @@ Additionally, the repository should have:
 * A `docs/getting-started.md` file that describes the installation and basic
   operation of the cloud controller manager code.
 
-Where the provider has additional capabilities, the repository should have
+Where the provider has additional capabilities, the repository may have
 the following subdirectories that contain the common features:
 
 * `dns` for DNS provider code.


### PR DESCRIPTION
Update the external CCM KEP to clarify in the repository requirements
section that co-locating additional provider feature implementations is optional. This applies to features such as CSI and CNI.