### PR TITLE
sig-api-machinery: add "Graduate CustomResourceDefinitions to GA"

### DIFF
--- a/keps/sig-api-machinery/20180415-crds-to-ga.md
+++ b/keps/sig-api-machinery/20180415-crds-to-ga.md
@@ -1,0 +1,198 @@
+---
+title: Graduate CustomResourceDefinitions to GA
+authors:
+  - "@jpbetz"
+  - "@roycaihw"
+  - "@sttts"
+owning-sig: sig-api-machinery
+participating-sigs:
+  - sig-api-machinery
+  - sig-architecture
+reviewers:
+  - "@deads2k"
+  - "@lavalamp"
+  - "@liggitt"
+  - "@mbohlool"
+  - "@sttts"
+approvers:
+  - "@deads2k"
+  - "@lavalamp"
+editor: TBD
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+see-also:
+  - [Umbrella Issue](https://github.com/kubernetes/kubernetes/issues/58682)
+  - [Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)
+  - [Pruning for CustomResources KEP](https://github.com/kubernetes/enhancements/pull/709)
+---
+
+# Title
+
+Graduate CustomResourceDefinitions to GA
+
+## Table of Contents
+
+* [Summary](#summary)
+* [Motivation](#motivation)
+  * [Goals](#goals)
+  * [Non-Goals](#non-goals)
+* [Proposal](#proposal)
+  * [Defaulting and pruning for custom resources is implemented](#defaulting-and-pruning-for-custom-resources-is-implemented)
+  * [CRD v1 schemas are restricted to a subset of the OpenAPI specification](#crd-v1-schemas-are-restricted-to-a-subset-of-the-openapi-specification)
+  * [Generator exists for CRD Validation Schema v3 (Kubebuilder)](#generator-exists-for-crd-validation-schema-v3-kubebuilder)
+  * [CustomResourceWebhookConversion API is GA ready](#customresourcewebhookconversion-api-is-ga-ready)
+  * [CustomResourceSubresources API is GA ready](#customresourcesubresources-api-is-ga-ready)
+  * [v1 API](#v1-api)
+* [Test Plan](#test-plan)
+  * [Integration tests for GA](#integration-tests-for-ga)
+  * [e2e tests for GA](#e2e-tests-for-ga)
+  * [Conformance plan for GA](#conformance-plan-for-ga)
+  * [Scale Targets for GA](#scale-targets-for-ga)
+* [Graduation Criteria](#graduation-criteria)
+* [Post-GA tasks](#post-ga-tasks)
+  * [Arbitrary subresources as Post-GA task](#arbitrary-subresources-as-post-ga-task)
+* [Implementation History](#implementation-history)
+
+## Summary
+
+CustomResourceDefinitions (CRDs) are the way to extend the Kubernetes API to
+include custom resource types that behave like the native resource types. CRDs
+have been in Beta since Kubernetes 1.7. This document outlines the required
+steps to graduate CRDs to general availability (GA).
+
+## Motivation
+
+CRDs are in widespread use as a Kubernetes extensibility mechanism and have been
+available in beta for the last 5 Kubernetes releases. Feature requests and bug
+reports suggest CRDs are nearing GA quality, and this KEP aims to itemize the
+remaining improvements to move this toward GA.
+
+### Goals
+
+Establish consensus for the remaining essential improvements needed to move CRDs to GA.
+
+Guiding principles:
+* if a missing feature forces or encourages users to implement non-Kubernetes-like APIs, and therefore damages the ecosystem long term, it belongs on this list.
+* If a feature cannot be added as an after-thought of a GA API, it or some preparation belongs on this list.
+
+
+### Non-Goals
+
+Full feature parity with native kubernetes resource types is not a GA graduation goal. See above guiding principles.
+
+## Proposal
+
+Objectives to graduate CRDs to GA, each of which is described in more detail further below:
+
+* Defaulting and pruning for custom resources is implemented
+* CRD v1 schemas are restricted to a subset of the OpenAPI specification (and there is a v1beta1 compatibility plan)
+* Generator exists for CRD Validation Schema v3 (Kubebuilder)
+* CustomResourceWebhookConversion API is GA ready
+* CustomResourceSubresources API is GA ready
+
+Bug fixes required to graduate CRDs to GA:
+
+* See “Required for GA” issues tracked via the [CRD Project Board](https://github.com/orgs/kubernetes/projects/28).
+
+For additional details on already completed features, see the [Umbrella Issue](https://github.com/kubernetes/kubernetes/issues/58682).
+
+See [Post-GA tasks](#post-ga-tasks) for decided out-of-scope features.
+
+### Defaulting and pruning for custom resources is implemented
+
+Both defaulting and pruning and also read-only validation are blocked by the
+OpenAPI subset definition (next point). An update of the [old Pruning for
+CustomResources KEP](https://github.com/kubernetes/enhancements/pull/709) and the implementation
+([pruning PR](https://github.com/kubernetes/kubernetes/pull/64558), [defaulting
+PR](https://github.com/kubernetes/kubernetes/pull/63604)), are follow-ups as soon as unblocked.
+
+### CRD v1 schemas are restricted to a subset of the OpenAPI specification
+
+See [Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)
+
+### Generator exists for CRD Validation Schema v3 (Kubebuilder)
+
+See [kubebuilder’s
+crd-gen](https://github.com/kubernetes-sigs/controller-tools/tree/master/cmd/crd)
+and a more general
+[crd-schema-gen](https://github.com/kubernetes-sigs/controller-tools/pull/183),
+to be integrated into kubebuidler’s controller-tools.
+
+### CustomResourceWebhookConversion API is GA ready
+
+Currently CRD webhook conversion is alpha. We plan to take this to v1beta1 via the
+"Graduation Criteria" proposed in [PR #1004](https://github.com/kubernetes/enhancements/pull/1004). 
+We plan to then graduate this to GA as part of the CRD to GA graduation.
+
+### CustomResourceSubresources API is GA ready
+
+Currently custom resource subresources are v1beta1 and provide support for the
+/status and /scale subresources. We plan to graduate this to GA as part of the
+CRD to GA graduation.
+
+### v1 API
+
+The CRD `v1` API will be the same as the `v1beta1` but with all changes to the API from the GA tasks:
+
+* Rename misnamed json field [JSONPath](https://github.com/kubernetes/kubernetes/blob/06bc7e3e0026ea25065f59f4bd305c0b7dbbc145/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go#L226-L227) to `jsonPath`
+* [Replace top-level fields with per version fields](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresource-conversion-webhook.md#top-level-fields-to-per-version-fields)
+* Restrict OpenAPI per [Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)
+
+## Test Plan
+
+### Integration tests for GA
+
+TODO: complete this list
+
+* [Pruning for CustomResources KEP](https://github.com/kubernetes/enhancements/pull/709)
+  * TODO
+* [Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)
+  * TODO
+* CRD versioning/conversion (https://github.com/kubernetes/kubernetes/issues/64136):
+  * Ensure what is persisted in etcd matches the storage version
+  * Set up a CRD, persist some data, changed the version, and ensure the previously persisted data is readable
+  * Ensure discovery docs track a CRD through creation, version addition, version removal, and deletion
+  * Ensure `spec.served` is respected
+
+### e2e tests for GA
+
+* Custom Resources should be readable and writable at all available versions (test for round trip-ability)
+* A Custom Resource watch should terminate if its CustomResourceDefinition is deleted or updated
+
+### Scale Targets for GA
+
+* TODO quantify: Read/write latency of CRDs within X% of native Kubernetes types
+* TODO quantify: Latency degrades less than X% for up to 100k Custom Resources per CRD kind
+* TODO quantify: Webhook conversion QPS of a noop converter is within X% of QPS with no webhook
+* Coordinate with sig-scalability
+
+## Graduation Criteria
+
+To mark these as complete, all of the above features need to be implemented. An
+umbrella issue is tracking all of these changes. Also there need to be
+sufficient tests for any of these new features and all existing features and
+documentation should be completed for all features.
+
+See [umbrella issue](https://github.com/kubernetes/kubernetes/issues/58682) for status.
+
+## Post-GA tasks
+
+See the [umbrella issue](https://github.com/kubernetes/kubernetes/issues/58682) for details on Post-GA tasks. The tasks at the time this KEP was written are:
+
+* Human readable status from conditions for a CRD using additionalPrinterColumns (https://github.com/kubernetes/kubernetes/issues/67268)
+* Consider changing the schema language in CRDs (https://github.com/kubernetes/kubernetes/issues/67840)
+* Should support graceful deletion for storage (https://github.com/kubernetes/kubernetes/issues/68508)
+* Enable arbitrary CRD field selectors by supporting a whitelist of fields in CRD spec (https://github.com/kubernetes/kubernetes/issues/53459)
+* Support graceful deletion for custom resources (https://github.com/kubernetes/kubernetes/issues/56567)
+* CRD validation webhooks (https://github.com/kubernetes/community/pull/1418)
+* Allow OpenAPI references in the CRD valiation schema (https://github.com/kubernetes/kubernetes/issues/54579, https://github.com/kubernetes/kubernetes/issues/62872)
+* Generate json-schema for use in the CRDs from the go types (https://github.com/kubernetes/kubernetes/issues/59154, https://github.com/kubernetes/sample-controller/issues/2, https://github.com/kubernetes/code-generator/issues/28)
+* Support for namespace-local CRD (https://github.com/kubernetes/kubernetes/issues/65551)
+* Support proto encoding for custom resources (https://github.com/kubernetes/kubernetes/issues/63677)
+* labelSelectorPath should be allowed not be under .status (https://github.com/kubernetes/kubernetes/issues/66688)
+* Support arbitrary non-standard subresources for CRDs (https://github.com/kubernetes/kubernetes/issues/72637)
+* OpenAPI v3 is published for all resources, including custom resources
+* Promote appropriate e2e test to Conformance
+
+## Implementation History


### PR DESCRIPTION
We'd like to graduate CRDs sub-features to beta in 1.15 and then graduate CRDs to GA in a following release, ideally 1.16.

The purpose of this KEP is to establish consensus for the remaining essential improvements needed to move CRDs to GA. In particular, we'd like to agree on the features and tests required.

A couple sections, particularly the test and scale goals sections, are not complete. Feedback on what we should include in those sections would be very helpful.