### PR TITLE
remove prefixed KEP version numbers from instrumentation KEPs (now obsolete)

### DIFF
--- a/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
+++ b/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 0031
 title: Kubernetes Metrics Overhaul
 authors:
   - "@brancz"
@@ -155,7 +154,7 @@ https://github.com/kubernetes/kubernetes/pull/75279
 
 Workqueue metrics need follow prometheus best practices and naming conventions.
 
-* Instead of naming metrics based on the name of the workqueue, create metrics for workqueues that use name as a label. 
+* Instead of naming metrics based on the name of the workqueue, create metrics for workqueues that use name as a label.
 * Use the recommended base units.
 * Change summaries to histograms.
 

--- a/keps/sig-instrumentation/20190131-event-series.md
+++ b/keps/sig-instrumentation/20190131-event-series.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 35
 title: Event series API
 authors:
   - "@gmarek"

--- a/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
+++ b/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
@@ -1,6 +1,5 @@
 ---
 title: Kubernetes Control-Plane Metrics Stability
-number: 42
 authors:
   - "@logicalhan"
 owning-sig:
@@ -25,7 +24,7 @@ editor:
   - @x13n
 creation-date: 2019-04-04
 see-also:
-  - 0031-kubernetes-metrics-overhaul
+  - 20181106-kubernetes-metrics-overhaul
 status: implementable
 ---
 


### PR DESCRIPTION
Cleaning up instrumentation KEP filenames. 

/cc @spiffxp 
/assign @brancz 
/sig instrumentation 