### PR TITLE
remove draft versioning from control-plane stability kep

### DIFF
--- a/keps/sig-instrumentation/42-kubernetes-control-plane-metrics-stability.md
+++ b/keps/sig-instrumentation/42-kubernetes-control-plane-metrics-stability.md
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Control-Plane Metrics Stability
+number: 42
 authors:
   - "@logicalhan"
 owning-sig:


### PR DESCRIPTION
This PR removes the draft versioning of the filename and assigns a KEP number to the control-plane metrics stability KEP.

/sig instrumentation
/assign @brancz 