### PR TITLE
Significantly fleshed out "move pkg/kubectl into staging"  proposal from feedback

### DIFF
--- a/keps/sig-cli/kubectl-staging.md
+++ b/keps/sig-cli/kubectl-staging.md
@@ -77,9 +77,86 @@ not be addressed in this KEP; it will be the subject of its own KEP.
 
 ## Proposal
 
-Move `k8s.io/kubernetes/pkg/kubectl` to a location under
-`k8s.io/kubernetes/staging/src/k8s.io/kubectl`, and update all
-`k8s.io/kubernetes/pkg/kubectl` imports.
+The following steps to create the staging repository have been copied from
+the base [staging directory README](https://github.com/kubernetes/kubernetes/tree/master/staging).
+
+### Adding the staging repository in kubernetes/kubernetes:
+
+1. Send an email to the SIG Architecture mailing list and the mailing list of
+   the SIG CLI which would own the repo requesting approval for creating the
+   staging repository.
+
+2. Once approval has been granted, create the new staging repository.
+
+3. Add a symlink to the staging repo in vendor/k8s.io.
+
+4. Update import-restrictions.yaml to add the list of other staging repos that
+   this new repo can import.
+
+5. Add all mandatory template files to the staging repo as mentioned in
+   https://github.com/kubernetes/kubernetes-template-project.
+
+6. Make sure that the .github/PULL_REQUEST_TEMPLATE.md and CONTRIBUTING.md files
+   mention that PRs are not directly accepted to the repo.
+
+### Modify and Set-up the existing receiving kubernetes/kubectl repository
+
+Currently, there are three types of content in the current kubernetes/kubectl
+repository that need to be dealt with. These items are 1) the [Kubectl
+Book](https://kubectl.docs.k8s.io/), 2) an integration test framework, and 3)
+some kubectl openapi code. Since we intend to copy the staging code into this
+kubernetes/kubectl repository, and since this repository must be empty, we need
+to dispose of these items. A copy of the kubectl openapi code already exists
+under `pkg/kubectl` in the kubernetes/kubernetes repository, so it can be
+deleted. The following steps describe how we intend to modify the existing
+kubernetes/kubectl repository:
+
+1. We will create a backup of the entire [current
+   kubectl](https://github.com/kubernetes/kubectl) repository in the [Google
+   Cloud Source Repository](https://cloud.google.com/source-repositories/).
+
+2. The [Kubectl Book](https://kubectl.docs.k8s.io/) should be in its own
+   repository. So we will create a new repository, and copy this content into
+   the new repository.
+
+3. We will then clear the [current
+   kubectl](https://github.com/kubernetes/kubectl) repository.
+
+4. Setup branch protection and enable access to the stage-bots team by adding
+   the repo in prow/config.yaml. See #kubernetes/test-infra#9292 for an
+   example.
+
+5. Once the repository has been cleared, update the publishing-bot to publish
+   the staging repository by updating:
+
+   rules.yaml: Make sure that the list of dependencies reflects the staging
+   repos in the go modules.
+
+   fetch-all-latest-and-push.sh: Add the staging repo in the list of repos to be
+   published.
+
+6. Add the staging and published repositories as a subproject for the SIG that
+   owns the repos in sigs.yaml.
+
+7. Add the repo to the list of staging repos in this README.md file.
+
+8. We will re-introduce the integration test framework into the kubectl
+   repository by submitting into the new staging directory.
+
+### Move `pkg/kubectl` Code
+
+Move `k8s.io/kubernetes/pkg/kubectl` to a location under the new
+`k8s.io/kubernetes/staging/src/k8s.io/kubectl` directory, and update all
+`k8s.io/kubernetes/pkg/kubectl` imports. This can be an incremental process.
+
+### Timeframe
+
+There are three remaining Kubernetes core dependencies that have to be resolved
+before all of `pkg/kubectl` can be moved to staging. While we work on those
+remaining dependencies, we can move some `pkg/kubectl` code to staging that is
+currently being requested by other projects. Specifically, we will move
+`pkg/kubectl/cmd/apply` into staging as soon as possible. The rest of the code
+would be moved over the next two releases (1.16 and 1.17).
 
 ## Risks and Mitigations
 


### PR DESCRIPTION
* Fleshes out proposal for moving `pkg/kubectl` into staging
* Describes process of creating staging directory
* Explains the disposition of the current `kubernetes/kubectl` repository content
* Adds a brief timeline

/sig cli
/area kubectl