### PR TITLE
Clarify host wildcard matching

### DIFF
--- a/keps/sig-network/20190125-ingress-api-group.md
+++ b/keps/sig-network/20190125-ingress-api-group.md
@@ -244,7 +244,8 @@ The `IngressRule.Host` comment would be changed to:
 > If `Host` is a wildcard, then request matches the rule if the http host header
 > is to equal to the suffix (removing the first label) of the wildcard rule.
 > E.g. wildcard "*.foo.com" matches "bar.foo.com" because they share an equal
-> suffix "foo.com".
+> suffix "foo.com" but does NOT match "baz.bar.foo.com" because only the first
+> label is removed for a match.
 
 ### Healthchecks
 


### PR DESCRIPTION
Expand the example to be clear that multiple labels in the hostname will not match a wildcard.