### PR TITLE
Update preemption policy kep

### DIFF
--- a/keps/sig-scheduling/20190317-non-preempting-priorityclass.md
+++ b/keps/sig-scheduling/20190317-non-preempting-priorityclass.md
@@ -1,5 +1,5 @@
 ---
-title: Add NonPreempting Option For PriorityClasses
+title: Add Preemption Option For PriorityClasses
 authors:
   - "@vllry"
 owning-sig: sig-scheduling
@@ -19,7 +19,7 @@ replaces:
 superseded-by:
 ---
 
-# Allow PriorityClasses To Be Non-Preempting
+# Allow PriorityClasses To Be Non-Preempting or Non-Preemptible
 
 ## Table of Contents
 
@@ -42,74 +42,80 @@ Pods are be scheduled according to descending priority.
 If a pod cannot be scheduled due to insufficient resources,
 lower-priority pods will be preempted to make room.
 
-This proposal makes the preempting behavior optional for a PriorityClass,
-by adding a new field to PriorityClasses,
+This proposal makes the preemption behavior optional for a PriorityClass,
+by adding a new policy field to PriorityClasses,
 which in turn populates PodSpec.
 If a pod is waiting to be scheduled,
-and it does not have preemption enabled,
+and it does not have preempting enabled,
 it will not trigger preemption of other pods.
+While a pod is a candidate to be preempted,
+but it has the non-preemptible policy,
+it will not be taken as victim.
 
 ## Motivation
 
-Allowing PriorityClasses to be non-preempting is important for running batch workloads.
+Allowing PriorityClasses to be non-preempting/non-preemptible is important for running batch workloads.
 
 Batch workloads typically have a backlog of work,
 with unscheduled pods.
 Higher-priority workloads can be assigned a higher priority via a PriorityClass,
 but this may result in pods with partially-completed work being preempted.
-Adding the non-preempting option allows users to prioritize the scheduling queue,
+Adding the non-preempting/non-preemptible option allows users to prioritize the scheduling queue,
 without discarding incomplete work.
 
 ### Goals
 
-Add a boolean to PriorityClasses,
+Add a preemption policy filed to PriorityClasses,
 to enable or disable preemption for pods of that PriorityClass.
+
+The policy includes non-preemting and non-preemptible.
 
 ### Non-Goals
 
-* Protecting pods from preemption. PodDisruptionBudget should be used.
+* Pod high available and autoscaling. PodDisruptionBudget should be used.
 
 ## Proposal
 
-Add a Preempting field to both PodSpec and PriorityClass.
-This field will default to true,
+Add a PreemptionPolicy field to both PodSpec and PriorityClass.
+This field will default to `PreemptLowerPriority`,
 for backwards compatibility.
 
-If Preempting is true for a pod,
-the scheduler will preempt lower priority pods to schedule this pod,
-as is current behavior.
-
-If Preempting is false,
-a pod of that priority will not preempt other pods.
-
-Setting the Preempting field in PriorityClass provides a straightforward interface,
-and allows ResourceQuotas to restrict preemption.
+* PreemptLowerPriority means that pod can preempt other pods with lower priority and
+can be preempted by other pods with higher priority.
+* PreemptNever means that pod never preempts other pods with lower priority and
+can be preempted by other pods with higher priority.
+* NonPreemptible means that pod can preempt other pods with lower priority and
+can not be preempted by other pods with higher priority.
+* NonPreemptiblePreemptNever means that pod can not preempt other pods with lower priority and
+can not be preempted by other pods with higher priority.
 
 PriorityClass type example:
 ```
+type PreemptionPolicy string
+
 type PriorityClass struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 	Value int32
 	GlobalDefault bool
 	Description string
-	Preempting *bool // New option
+	PreemptionPolicy *PreemptionPolicy // New option
 }
 ```
 
-The Preempting field in PodSpec will be populated during pod admission,
+The PreemptionPolicy field in PodSpec will be populated during pod admission,
 similarly to how the PriorityClass Value is populated.
-Storing the Preempting field in the pod spec has several benefits:
+Storing the PreemptionPolicy field in the pod spec has several benefits:
 * The scheduler does not need to be aware of PiorityClasses,
 as all relevant information is in the pod.
 * Mutating PriorityClass objects does not impact existing pods.
-* Kubelets can set Preempting on static pods.
+* Kubelets can set PreemptionPolicy on static pods.
 
 PodSpec type example:
 ```
 type PodSpec struct {
     ...
-    Preempting *bool
+	PreemptionPolicy *PreemptionPolicy
     ...
 }
 ```
@@ -128,7 +134,7 @@ and the existing preempting PriorityClass tests should be used to prove stabilit
 
 ## Graduation Criteria
 
-**Typical user story:**
+**Typical user story A:**
 A user is running batch workloads on a cluster.
 The user has a high-priority job,
 that they wish to schedule before other workloads in the queue.
@@ -138,6 +144,17 @@ non-preempting PriorityClass.
 The new workload's pods are scheduled ahead of the queue,
 without disrupting running workloads.
 
+**Typical user story B:**
+A user is running batch workloads on a cluster.
+The user has a low-priority jobs, and it's non-interruptible,
+that they wish to schedule after other higer priority workloads in the queue.
+As the user does not want it to be preempted once it's running and until finishing,
+the user creates the new workload with a low-priority,
+non-preemptible PriorityClass.
+The new workload's pods will be scheduled base on the priority queue,
+and when it's running it would not be preempted by higher priority tasks.
+
+
 * Users are able to run preempting and non-preempting workloads in a stable manner,
 and are not requesting additional changes.
 * The feature has been stable and reliable in at least 2 releases.
@@ -146,7 +163,7 @@ and are not requesting additional changes.
 * Conformance requirements for non-preempting PriorityClasses are agreed upon.
 
 ## Testing Plan
-Add detailed unit and integration tests for nonpreempting workloads.
+Add detailed unit and integration tests for non-preempting/non-preemptible workloads.
 
 Add basic e2e tests, to ensure all components are working together.
 


### PR DESCRIPTION
As we've have non-preempting(https://github.com/kubernetes/kubernetes/pull/74614) policy, for some cases, users may need non-preemptible PriorityClasses as well.

We could add two more preemption policies to control both preempting and preemptible:

- `PreemptLowerPriority` means that pod can preempt other pods with lower priority and can be preempted by other pods with higher priority.
- `PreemptNever` means that pod never preempts other pods with lower priority and can be preempted by other pods with higher priority.
- `NonPreemptible` means that pod can preempt other pods with lower priority and can not be preempted by other pods with higher priority.
- `NonPreemptiblePreemptNever` means that pod can not preempt other pods with lower priority and can not be preempted by other pods with higher priority.

