### PR TITLE
WIP: Platform-level resource reclamation

### DIFF
--- a/keps/sig-node/20190530-commit-class.md
+++ b/keps/sig-node/20190530-commit-class.md
@@ -113,8 +113,9 @@ reduce cost via platform-level over-commit policies.
 * Help cluster operators choose appropriate commit settings.
 * Automatically adjust commit settings to maximize utilization.
 * Replace VPA, HPA, or any other Pod-level right-sizing/auto-scaling API.
-  These APIs are complimentary: they help Pod owners optimize their footprint,
-  while `CommitClass` helps cluster operators optimize the cluster footprint.
+  These APIs are complimentary: they help Pod owners optimize their Pod
+  footprint, while `CommitClass` helps cluster operators optimize the cluster
+  footprint.
 
 ## Proposal
 
@@ -286,10 +287,10 @@ are managed by VPA, high cluster resource density may be achieved without
 over-commit.
 
 VPA is a powerful tool for right-sizing Pods, but is difficult to wield for the
-purposes of cluster footprint optimization:
+purposes of cluster-wide footprint optimization:
 
 - It is difficult to mandate VPA usage in a 'Namespace as a Service' style
-  Kubernetes platform.
+  Kubernetes platform, where such a mandate crosses ownership boundaries.
 - VPA complicates capacity planning for Pod owners, so not all Pod owners may
   want to use it.
 - VPA may increase platform exposure to application memory or CPU leaks, and so

--- a/keps/sig-node/20190530-commit-class.md
+++ b/keps/sig-node/20190530-commit-class.md
@@ -136,9 +136,15 @@ the Node names it applied to, but that interacts badly with Cluster autoscaler.
 
 Nodes should default to a `CommitClass` where all multipliers are '1'.
 
-Consideration: it is usually a bad idea to give a single VM more vCPUs than
-physical CPUs are available on the host system. Should that be reflected here
-somehow for containers?
+#### Consideration: container CPU requests vs host physical CPUs
+It is usually a bad idea to give a single VM more vCPUs than physical CPUs are
+available on the host system. Should that be reflected here somehow for
+containers?
+
+#### Consideration: system reserved
+System reserved resource slices should almost certainly not be subject to
+`CommitClass` multipliers, so that node health is not at risk under high
+multipliers ("just" workload health).
 
 ### API Design
 

--- a/keps/sig-node/20190530-commit-class.md
+++ b/keps/sig-node/20190530-commit-class.md
@@ -88,9 +88,9 @@ resource may be allocated multiple times to different workloads. Higher
 over-commit levels achieve better cost outcomes, but risk compromising service
 quality if the uncoordinated-spike hypothesis does not hold.
 
-Kubernetes currently provides for resource over-commit by allowing Pods to
-declare themselves 'Burstable' or 'Best Effort' via container resource
-request:limit ratios. This is a powerful approach, but achieving high
+Kubernetes currently provides for resource over-commit by allowing Pods to opt
+into 'Burstable' or 'Best Effort' quality of service classes via container
+resource request:limit ratios. This is a powerful approach, but achieving high
 utilization at the cluster level requires coordination across many authors of
 Pod specs, which is challenging in a 'Namespace as a Service' multi-tenant
 Kubernetes environment, or surprising when implemented by fiat as a mutating
