### PR TITLE
apiextensions: clarify XPreserveUnknownFields type in structural schema

### DIFF
--- a/keps/sig-api-machinery/20190425-structural-openapi.md
+++ b/keps/sig-api-machinery/20190425-structural-openapi.md
@@ -213,7 +213,8 @@ type Extensions struct {
 	// in the validation schema. This affects fields recursively,
 	// but switches back to normal pruning behaviour if nested
 	// properties or additionalProperties are specified in the schema.
-        XPreserveUnknownFields bool
+	// This can either be true or null. False is forbidden.
+        XPreserveUnknownFields *bool
         
 	// x-kubernetes-embedded-resource defines that the value is an
 	// embedded Kubernetes runtime.Object, with TypeMeta and


### PR DESCRIPTION
This is needed so we can catch/forbid explicit false values from the user to avoid confusion

