### PR TITLE
kubeadm HA KEPs updated for v1.15

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/0015-kubeadm-join-control-plane.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/0015-kubeadm-join-control-plane.md
@@ -20,7 +20,7 @@ approvers:
 editor:
   - "@fabriziopandini"
 creation-date: 2018-01-28
-last-updated: 2019-01-07
+last-updated: 2019-04-18
 see-also:
   - KEP 0004
 ```
@@ -135,10 +135,8 @@ capabilities like e.g. kubeadm upgrade for HA clusters.
   explicitly prevent us to reconsider this in the future as well).
 
 - This proposal doesn't provide an automated solution for transferring the CA key and other required
-  certs from one control-plane instance to the other. More specifically, this proposal doesn't address
-  the ongoing discussion about storage of kubeadm TLS assets in secrets and it is not planned
-  to provide support for clusters with TLS stored in secrets, but nothing in
-  this proposal prevents us from reconsidering this in the future..
+  certs from one control-plane instance to the other. This is addressed in a separated KEP.
+  (see KEP [Certificates copy for join --control-plane](20190122-Certificates-copy-for-kubeadm-join--control-plane.md))
 
 - Nothing in this proposal should prevent practices that exist today.
 
@@ -366,20 +364,14 @@ As of today kubeadm supports two solutions for storing cluster certificates:
 2. Cluster certificates stored in secrets (currently alpha and applicable only to
    self-hosted control plane)
 
-The proposed solution for case 1. "Cluster certificates stored on file system",
-requires the user/the higher level tools to execute an additional action _before_
-invoking `kubeadm join --control plane`.
+There are two possible alternatives for case 1. "Cluster certificates stored on file system":
 
-More specifically, in case of cluster with "cluster certificates stored on file
-system", before invoking `kubeadm join --control plane`, the user/higher level tools
-should copy control plane certificates from an existing node, e.g. the bootstrap control plane
+- delegate to the user/the higher level tools the responsibility to copy certificates
+  from an existing node, e.g. the bootstrap control plane, to the joining node _before_
+  invoking `kubeadm join --control-plane`.
 
-> NB. kubeadm is limited to execute actions *only*
-in the machine where it is running, so it is not possible to copy automatically
-certificates from remote locations.
-
-Then, the `kubeadm join --control plane` flow will take care of checking certificates
-existence and conformance.
+- let kubeadm copy the certificates. This alternative is described in a separated KEP
+  (see KEP [Certificates copy for join --control-plane](20190122-Certificates-copy-for-kubeadm-join--control-plane.md))
 
 As stated above, supporting for Cluster certificates self-hosted control plane is a non goal
 for this proposal, and the same apply to Cluster certificates stored in secrets.
@@ -417,6 +409,8 @@ one control plane instances, but with a new sub-step to be executed on secondary
 - [PR #58261](https://github.com/kubernetes/kubernetes/pull/58261) with the showcase implementation of the first release of this KEP
 - v1.12 first implementation of `kubeadm join --control plane`
 - v1.13 support for local/stacked etcd
+- v1.14 implementation of automatic certificates copy
+  (see KEP [Certificates copy for join --control-plane](20190122-Certificates-copy-for-kubeadm-join--control-plane.md)).
 
 ## Drawbacks
 

--- a/keps/sig-cluster-lifecycle/kubeadm/20190122-Certificates-copy-for-kubeadm-join--control-plane.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/20190122-Certificates-copy-for-kubeadm-join--control-plane.md
@@ -16,7 +16,7 @@ approvers:
   - @luxas
 editor: TBD
 creation-date: 2019-01-22
-last-updated: 2019-01-22
+last-updated: 2019-04-18
 status: implementable
 see-also:
   - KEP-0015
@@ -56,7 +56,7 @@ superseded-by:
 
 - [x] k/enhancements [issue 357](https://github.com/kubernetes/enhancements/issues/357) in release
       milestone and linked to KEP
-- [ ] KEP approvers have set the KEP status to `implementable`
+- [x] KEP approvers have set the KEP status to `implementable`
 - [x] Design details are appropriately documented
 - [x] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [x] Graduation criteria is in place
@@ -89,6 +89,13 @@ above and completing the kubeadm solution for creating HA clusters.
   familiar with.
 - Security: provide a solution that enables the secure copy of cluster certificates between
   control-plane nodes
+
+### Non Goals
+
+- Handle certificate copy in case of External CA.
+  If users decide to use an external CA with kubeadm without providing the CA keys, they will be required to create
+  signed certificates and all the kubeconfig files (including X.509 certificates) for the control plane nodes.
+  This is needed, because kubeadm cannot generate any certificates without the required CA keys.
 
 ## Proposal
 
@@ -325,7 +332,10 @@ affect component version or version skew policy)
 ## Implementation History
 
 - 22 Jan 2019 - first release of this KEP
-- v1.14 implementation (planned)
+- v1.14 implementation as alpha feature without
+  - Extension of the kubeadm config file for allowing usage of pre-generated certificate keys
+  - TokenCleaner enforcement
+  - E2E tests
 
 ## Alternatives
 


### PR DESCRIPTION
This PR update kubeadm HA KEPs (join control plane and automatic copy certs) with v1.14 achievements and activities planned for v1.15

/assign  @timothysc @neolit123 @rosti 
@kubernetes/sig-cluster-lifecycle-pr-reviews 