@@ -144,7 +144,7 @@ spec:
 ```
 
 Nodes which match the `selector` will scale the resource amounts advertised in
-the `node.status` object by the `percent` for that resource.
+the `node.status.allocatable` object by the `percent` for that resource.
 
 Supported resources: **cpu**, **memory**, **ephemeral-storage**.
 
@@ -152,12 +152,6 @@ Supported resources: **cpu**, **memory**, **ephemeral-storage**.
 
 `CommitClass` is an operator-facing API. Therefore, user stories focus on
 cluster operator profiles.
-
-Implicit in each of these stories is a large, multi-tenant cluster where close
-coordination with all authors of Pod specs is infeasible. This is because small
-multi-tenant or single-tenant clusters can use Pod-oriented APIs, like VPA, to
-achieve good utilization; as such, the `CommitClass` API is likely not
-interesting.
 
 #### Kubernetes deployed on bare metal
 

--- a/keps/sig-node/20190530-commit-class.md
+++ b/keps/sig-node/20190530-commit-class.md
@@ -310,3 +310,15 @@ Kubernetes project could take the position that Kubernetes clusters with an
 interest in platform-level cost optimization should run on top of a VM
 infrastructure, and thereby delegate the commit settings to the VM
 orchestrator.
+
+### Virtual Kubelet
+
+Virtual Kubelet is a project to allow non-Kubernetes platforms to masquerade as
+a Kubelet, so that the Kubernetes API may be used for orchestration. For
+example, this allows workloads to be scheduled to serverless platforms via the
+Kubernetes API.
+
+Virtual Kubelet is orthongonal to `CommitClass`: while the non-Kubelet
+providers may support over- or under-commit of platform resources, or very high
+workload/machine density (for example, 'scale to zero' serverless) , this is
+not a required characteristic of Virtual Kubelet providers.

--- a/keps/sig-node/20190530-commit-class.md
+++ b/keps/sig-node/20190530-commit-class.md
@@ -1,0 +1,276 @@
+---
+title: Commit Class
+authors:
+  - "@kanatohodets"
+owning-sig: sig-node
+participating-sigs:
+  - sig-scheduling
+  - sig-scalability
+reviewers: []
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2019-05-30
+last-updated: 2019-04-12
+status: provisional
+---
+
+# Commit Class
+
+## Table of Contents
+
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [API Design](#api-design)
+  - [Implementation Details](#implementation-details)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+  - [Mutating Admission Webhook](#mutating-admission-webhook)
+  - [Vertical Pod Autoscaler](#vertical-pod-autoscaler)
+  - [Delegate to underlying infrastructure](#delegate-to-underyling-infrastructure)
+
+## Release Signoff Checklist
+
+- [ ] kubernetes/enhancements issue in release milestone, which links to KEP (this should be a link to the KEP location in kubernetes/enhancements, not the initial KEP PR)
+- [ ] KEP approvers have set the KEP status to `implementable`
+- [ ] Design details are appropriately documented
+- [ ] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [ ] Graduation criteria is in place
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+**Note:** Any PRs to move a KEP to `implementable` or significant changes once it is marked `implementable` should be approved by each of the KEP approvers. If any of those
+approvers is no longer appropriate than changes to that list should be approved by the remaining approvers and/or the owning SIG (or SIG-arch for cross cutting KEPs).
+
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://github.com/kubernetes/enhancements/issues
+[kubernetes/kubernetes]: https://github.com/kubernetes/kubernetes
+[kubernetes/website]: https://github.com/kubernetes/website
+
+## Summary
+
+Over-committing physical host resources is a powerful tool for managing server
+footprint, and therefore cost. The canonical example is CPU, where
+virtualization platforms run 10+ virtual CPUs per physical CPU. Kubernetes
+currently allows this by manipulating the ratio between resource `request` and
+resource `limit` on a per-container basis. However, these values may be set by
+a single application owner, who may not have a clear view on the utilization
+level over the entire cluster.
+
+This KEP proposes an API, `CommitClass`, to allow cluster operators to over- or
+under-commit the physical resources on a group of nodes by modifying the
+amount of resource advertised by kubelet to the scheduler.
+
+## Motivation
+
+Cost is a key quality metric for business value delivered by a Kubernetes
+cluster. Cluster cost is typically proportional to the number of nodes required
+to run the Pods present on the cluster, which is a function of the resources
+requested by those Pods.
+
+One traditional strategy for minimizing the number of nodes required to run the
+desired workloads is over-commit of resources. The key hypothesis is that load
+spikes between distinct workloads are typically uncoordinated, and so the same
+resource may be allocated multiple times to different workloads. Higher
+over-commit levels achieve better cost outcomes, but risk compromising service
+quality if the uncoordinated-spike hypothesis does not hold.
+
+Kubernetes currently provides for resource over-commit by allowing Pods to
+declare themselves 'Burstable' or 'Best Effort' via container resource
+request:limit ratios. This is a powerful approach, but achieving high
+utilization at the cluster level requires coordination across many authors of
+Pod specs, which is challenging in a 'Namespace as a Service' multi-tenant
+Kubernetes environment, or surprising when implemented by fiat as a mutating
+admission webhook or required usage of Vertical Pod Autoscaler.
+
+The key belief behind this KEP is that Pod resource request:limit ratios are
+the business of the owner of that Pod, and should be primarily concerned with
+the cost of running that particular Pod. The cost of the cluster as a whole is
+outside their scope; as such, Kubernetes should provide a "big hammer" for
+cluster operators to use their wider perspective on cluster utilization to
+reduce cost via platform-level over-commit policies.
+
+### Goals
+
+* Allow platform-level over- or under- subscription of resources on groups of
+  nodes.
+
+### Non-Goals
+
+* Help cluster operators choose appropriate commit settings.
+* Automatically adjust commit settings to maximize utilization.
+* Replace VPA, HPA, or any other Pod-level right-sizing/auto-scaling API.
+  These APIs are complimentary: they help Pod owners optimize their footprint,
+  while `CommitClass` helps cluster operators optimize the cluster footprint.
+
+## Proposal
+
+TODO
+
+Approximately: introduce a `CommitClass` cluster-scoped object which defines
+a node selector and a list of resource multipliers. All nodes which match the
+node selector should apply the multipliers to the associated resource when
+updating their Node API object.
+
+#### Open question: conflict between multiple CommitClasses
+
+How do you resolve conflict if multiple nodes are selected by the same
+`CommitClass`? kubelet probably needs to record which `CommitClass` is in
+effect on a Node object so that it is clear to operators what's up. One
+alternative strategy would be to have a 'Binding' style object which enumerated
+the Node names it applied to, but that interacts badly with Cluster autoscaler.
+
+Nodes should default to a `CommitClass` where all multipliers are '1'.
+
+Consideration: it is usually a bad idea to give a single VM more vCPUs than
+physical CPUs are available on the host system. Should that be reflected here
+somehow for containers?
+
+### API Design
+
+TODO, perhaps something like:
+
+```yaml
+kind: CommitClass
+apiVersion: node.k8s.io/v1alpha1
+metadata:
+    name: high-cpu-density
+spec:
+  nodes:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: beta.kubernetes.io/instance-type
+      operator: In
+      values:
+      - compute-optimized
+  resources:
+  - name: cpu
+    multiplier: 10
+  - name: memory
+    multiplier: 1.2
+```
+
+### Implementation Details
+
+(very approximate, my initial guess)
+
+With this proposal, the following changes are required:
+ - Introduce a new cluster-scoped API object, `CommitClass`.
+ - Add an informer for `CommitClass` objects to `kubelet`.
+ - When updating the Node object with resources available for scheduling,
+   `kubelet` should determine which `CommitClass` object is in effect, and use
+   the multipliers of that `CommitClass` to change the resource amount
+   advertised.
+ - Determine a location in the Node API to record which `CommitClass` is in
+   effect for that Node.
+ - Change `kubelet` to record the `CommitClass` into that location.
+
+### Risks and Mitigations
+
+This proposal introduces new behavior to `kubelet` in a way which can
+meaningfully impact its work. A feature gate may be appropriate.
+
+## Design Details
+
+### Graduation Criteria
+
+TODO. Probably feature gate, alpha/beta/GA sequence, figure out graduation
+criteria between levels.
+
+### Upgrade / Downgrade Strategy
+
+No action is required to keep existing behavior on upgrade: kubelets should
+default (explicitly or implicitly) to a `CommitClass` where all multipliers are
+'1'.
+
+A cluster operator may start using this enhancement by upgrading to a version
+of kubelet which supports it, and using the CommitClass API.
+
+Downgrading kubelet will cause the CommitClass API to lose effect, which may
+result in Pods being over-scheduled on a node.
+
+### Version Skew Strategy
+
+Kubelets from versions which do not support CommitClass will advertise the
+exact amount of resources they have. As they are upgraded to a version with
+CommitClass support, they will advertise a different amount of resources
+depending on the CommitClass in effect. This may be surprising if a CommitClass
+selector includes nodes which do not yet support it.
+
+## Implementation History
+
+- 2019-05-30: Draft KEP published.
+
+## Drawbacks
+
+The proposed CommitClass API has the potential to materially impact the cost
+and service quality of a Kubernetes cluster. Using the CommitClass API to
+over-commit may introduce workload performance degradation or instability.
+Conversely, significantly under-committing cluster resources will result in
+excessive cost. These issues may result in a higher support burden for the
+Kubernetes community as cluster operators encounter these extremes.
+
+This KEP introduces technical complexity to the `kubelet`. It also introduces
+a layer of indirection for cluster operators debugging resource or performance
+issues.
+
+## Alternatives
+
+### Mutating Admission Webhook
+
+Systemic over- or under-commit may be implemented by a mutating admission
+webhook which modifies a Pod's resource request by a particular amount. This is
+[how it is implemented in
+OpenShift](https://docs.openshift.com/container-platform/3.4/admin_guide/overcommit.html#configuring-masters-for-overcommitment).
+
+This approach is very straightforward to implement, and requires no new API
+from Kubernetes. However, it has a few drawbacks:
+
+- In a multi-tenant environment, Pod owners may be surprised that their Pod
+  specs have been mutated.
+- The webhook is likely to change 'guaranteed' class Pods into 'burstable'
+  ones, which impacts priority in case of resource contention. If it maintains
+  'guaranteed' class by also reducing resource limits, it may starve the
+  application.
+- Changing over-commit level based on node characteristics requires careful
+  business logic in the webhook (likely a Node informer).
+
+### Vertical Pod Autoscaler
+
+Pod resource requests may also be managed with use of the Vertical Pod
+Autoscaler. With this approach, Pods which use minimal resources will find
+their resource requests shrinking over time. If enough of a cluster's workloads
+are managed by VPA, high cluster resource density may be achieved without
+over-commit.
+
+VPA is a powerful tool for right-sizing Pods, but is difficult to wield for the
+purposes of cluster footprint optimization:
+
+- It is difficult to mandate VPA usage in a 'Namespace as a Service' style
+  Kubernetes platform.
+- VPA complicates capacity planning for Pod owners, so not all Pod owners may
+  want to use it.
+- VPA may increase platform exposure to application memory or CPU leaks, and so
+  may be an undesirable default.
+
+### Delegate to Underlying Infrastructure
+
+Virtual Machine infrastructures have provided distinct user-level resource
+request/limit and platform-level over-commit settings for some time. The
+Kubernetes project could take the position that Kubernetes clusters with an
+interest in platform-level cost optimization should run on top of a VM
+infrastructure, and thereby delegate the commit settings to the VM
+orchestrator.

--- a/keps/sig-node/20190530-commit-class.md
+++ b/keps/sig-node/20190530-commit-class.md
@@ -218,9 +218,6 @@ In more detail, first cut implementation idea:
   vCPUs, which is a correct representation of the operator intent. Need to
   think whether this should also be the case for under-commit percentages.
 
-* Also learn whether the Admit function in PredicateAdmitHandler needs to
-  apply the percentages, or whether it uses the Node object already transformed.
-
 ### Risks and Mitigations
 
 This proposal introduces new behavior to `kubelet` in a way which can


### PR DESCRIPTION
This is a KEP describing a way for platform operators to over- or under-subscribe node resources in a cluster. The main motivation is to allow operators to use their cluster-level perspective on utilization to strategically increase (or decrease) density in groups of nodes. Ideally this allows operators a way to position themselves on the cost<->quality of service spectrum according to business need, and without coordinating with each potential author of Pod specs on the platform.

I'm totally not sure which SIG this should be rooted in: I've reached out to sig-node, sig-scalability, sig-scheduling, and wg-multitenancy on slack for initial feedback on the idea. The PR currently has it in sig-node mostly because my imagined implementation is largely changes to `kubelet`, but I would very much appreciate some pointers there, or for a set of reviewers that make sense.

Thank you!