### PR TITLE
Proposal for metrics stability migration

### DIFF
--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -70,11 +70,13 @@ Kubernetes control-plane binaries can expose one or more metrics endpoints:
     * [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/cmd/kube-proxy/app/server.go#L570)
 * one kube-apiserver metrics endpoint
     * [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go#L36)
+* one scheduler metrics endpoint
+    * [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/cmd/kube-scheduler/app/server.go#L289)
 * [four kubelet metrics endpoints](https://github.com/kubernetes/kubernetes/blob/release-1.15/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go#L36)
     * [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L299)
-    * [/metrics/cadvisor](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L315)
-    * [/metrics/resource](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L321-L323)
     * [/metrics/probes](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L329-L331)
+    * (out of scope) ~~[/metrics/cadvisor](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L315)~~
+    * (out of scope) ~~[/metrics/resource](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L321-L323)~~
 
 Following our desired approach, each of metrics endpoint above (except those out of scope) will be accompanied by an individual PR for migrating that endpoint.
 

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -24,7 +24,7 @@ creation-date: 2019-06-05
 see-also:
   - 20181106-kubernetes-metrics-overhaul
   - 20190404-kubernetes-control-plane-metrics-stability
-status: proposal
+status: implementable
 ---
 
 # Metrics Stability Migration

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -96,6 +96,8 @@ The [metrics overhaul KEP](https://github.com/kubernetes/enhancements/blob/maste
 
 ## Implementation History
 
+- [ ] [Migrate kubelet metrics to use standard prometheus collectors](https://github.com/kubernetes/kubernetes/issues/79286)
+
 TBD (since this is not yet implemented)
 
 ## Graduation Criteria

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -44,12 +44,11 @@ This KEP intends to document and communicate the general strategy for migrating 
 
 ## Motivation
 
-We want to start using the metrics stability framework built based off the [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md), so that we can define stability levels for metrics in the Kubernetes codebase.
+We want to start using the metrics stability framework built based off the [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md), so that we can define stability levels for metrics in the Kubernetes codebase. These stability levels would provide API compatibility guarantees across version bumps.
 
 ### Goals
 
-Setup a strategy for migrating metrics to the stability framework. Also:
-
+ * Outline the general strategy for migrating metrics to the stability framework
  * Explicitly define a strategy for handling migration of shared metrics.
  * Maintain backwards compatibility through the migration path. *This excludes metrics which are slated to be removed after deprecation due to metrics overhaul.*
  * Communicate upcoming changes to metrics to respective component owners.
@@ -57,7 +56,7 @@ Setup a strategy for migrating metrics to the stability framework. Also:
 ### Non-Goals
 
 * During migration, we will __*not*__ be determining whether a metric is considered stable. Any metrics which will be promoted to a stable status must be done post-migration.
-* Kubelet '/metrics/resource' and '/metrics/cadvisor' are out of scope for this migration.
+* Kubelet '/metrics/resource' and '/metrics/cadvisor' are out of scope for this migration due to use of non-standard prometheus collectors.
 
 ## General Migration Strategy
 
@@ -99,6 +98,14 @@ The [metrics overhaul KEP](https://github.com/kubernetes/enhancements/blob/maste
 
 TBD (since this is not yet implemented)
 
-## Graduating metrics
+## Graduation Criteria
 
+- [ ] Prior to migrating a component, automated static analysis testing is in place to validate and verify API guarantees.
+- [ ] Adequate documentation exists for new flags on components.
+- [ ] Update instrumentation documents to reflect changes
 
+## Testing Plan
+
+- [ ] Prior to migrating a metric's endpoint, we will run local tests to verify that the same metrics are populated
+- [ ] All metrics framework code will have unit/integration tests
+- [ ] All validation and verification code will have unit/integration tests

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -17,7 +17,7 @@ reviewers:
   - @sttts from sig-api-machinery
   - @DirectXMan12 from sig-cluster-lifecycle
   - @bsalamat from sig-scheduling
-  - TBD from sig-cloud-provider
+  - @andrewsykim from sig-cloud-provider
 approvers:
   - "@brancz"
 creation-date: 2019-06-05

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -99,6 +99,14 @@ The [metrics overhaul KEP](https://github.com/kubernetes/enhancements/blob/maste
 ## Implementation History
 
 - [ ] [Migrate kubelet metrics to use standard prometheus collectors](https://github.com/kubernetes/kubernetes/issues/79286)
+- [ ] Create migrated variants of shared client metrics
+- [ ] Create migrated variants of shared leader-election metrics
+- [ ] Create migrated variants of shared workqueue metrics
+- [ ] Migrate kubelet's /metrics/probes endpoint
+- [ ] Migrate apiserver /metrics endpoint
+- [ ] Migrate scheduler /metrics endpoint
+- [ ] Migrate kube-proxy /metrics endpoint
+- [ ] Migrate controller-manager /metrics endpoint (this include in-tree cloud-provider metrics)
 
 TBD (since this is not yet implemented)
 

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -1,0 +1,137 @@
+---
+title: Control-Plane Metrics Stability Migration
+authors:
+  - "@logicalhan"
+  - "@solodov"
+owning-sig:
+  - sig-instrumentation
+participating-sigs:
+  - sig-scheduling
+  - sig-node
+  - sig-api-machinery
+  - sig-cli
+  - sig-cloud-provider
+reviewers:
+  - TBD
+approvers:
+  - TBD
+editor:
+  - TBD
+creation-date: 2019-06-05
+see-also:
+  - 20181106-kubernetes-metrics-overhaul
+  - 20190404-kubernetes-control-plane-metrics-stability
+status: proposal
+---
+
+# Control-Plane Metrics Stability Migration
+
+## Table of Contents
+
+* [Table of Contents](#table-of-contents)
+* [Summary](#summary)
+* [Motivation](#motivation)
+    * [Goals](#goals)
+    * [Non-Goals](#non-goals)
+
+
+## Summary
+
+Currently metrics emitted in the Kubernetes control-plane do not offer any stability guarantees. This Kubernetes Enhancement Proposal (KEP) builds off of the framework proposed in the [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) and proposes a migration strategy for the Kubernetes code base.
+
+## Motivation
+
+We want to start using the metrics stability framework which was based off of [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md).
+
+### Goals
+
+ * Describe a migration strategy for moving metrics onto our metrics stability framework.
+ * Maintain backwards compatibility through the migration path. This excludes metrics which are slated to be removed after deprecation due to metrics overhaul.
+
+### Non-Goals
+
+* During migration, we will __*not*__ be determining whether a metric is considered stable. Any metrics which will be promoted to a stable status must be done post-migration.
+
+## Background
+
+The [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) outlined a framework which we will use to annotate Kubernetes metrics with stability and deprecation metadata. This KEP intends to address our migration strategy.
+
+Kubernetes control-plane binaries can expose one or more metrics endpoints:
+
+* controller-manager - [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/cmd/controller-manager/app/serve.go#L65)
+* kube-proxy - [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/cmd/kube-proxy/app/server.go#L570)
+* kube-apiserver - [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go#L36)
+* kubelet - [four metrics endpoints](https://github.com/kubernetes/kubernetes/blob/release-1.15/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go#L36)
+    * [/metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L299)
+    * [/metrics/cadvisor](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L315)
+    * [/metrics/resource](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L321-L323)
+    * [/metrics/probes](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/server/server.go#L329-L331)
+
+Ideally, we want to be able to migrate each metrics endpoint individually. Migration in a piecemeal fashion would allow us to avoid having to operate across the entire codebase at once.
+
+However, there are two major shared metric components across binaries:
+
+1. [Kubernetes build info metadata metric](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/version/prometheus/prometheus.go#L26-L38) - used by kube-apiserver, controller-manager, hollow-node, kubelet, kube-proxy, scheduler.
+2. [Client-go metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/util/prometheusclientgo/adapters.go#L20-L24)
+    * [client metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/client/metrics/prometheus/prometheus.go#L61-L66)
+    * [leader-election metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/util/prometheusclientgo/leaderelection/adapter.go#L27-L29)
+    * [workqueue metrics](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/util/workqueue/prometheus/prometheus.go)
+
+This potentially poses a challenge for piecemeal migration. How do we migrate these shared metrics so that we do not have to migrate every component which uses them at the same time?
+
+Consider this:
+
+```golang
+func init() {
+  leaderelection.SetProvider(prometheusMetricsProvider{})
+}
+
+type prometheusMetricsProvider struct{}
+
+func (prometheusMetricsProvider) NewLeaderMetric() leaderelection.SwitchMetric {
+  leaderGauge := prometheus.NewGaugeVec(
+    prometheus.GaugeOpts{
+      Name: "leader_election_master_status",
+      Help: "Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.",
+    },
+    []string{"name"},
+  )
+  prometheus.Register(leaderGauge)
+  return &switchAdapter{gauge: leaderGauge}
+}
+```
+
+There are two distinct issues:
+
+1. the metrics provider is set in an `init` function which means that the metrics provider is set as a side effect of an import statement like this one:
+
+```golang
+import (
+  _ "k8s.io/kubernetes/pkg/util/prometheusclientgo/leaderelection" // for leader election metric registration
+)
+```
+This means we cannot use anything in this file without invoking the `init` function (which we would probably want to do in order to migrate metrics).
+
+2. The `NewLeaderMetric` metric creates a new metric and registers that metric to the default global prometheus registry. To enable piecemeal migration, we would want to be able configure a registry and a registerable metric so that we can toggle between using the global prom registry or our internal registry based on whether the component importing this shared metric is migrated or not.
+
+## Proposal
+
+We migrate each endpoint individually, starting with kubelet's metrics/probes endpoint, since it is a relatively thin metrics enpoint.
+
+### Graduation Criteria
+
+TBD
+
+## Drawbacks
+
+TBD
+
+## Alternatives
+
+TBD
+
+## Implementation History
+
+TBD (since this is not yet implemented)
+
+## References

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -12,12 +12,12 @@ participating-sigs:
   - sig-cluster-lifecycle
   - sig-cloud-provider
 reviewers:
-  - TBD from sig-instrumentation
-  - TBD from sig-node
-  - TBD from sig-api-machinery
-  - TBD from sig-cluster-lifecycle
+  - @brancz from sig-instrumentation
+  - @dashpole from sig-node
+  - @sttts from sig-api-machinery
+  - @DirectXMan12 from sig-cluster-lifecycle
+  - @bsalamat from sig-scheduling
   - TBD from sig-cloud-provider
-  - TBD from sig-scheduling
 approvers:
   - "@brancz"
 creation-date: 2019-06-05
@@ -92,7 +92,7 @@ Our strategy around shared metrics is to simply duplicate shared metric files an
 
 ### Deprecation of modified metrics from metrics overhaul KEP
 
-The [metrics overhaul KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md) deprecates a number of metrics across the Kubernetes code-base. As a part of this migration, these metrics will be marked as deprecated since 1.16, meaning that they will be hidden automatically for 1.17. These metrics will be in a deprecated but 'hidden' state and will be able to be optionally enabled through command line flags for one release cycle, after which they will be permanently deleted.
+The [metrics overhaul KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md) deprecates a number of metrics across the Kubernetes code-base. As a part of this migration, these metrics will be marked as deprecated since 1.16, meaning that they will be hidden automatically for 1.17. These metrics will be in a deprecated but 'hidden' state and will be able to be optionally enabled through command line flags for one release cycle, and they will be permanently deleted in 1.18.
 
 ## Implementation History
 


### PR DESCRIPTION
This KEP proposes a strategy for migrating control-plane metrics to use the metrics framework which was the output of the control-plane metrics stability KEP.