### PR TITLE
Cleanup all metadata and enable metadata validation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dae70dd90d4778dfb750806d9da1132d0476d7624667c8c028957290fd29b7c0"
+  digest = "1:ec85bf30d11286b143ce17bbc6534782c2c426e5566cc6df5e7568b4db320856"
   name = "github.com/chuckha/kepview"
   packages = [
     ".",
@@ -20,7 +20,7 @@
     "keps/validations",
   ]
   pruneopts = "NUT"
-  revision = "1c4a214e81dc19d5904c635e4b7840fd15341800"
+  revision = "b97ce7d3f1daca6bc79d60952e461df3ffa88a5b"
 
 [[projects]]
   digest = "1:a58083c7c5f9e83cc3bc1af06f53b92693ed6cbdf691a1f3a14dcb2bcee2f53c"

--- a/hack/verify-all-metadata.sh
+++ b/hack/verify-all-metadata.sh
@@ -19,10 +19,11 @@ set -o nounset
 set -o pipefail
 
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+cd ${KUBE_ROOT}
 
 go install ./vendor/github.com/chuckha/kepview/cmd/kepval
-if ! which kepview >/dev/null 2>&1; then
-    echo "Can't find kepview - is your GOPATH 'bin' in your PATH?" >&2
+if ! which kepval >/dev/null 2>&1; then
+    echo "Can't find kepval - is your GOPATH 'bin' in your PATH?" >&2
     echo "  GOPATH: ${GOPATH}" >&2
     echo "  PATH:   ${PATH}" >&2
     exit 1
@@ -30,4 +31,4 @@ fi
 
 # TODO: perhaps there is a way to make the template valid while still
 # communicating the expected date format.
-grep --recursive --files-with-matches --regexp '---' --include='*.md' keps | grep --invert-match "YYYYMMDD-kep-template.md" | xargs kepval
+grep --recursive --files-with-matches --regexp '---' --include='*.md' keps | grep --invert-match "YYYYMMDD-kep-template.md" | grep --invert-match "0023-documentation-for-images.md" | xargs kepval

--- a/hack/verify-kep-metadata.sh
+++ b/hack/verify-kep-metadata.sh
@@ -29,6 +29,6 @@ if ! which kepval >/dev/null 2>&1; then
     exit 1
 fi
 
-# TODO: perhaps there is a way to make the template valid while still
-# communicating the expected date format.
+# * ignore "0023-documentation-for-images.md" because it is not a real KEP
+# * ignore "YYYYMMDD-kep-template.md" because it is not a real KEP
 grep --recursive --files-with-matches --regexp '---' --include='*.md' keps | grep --invert-match "YYYYMMDD-kep-template.md" | grep --invert-match "0023-documentation-for-images.md" | xargs kepval

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -33,7 +33,6 @@ fi
 EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
-  "verify-all-metadata.sh"       # TODO: this can be removed once all old metadata is fixed
   )
 
 EXCLUDED_CHECKS=$(ls ${EXCLUDED_PATTERNS[@]/#/${KUBE_ROOT}\/hack\/} 2>/dev/null || true)

--- a/keps/0001-kubernetes-enhancement-proposal-process.md
+++ b/keps/0001-kubernetes-enhancement-proposal-process.md
@@ -12,7 +12,7 @@ approvers:
   - "@bgrant0607"
 editor: "@jbeda"
 creation-date: 2017-08-22
-last-updated: 2019-07-02
+last-updated: 2019-04-12
 status: implementable
 ---
 

--- a/keps/0001-kubernetes-enhancement-proposal-process.md
+++ b/keps/0001-kubernetes-enhancement-proposal-process.md
@@ -12,6 +12,7 @@ approvers:
   - "@bgrant0607"
 editor: "@jbeda"
 creation-date: 2017-08-22
+last-updated: 2019-07-02
 status: implementable
 ---
 

--- a/keps/0001a-meta-kep-implementation.md
+++ b/keps/0001a-meta-kep-implementation.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 1a
 title: Meta KEP Implementation
 authors:
   - "@justaugustus"

--- a/keps/sig-api-machinery/0006-apply.md
+++ b/keps/sig-api-machinery/0006-apply.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 6
 title: Apply
 authors:
   - "@lavalamp"

--- a/keps/sig-api-machinery/0015-dry-run.md
+++ b/keps/sig-api-machinery/0015-dry-run.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 15
 title: Dry-run
 authors:
   - "@apelisse"

--- a/keps/sig-api-machinery/0030-storage-migration.md
+++ b/keps/sig-api-machinery/0030-storage-migration.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 30
 title: Migrating API objects to latest storage version
 authors:
   - "@xuchao"

--- a/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
+++ b/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 36
 title: Graduate Admission Webhooks to GA
 authors:
   - "@mbohlool"

--- a/keps/sig-api-machinery/00xx-publish-crd-openapi.md
+++ b/keps/sig-api-machinery/00xx-publish-crd-openapi.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 0
 title: Publish CRD OpenAPI
 authors:
   - "@roycaihw"

--- a/keps/sig-api-machinery/20180731-crd-pruning.md
+++ b/keps/sig-api-machinery/20180731-crd-pruning.md
@@ -20,8 +20,8 @@ creation-date: 2018-07-31
 last-updated: 2019-04-30
 status: implementable
 see-also:
- - "https://github.com/kubernetes/enhancements/pull/1002"
- - "/keps/sig-api-machinery/20180415-crds-to-ga.md"
+  - "https://github.com/kubernetes/enhancements/pull/1002"
+  - "/keps/sig-api-machinery/20180415-crds-to-ga.md"
 ---
 
 # Pruning for Custom Resources

--- a/keps/sig-api-machinery/20190206-watch-bookmark.md
+++ b/keps/sig-api-machinery/20190206-watch-bookmark.md
@@ -11,9 +11,10 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 creation-date: 2019-02-06
+last-updated: 2019-07-02
 status: implementable
 see-also:
-  - https://github.com/kubernetes/kubernetes/issues/73585
+  - "https://github.com/kubernetes/kubernetes/issues/73585"
 replaces:
   - n/a
 superseded-by:

--- a/keps/sig-api-machinery/20190206-watch-bookmark.md
+++ b/keps/sig-api-machinery/20190206-watch-bookmark.md
@@ -11,7 +11,7 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 creation-date: 2019-02-06
-last-updated: 2019-07-02
+last-updated: 2019-04-30
 status: implementable
 see-also:
   - "https://github.com/kubernetes/kubernetes/issues/73585"

--- a/keps/sig-api-machinery/20190226-network-proxy.md
+++ b/keps/sig-api-machinery/20190226-network-proxy.md
@@ -17,8 +17,8 @@ reviewers:
   - "@krousey"
   - "@khenidak"
 approvers:
-  - "@deads2k" - For Kube API Server portion of KEP
-  - "@bowei" - For networking/proxy portion of KEP
+  - "@deads2k - For Kube API Server portion of KEP"
+  - "@bowei - For networking/proxy portion of KEP"
 editor: "@calebamiles"
 creation-date: 2019-02-25
 last-updated: 2019-04-30

--- a/keps/sig-api-machinery/20190228-priority-and-fairness.md
+++ b/keps/sig-api-machinery/20190228-priority-and-fairness.md
@@ -16,9 +16,9 @@ editor: TBD
 creation-date: 2019-02-28
 last-updated: 2019-02-28
 status: implementable
-see-also: []
-replaces: []
-superseded-by: []
+see-also:
+replaces:
+superseded-by:
 ---
 
 # Priority and Fairness for API Server Requests

--- a/keps/sig-api-machinery/20190325-unions.md
+++ b/keps/sig-api-machinery/20190325-unions.md
@@ -5,12 +5,12 @@ authors:
 owning-sig: sig-api-machinery
 participating-sigs:
 reviewers:
-- "@sttts"
-- "@lavalamp"
-- "@thockin"
-- "@DirectXMan12"
+  - "@sttts"
+  - "@lavalamp"
+  - "@thockin"
+  - "@DirectXMan12"
 approvers:
-- "@lavalamp"
+  - "@lavalamp"
 editor: TBD
 creation-date: 2019-03-25
 last-updated: 2019-03-25
@@ -18,7 +18,7 @@ status: implementable
 see-also:
   - "/keps/sig-api-machinery/0006-apply.md"
 replaces:
-  - https://docs.google.com/document/d/1lrV-P25ZTWukixE9ZWyvchfFR0NE2eCHlObiCUgNQGQ
+  - "https://docs.google.com/document/d/1lrV-P25ZTWukixE9ZWyvchfFR0NE2eCHlObiCUgNQGQ"
 superseded-by:
 ---
 

--- a/keps/sig-api-machinery/20190425-crd-conversion-webhook.md
+++ b/keps/sig-api-machinery/20190425-crd-conversion-webhook.md
@@ -17,7 +17,7 @@ creation-date: 2019-04-25
 last-updated: 2019-04-25
 status: implemented
 replaces:
-  - (https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresource-conversion-webhook.md)
+  - "(https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/customresource-conversion-webhook.md)"
 ---
 
 # CustomResourceDefinition Conversion Webhook

--- a/keps/sig-api-machinery/20190425-structural-openapi.md
+++ b/keps/sig-api-machinery/20190425-structural-openapi.md
@@ -1,5 +1,5 @@
 ---
-title: Vanilla CRD OpenAPI Subset: Structural Schemas
+title: "Vanilla CRD OpenAPI Subset: Structural Schemas"
 authors:
   - "@sttts"
   - "@mbohlool"

--- a/keps/sig-api-machinery/20190426-crd-defaulting.md
+++ b/keps/sig-api-machinery/20190426-crd-defaulting.md
@@ -19,8 +19,8 @@ creation-date: 2019-04-26
 last-updated: 2019-05-01
 status: implementable
 see-also:
- - "/keps/sig-api-machinery/20180731-crd-pruning.md"
- - "/keps/sig-api-machinery/20190425-structural-openapi.md"
+  - "/keps/sig-api-machinery/20180731-crd-pruning.md"
+  - "/keps/sig-api-machinery/20190425-structural-openapi.md"
 ---
 
 # Defaulting for Custom Resources

--- a/keps/sig-api-machinery/34-storage-hash.md
+++ b/keps/sig-api-machinery/34-storage-hash.md
@@ -10,7 +10,7 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 creation-date: 2018-10-12
-last-updated: 2019-06-27
+last-updated: 2018-12-17
 status: provisional
 ---
 

--- a/keps/sig-api-machinery/34-storage-hash.md
+++ b/keps/sig-api-machinery/34-storage-hash.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 34
 title: Enabling clients to tell if resource endpoints serve the same set of objects
 authors:
   - "@xuchao"
@@ -11,7 +10,7 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 creation-date: 2018-10-12
-last-updated: 2018-xx-xx
+last-updated: 2019-06-27
 status: provisional
 ---
 

--- a/keps/sig-api-machinery/35-storage-version-hash.md
+++ b/keps/sig-api-machinery/35-storage-version-hash.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 35
 title: exposing hashed storage versions via the discovery API
 authors:
   - "@xuchao"

--- a/keps/sig-apps/0026-ttl-after-finish.md
+++ b/keps/sig-apps/0026-ttl-after-finish.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 26
 title: TTL After Finished
 authors:
   - "@janetkuo"

--- a/keps/sig-apps/0028-20180925-optional-service-environment-variables.md
+++ b/keps/sig-apps/0028-20180925-optional-service-environment-variables.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 28
 title: Optional Service Environment Variables
 authors:
   - "@bradhoekstra"
@@ -15,7 +14,7 @@ creation-date: 2018-09-25
 last-updated: 2018-09-25
 status: provisional
 see-also:
-  - https://github.com/kubernetes/community/pull/1249
+  - "https://github.com/kubernetes/community/pull/1249"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-apps/0032-portable-service-definitions.md
+++ b/keps/sig-apps/0032-portable-service-definitions.md
@@ -1,7 +1,6 @@
 # KEP: Portable Service Definitions
 
 ---
-kep-number: 31
 title: Portable Service Definitions
 authors:
   - "@mattfarina"
@@ -26,7 +25,6 @@ status: provisional
 see-also:
 replaces:
 superseded-by:
-
 ---
 
 # Portable Service Definitions

--- a/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md
+++ b/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 0
 title: Bounding Self-Labeling Kubelets
 authors:
   - "@mikedanese"

--- a/keps/sig-auth/0014-dynamic-audit-configuration.md
+++ b/keps/sig-auth/0014-dynamic-audit-configuration.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 14
 title: Dynamic Audit Configuration
 authors:
   - "@pbarker"

--- a/keps/sig-autoscaling/0032-enhance-hpa-metrics-specificity.md
+++ b/keps/sig-autoscaling/0032-enhance-hpa-metrics-specificity.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 0032
 title: Enhance HPA Metrics Specificity
 authors:
   - "@directxman12"
@@ -15,6 +14,7 @@ approvers:
   - "@directxman12"
 editor: "@directxman12"
 creation-date: 2018-04-19
+last-updated: 2019-06-27
 status: implemented
 ---
 

--- a/keps/sig-autoscaling/0032-enhance-hpa-metrics-specificity.md
+++ b/keps/sig-autoscaling/0032-enhance-hpa-metrics-specificity.md
@@ -14,7 +14,7 @@ approvers:
   - "@directxman12"
 editor: "@directxman12"
 creation-date: 2018-04-19
-last-updated: 2019-06-27
+last-updated: 2018-04-19
 status: implemented
 ---
 

--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -12,7 +12,7 @@ editor: TBD
 creation-date: 2019-03-07
 last-updated: 2019-03-07
 status: provisional
-superseded-by: TBD
+superseded-by:
 ---
 
 # Configurable scale up/down velocity for HPA

--- a/keps/sig-aws/20190128-cloud-controller-custom-endpoints.md
+++ b/keps/sig-aws/20190128-cloud-controller-custom-endpoints.md
@@ -14,9 +14,9 @@ editor: "@micahhausler"
 creation-date: 2019-01-28
 last-updated: 2019-01-28
 status: provisional
-see-also: []
-replaces: []
-superseded-by: []
+see-also:
+replaces:
+superseded-by:
 ---
 
 # Custom endpoint support for AWS Cloud Provider

--- a/keps/sig-aws/20190501-aws-nlb-beta.md
+++ b/keps/sig-aws/20190501-aws-nlb-beta.md
@@ -3,7 +3,7 @@ title: graduate-aws-nlb-to-beta
 authors:
   - "@M00nF1sh"
 owning-sig: sig-aws
-participating-sigs: null
+participating-sigs:
 reviewers:
   - "@dnishi"
 approvers:
@@ -14,7 +14,6 @@ creation-date: 2019-05-01
 last-updated: 2019-05-01
 status: implementable
 see-also:
-  - 
 replaces:
 superseded-by:
 ---

--- a/keps/sig-aws/aws-lb-prefix-annotation.md
+++ b/keps/sig-aws/aws-lb-prefix-annotation.md
@@ -1,5 +1,4 @@
 ---
-kep-number: TBD
 title: AWS LoadBalancer Prefix
 authors:
   - "@minherz"

--- a/keps/sig-aws/draft-20181127-aws-alb-ingress-controller.md
+++ b/keps/sig-aws/draft-20181127-aws-alb-ingress-controller.md
@@ -1,5 +1,4 @@
 ---
-kep-number: draft-20181127
 title: AWS ALB Ingress Controller
 authors:
   - "@M00nF1sh"

--- a/keps/sig-cli/0008-kustomize.md
+++ b/keps/sig-cli/0008-kustomize.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 8
 title: Kustomize
 authors:
   - "@pwittrock"

--- a/keps/sig-cli/0024-kubectl-plugins.md
+++ b/keps/sig-cli/0024-kubectl-plugins.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 24
 title: Kubectl Plugins
 authors:
   - "@juanvallejo"

--- a/keps/sig-cli/0032-datadrivencommands.md
+++ b/keps/sig-cli/0032-datadrivencommands.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 32
 title: Data Driven Commands for Kubectl
 authors:
   - "@pwittrock"

--- a/keps/sig-cli/kubectl-staging.md
+++ b/keps/sig-cli/kubectl-staging.md
@@ -12,8 +12,8 @@ approvers:
 editor: "@seans3"
 creation-date: 2019-04-09
 last-updated: 2019-04-09
-see-also:
 status: implementable
+see-also:
 ---
 
 

--- a/keps/sig-cli/kustomize-exec-secret-generator.md
+++ b/keps/sig-cli/kustomize-exec-secret-generator.md
@@ -13,9 +13,9 @@ approvers:
 editor: "@pwittrock"
 creation-date: 2019-03-12
 last-updated: 2019-03-12
-see-also:
-  - https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kustomize-secret-generator-plugins.md
 status: implementable
+see-also:
+  - "https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/kustomize-secret-generator-plugins.md"
 ---
 
 

--- a/keps/sig-cli/kustomize-file-processing-integration.md
+++ b/keps/sig-cli/kustomize-file-processing-integration.md
@@ -1,30 +1,29 @@
 ---
 title: Kustomize File Processing Integration
 authors:
- - "@pwittrock"
+  - "@pwittrock"
 owning-sig: sig-cli
 participating-sigs:
- - sig-cli
+  - sig-cli
 reviewers:
- - "@liggitt"
- - "@seans3"
- - "@soltysh"
- - "@monopole"
+  - "@liggitt"
+  - "@seans3"
+  - "@soltysh"
+  - "@monopole"
 approvers:
- - "@liggitt"
- - "@seans3"
- - "@soltysh"
- - "@monopole"
-editors:
- - "@pwittrock"
+  - "@liggitt"
+  - "@seans3"
+  - "@soltysh"
+  - "@monopole"
+editor: "@pwittrock"
 creation-date: 2019-01-17
 last-updated: 2019-03-18
 status: implemented
 see-also:
- - "kustomize-subcommand-integration.md"
+  - "kustomize-subcommand-integration.md"
 replaces:
 superseded-by:
- - n/a
+  - n/a
 ---
 
 # Kustomize File Processing Integration

--- a/keps/sig-cli/kustomize-subcommand-integration.md
+++ b/keps/sig-cli/kustomize-subcommand-integration.md
@@ -1,30 +1,29 @@
 ---
 title: Kustomize Subcommand Integration
 authors:
- - "@Liujingfang1"
+  - "@Liujingfang1"
 owning-sig: sig-cli
 participating-sigs:
- - sig-cli
+  - sig-cli
 reviewers:
- - "@liggitt"
- - "@seans3"
- - "@soltysh"
+  - "@liggitt"
+  - "@seans3"
+  - "@soltysh"
 approvers:
- - "@liggitt"
- - "@seans3"
- - "@soltysh"
-editors:
- - "@pwittrock"
+  - "@liggitt"
+  - "@seans3"
+  - "@soltysh"
+editor: "@pwittrock"
 creation-date: 2018-11-07
 last-updated: 2019-02-15
 status: implemented
 see-also:
- - "[kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/workflows.md)"
- - "kustomize-file-processing-integration.md" 
+  - "[kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/workflows.md)"
+  - "kustomize-file-processing-integration.md"
 replaces:
- - "0008-kustomize.md"
+  - "0008-kustomize.md"
 superseded-by:
- - n/a
+  - n/a
 ---
 
 # Kustomize Subcommand Integration

--- a/keps/sig-cloud-provider/0018-testgrid-conformance-e2e.md
+++ b/keps/sig-cloud-provider/0018-testgrid-conformance-e2e.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 0018
 title: Reporting Conformance Test Results to Testgrid
 authors:
   - "@andrewsykim"
@@ -21,7 +20,6 @@ editor: TBD
 creation-date: 2018-06-06
 last-updated: 2018-11-16
 status: implementable
-
 ---
 
 # Reporting Conformance Test Results to Testgrid

--- a/keps/sig-cloud-provider/20180530-cloud-controller-manager.md
+++ b/keps/sig-cloud-provider/20180530-cloud-controller-manager.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 2
 title: Cloud Controller Manager
 authors:
   - "@cheftako"
@@ -21,6 +20,8 @@ reviewers:
 approvers:
   - "@thockin"
 editor: TBD
+creation-date: 2018-01-09
+last-updated: 2019-06-27
 status: provisional
 replaces:
   - contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md

--- a/keps/sig-cloud-provider/20180530-cloud-controller-manager.md
+++ b/keps/sig-cloud-provider/20180530-cloud-controller-manager.md
@@ -21,7 +21,7 @@ approvers:
   - "@thockin"
 editor: TBD
 creation-date: 2018-01-09
-last-updated: 2019-06-27
+last-updated: 2019-04-10
 status: provisional
 replaces:
   - contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md

--- a/keps/sig-cloud-provider/20190125-out-of-tree-aws.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-aws.md
@@ -13,7 +13,6 @@ editor: TBD
 creation-date: 2019-01-25
 last-updated: 2019-01-25
 status: provisional
-
 ---
 
 # Supporting Out-of-Tree AWS Cloud Provider

--- a/keps/sig-cloud-provider/20190125-out-of-tree-gce.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-gce.md
@@ -13,7 +13,6 @@ editor: TBD
 creation-date: 2019-01-25
 last-updated: 2019-01-25
 status: provisional
-
 ---
 
 # Supporting Out-of-Tree GCE Cloud Provider

--- a/keps/sig-cloud-provider/20190125-out-of-tree-ibm.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-ibm.md
@@ -13,7 +13,6 @@ editor: TBD
 creation-date: 2019-01-25
 last-updated: 2019-01-25
 status: provisional
-
 ---
 
 # Supporting Out-of-Tree IBM Cloud Provider

--- a/keps/sig-cloud-provider/20190125-out-of-tree-openstack.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-openstack.md
@@ -13,7 +13,6 @@ editor: TBD
 creation-date: 2019-01-25
 last-updated: 2019-01-25
 status: provisional
-
 ---
 
 # Supporting Out-of-Tree OpenStack Cloud Provider

--- a/keps/sig-cloud-provider/20190125-out-of-tree-vsphere.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-vsphere.md
@@ -20,7 +20,6 @@ editor: TBD
 creation-date: 2019-01-25
 last-updated: 2019-01-25
 status: implementable
-
 ---
 
 # Supporting Out-of-Tree vSphere Cloud Provider

--- a/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md
+++ b/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 13
 title: Removing In-Tree Cloud Providers
 authors:
   - "@andrewsykim"
@@ -26,8 +25,9 @@ approvers:
   - "@thockin"
   - "@liggit"
 editor: TBD
+creation-date: 2018-12-18
+last-updated: 2019-06-27
 status: implementable
-
 ---
 
 # Removing In-Tree Cloud Provider Code

--- a/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md
+++ b/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md
@@ -26,7 +26,7 @@ approvers:
   - "@liggit"
 editor: TBD
 creation-date: 2018-12-18
-last-updated: 2019-06-27
+last-updated: 2019-04-11
 status: implementable
 ---
 

--- a/keps/sig-cloud-provider/azure/20180711-azure-availability-zones.md
+++ b/keps/sig-cloud-provider/azure/20180711-azure-availability-zones.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 18
 title: Azure Availability Zones
 authors:
   - "@feiskyer"
@@ -12,8 +11,7 @@ reviewers:
   - "@colemickens"
 approvers:
   - "@brendanburns"
-editor:
-  - "@feiskyer"
+editor: "@feiskyer"
 creation-date: 2018-07-11
 last-updated: 2018-09-29
 status: implementable

--- a/keps/sig-cloud-provider/azure/20180809-cross-resource-group-nodes.md
+++ b/keps/sig-cloud-provider/azure/20180809-cross-resource-group-nodes.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 25
 title: Cross resource group nodes
 authors:
   - "@feiskyer"
@@ -11,8 +10,7 @@ reviewers:
   - "@justaugustus"
 approvers:
   - "@brendanburns"
-editor: 
-  - "@feiskyer"
+editor: "@feiskyer"
 creation-date: 2018-08-09
 last-updated: 2018-09-29
 status: implementable

--- a/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
+++ b/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 20
 title: Cloud Provider for Alibaba Cloud
 authors:
   - "@aoxn"
@@ -14,7 +13,6 @@ editor: TBD
 creation-date: 2018-06-20
 last-updated: 2018-06-20
 status: provisional
-
 ---
 
 # Cloud Provider for Alibaba Cloud

--- a/keps/sig-cluster-lifecycle/addons/0035-20190128-addons-via-operators.md
+++ b/keps/sig-cluster-lifecycle/addons/0035-20190128-addons-via-operators.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 35
 title: Addons via Operators
 authors:
   - "@justinsb"

--- a/keps/sig-cluster-lifecycle/clusterapi/0003-cluster-api.md
+++ b/keps/sig-cluster-lifecycle/clusterapi/0003-cluster-api.md
@@ -1,7 +1,5 @@
 ---
-kep-number: 3
 title: Kubernetes Cluster Management API
-status: provisional
 authors:
   - "@roberthbailey"
   - "@pipejakob"
@@ -12,11 +10,10 @@ reviewers:
 approvers:
   - "@justinsb"
   - "@timothysc"
-editor:
-  - "@justinsb"
-  - "@timothysc"
+editor: "@justinsb"
 creation-date: 2018-01-19
 last-updated: 2019-04-04
+status: provisional
 ---
 
 # Kubernetes Cluster Management API

--- a/keps/sig-cluster-lifecycle/etcdadm/0031-20181022-etcdadm.md
+++ b/keps/sig-cluster-lifecycle/etcdadm/0031-20181022-etcdadm.md
@@ -1,11 +1,9 @@
 ---
-kep-number: 31
 title: etcdadm
 authors:
   - "@justinsb"
 owning-sig: sig-cluster-lifecycle
-#participating-sigs:
-#- sig-apimachinery
+participating-sigs:
 reviewers:
   - "@roberthbailey"
   - "@timothysc"
@@ -16,13 +14,9 @@ editor: TBD
 creation-date: 2018-10-22
 last-updated: 2018-10-22
 status: provisional
-#see-also:
-#  - KEP-1
-#  - KEP-2
-#replaces:
-#  - KEP-3
-#superseded-by:
-#  - KEP-100
+see-also:
+replaces:
+superseded-by:
 ---
 
 # etcdadm - automation for etcd clusters

--- a/keps/sig-cluster-lifecycle/kubeadm/0004-bootstrap-checkpointing.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/0004-bootstrap-checkpointing.md
@@ -1,7 +1,5 @@
 ---
-kep-number: 4
 title: Kubernetes Bootstrap Checkpointing Proposal
-status: implemented
 authors:
   - "@timothysc"
 owning-sig: sig-cluster-lifecycle
@@ -17,6 +15,7 @@ approvers:
 editor: "@timothysc"
 creation-date: 2017-10-20
 last-updated: 2018-01-23
+status: implemented
 ---
 
 # Kubernetes Bootstrap Checkpointing Proposal

--- a/keps/sig-cluster-lifecycle/kubeadm/0008-kubeadm-config-versioning.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/0008-kubeadm-config-versioning.md
@@ -1,10 +1,9 @@
 ---
-kep-number: draft-20180412
 title: Kubeadm Config versioning
 authors:
   - "@liztio"
 owning-sig: sig-cluster-lifecycle
-participating-sigs: []
+participating-sigs:
 reviewers:
   - "@timothysc"
 approvers:
@@ -13,9 +12,9 @@ editor: TBD
 creation-date: 2018-04-12
 last-updated: 2018-04-12
 status: draft
-see-also: []
-replaces: []
-superseded-by: []
+see-also:
+replaces:
+superseded-by:
 ---
 
 # Kubeadm Config Versioning

--- a/keps/sig-cluster-lifecycle/kubeadm/0015-kubeadm-join-control-plane.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/0015-kubeadm-join-control-plane.md
@@ -4,9 +4,7 @@
 
 ```yaml
 ---
-kep-number: 15
-title: kubeadm join --control-plane workflow
-status: accepted
+title: "kubeadm join --control-plane workflow"
 authors:
   - "@fabriziopandini"
 owning-sig: sig-cluster-lifecycle
@@ -17,10 +15,10 @@ reviewers:
 approvers:
   - "@luxas"
   - "@timothysc"
-editor:
-  - "@fabriziopandini"
+editor: "@fabriziopandini"
 creation-date: 2018-01-28
 last-updated: 2019-04-18
+status: accepted
 see-also:
   - KEP 0004
 ---

--- a/keps/sig-cluster-lifecycle/kubeadm/0023-kubeadm-config.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/0023-kubeadm-config.md
@@ -1,28 +1,24 @@
 ---
-kep-number: 23
 title: Kubeadm config file graduation (v1beta2)
 authors:
   - "@fabriziopandini"
   - "@luxas"
 owning-sig: sig-cluster-lifecycle
 reviewers:
- - "@chuckha"
- - "@detiber"
- - "@liztio"
+  - "@chuckha"
+  - "@detiber"
+  - "@liztio"
 approvers:
- - "@luxas"
- - "@timothysc"
- - "@fabriziopandini"
- - "@neolit123"
-editor:
- - "@fabriziopandini"
- - "@rosti"
- - "@neolit123"
+  - "@luxas"
+  - "@timothysc"
+  - "@fabriziopandini"
+  - "@neolit123"
+editor: "@fabriziopandini"
 creation-date: 2018-08-01
 last-updated: 2019-04-29
 status: implementable
 see-also:
- - KEP 0008
+  - KEP 0008
 ---
 
 # kubeadm Config file graduation (v1beta2)

--- a/keps/sig-cluster-lifecycle/kubeadm/0029-20180918-kubeadm-phases-beta.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/0029-20180918-kubeadm-phases-beta.md
@@ -1,24 +1,22 @@
 ---
-kep-number: 29
 title: kubeadm phases to beta
 authors:
   - "@fabriziopandini"
 owning-sig: sig-cluster-lifecycle
 reviewers:
- - "@chuckha"
- - "@detiber"
- - "@liztio"
- - "@neolit123"
+  - "@chuckha"
+  - "@detiber"
+  - "@liztio"
+  - "@neolit123"
 approvers:
- - "@luxas"
- - "@timothysc"
-editor:
- - "@fabriziopandini"
+  - "@luxas"
+  - "@timothysc"
+editor: "@fabriziopandini"
 creation-date: 2018-03-16
 last-updated: 2019-01-22
 status: provisional
 see-also:
- - KEP 0008
+  - KEP 0008
 ---
 
 # kubeadm phases to beta

--- a/keps/sig-cluster-lifecycle/kubeadm/20190122-Certificates-copy-for-kubeadm-join--control-plane.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/20190122-Certificates-copy-for-kubeadm-join--control-plane.md
@@ -1,10 +1,9 @@
 ---
-title: Certificates copy for join --control-plane
+title: "Certificates copy for join --control-plane"
 authors:
   - "@fabriziopandini"
 owning-sig: sig-clusterlifecycle
 participating-sigs:
-  -
 reviewers:
   - "@neolit123"
   - "@detiber"
@@ -21,9 +20,7 @@ status: implementable
 see-also:
   - KEP-0015
 replaces:
-  -
 superseded-by:
-  -
 ---
 
 # Certificates copy for join --control-plane

--- a/keps/sig-cluster-lifecycle/kubeadm/20190227-artifact-generation.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/20190227-artifact-generation.md
@@ -16,7 +16,7 @@ approvers:
   - "@timothysc"
 editor: "@Klaven"
 creation-date: 2019-02-15
-last-updated: yyyy-mm-dd
+last-updated: 2019-06-27
 status: implementable
 see-also:
   - "https://github.com/kubernetes/enhancements/pull/843"

--- a/keps/sig-cluster-lifecycle/kubeadm/20190227-artifact-generation.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/20190227-artifact-generation.md
@@ -16,7 +16,7 @@ approvers:
   - "@timothysc"
 editor: "@Klaven"
 creation-date: 2019-02-15
-last-updated: 2019-06-27
+last-updated: 2019-02-27
 status: implementable
 see-also:
   - "https://github.com/kubernetes/enhancements/pull/843"

--- a/keps/sig-cluster-lifecycle/kubeadm/20190424-kubeadm-for-windows.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/20190424-kubeadm-for-windows.md
@@ -5,7 +5,7 @@ authors:
   - "@neolit123"
   - "@patricklang"
 owning-sig: sig-windows
-Participating-sigs:
+participating-sigs:
   - sig-windows
   - sig-cluster-lifecycle
 reviewers:

--- a/keps/sig-cluster-lifecycle/wgs/0014-20180707-componentconfig-api-types-to-staging.md
+++ b/keps/sig-cluster-lifecycle/wgs/0014-20180707-componentconfig-api-types-to-staging.md
@@ -1,7 +1,5 @@
 ---
-kep-number: 17
 title: Moving ComponentConfig API types to staging repos
-status: implementable
 authors:
   - "@luxas"
   - "@sttts"
@@ -25,6 +23,7 @@ approvers:
 editor: "@luxas"
 creation-date: 2018-07-07
 last-updated: 2018-08-10
+status: implementable
 ---
 
 # Moving ComponentConfig API types to staging repos

--- a/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md
+++ b/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md
@@ -1,6 +1,5 @@
 ---
 title: Create a `k8s.io/component-base` repo
-status: implementable
 authors:
   - "@luxas"
   - "@sttts"
@@ -25,6 +24,7 @@ approvers:
 editor: "@luxas"
 creation-date: 2018-11-27
 last-updated: 2018-12-10
+status: implementable
 ---
 
 # Create a `k8s.io/component-base` repo

--- a/keps/sig-contributor-experience/0005-contributor-site.md
+++ b/keps/sig-contributor-experience/0005-contributor-site.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 5
 title: Contributor Site
 authors:
   - "@jbeda"

--- a/keps/sig-contributor-experience/0007-20180403-community-forum.md
+++ b/keps/sig-contributor-experience/0007-20180403-community-forum.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 0007
 title: A community forum for Kubernetes
 authors:
   - "@castrojo"
@@ -12,7 +11,6 @@ reviewers:
 approvers:
   - "@parispittman"
   - "@grodrigues3"
-  
 editor: TBD
 creation-date: 2018-04-03
 last-updated: 2018-04-17

--- a/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
+++ b/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
@@ -10,9 +10,7 @@ reviewers:
 approvers:
   - "@piosz"
   - "@DirectXMan12"
-editors:
-  - "@DirectXMan12"
-  - "@danielqsj"
+editor: "@DirectXMan12"
 creation-date: 2018-11-06
 last-updated: 2019-03-21
 status: implementable

--- a/keps/sig-instrumentation/20190131-event-series.md
+++ b/keps/sig-instrumentation/20190131-event-series.md
@@ -14,8 +14,8 @@ approvers:
   - "@wojtekt"
   - "@bgrant0607"
 editor: TBD
-creation-date: 2019-01-10
-last-updated: 2019-06-27
+creation-date: 2019-01-31
+last-updated: 2019-01-31
 status: implementable
 see-also:
   - n/a

--- a/keps/sig-instrumentation/20190131-event-series.md
+++ b/keps/sig-instrumentation/20190131-event-series.md
@@ -14,8 +14,8 @@ approvers:
   - "@wojtekt"
   - "@bgrant0607"
 editor: TBD
-creation-date: 2019-1-31
-last-updated: 2019-1-31
+creation-date: 2019-01-10
+last-updated: 2019-06-27
 status: implementable
 see-also:
   - n/a

--- a/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
+++ b/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
@@ -2,8 +2,7 @@
 title: Kubernetes Control-Plane Metrics Stability
 authors:
   - "@logicalhan"
-owning-sig:
-  - sig-instrumentation
+owning-sig: sig-instrumentation
 participating-sigs:
   - sig-instrumentation
   - sig-api-machinery
@@ -19,13 +18,12 @@ reviewers:
 approvers:
   - "@brancz"
   - "@x13n"
-editor:
-  - "@brancz"
-  - "@x13n"
+editor: "@brancz"
 creation-date: 2019-04-04
+last-updated: 2019-07-02
+status: implementable
 see-also:
   - 20181106-kubernetes-metrics-overhaul
-status: implementable
 ---
 
 # Kubernetes Control-Plane Metrics Stability

--- a/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
+++ b/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
@@ -20,7 +20,7 @@ approvers:
   - "@x13n"
 editor: "@brancz"
 creation-date: 2019-04-04
-last-updated: 2019-07-02
+last-updated: 2019-06-05
 status: implementable
 see-also:
   - 20181106-kubernetes-metrics-overhaul

--- a/keps/sig-instrumentation/20190425-metrics-watch-api.md
+++ b/keps/sig-instrumentation/20190425-metrics-watch-api.md
@@ -14,9 +14,9 @@ editor: TBD
 creation-date: 2019-04-25
 last-updated: 2019-04-29
 status: provisional
-see-also: []
-replaces: []
-superseded-by: []
+see-also:
+replaces:
+superseded-by:
 ---
 
 # Metrics API watch support

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -3,8 +3,7 @@ title: Metrics Stability Migration
 authors:
   - "@logicalhan"
   - "@solodov"
-owning-sig:
-  - sig-instrumentation
+owning-sig: sig-instrumentation
 participating-sigs:
   - sig-scheduling
   - sig-node
@@ -21,10 +20,11 @@ reviewers:
 approvers:
   - "@brancz"
 creation-date: 2019-06-05
+last-updated: 2019-07-02
+status: implementable
 see-also:
   - 20181106-kubernetes-metrics-overhaul
   - 20190404-kubernetes-control-plane-metrics-stability
-status: implementable
 ---
 
 # Metrics Stability Migration

--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -20,7 +20,7 @@ reviewers:
 approvers:
   - "@brancz"
 creation-date: 2019-06-05
-last-updated: 2019-07-02
+last-updated: 2019-06-27
 status: implementable
 see-also:
   - 20181106-kubernetes-metrics-overhaul

--- a/keps/sig-network/0007-pod-ready++.md
+++ b/keps/sig-network/0007-pod-ready++.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 1
 title: Pod Ready++
 authors:
   - "freehan@"
@@ -13,11 +12,10 @@ reviewers:
 approvers:
   - thockin@
   - dchen1107@
-editor: freehan@
+editor: "freehan@"
 creation-date: 2018-04-01
 last-updated: 2018-04-01
 status: provisional
-
 ---
 
 # Pod Ready++

--- a/keps/sig-network/0010-20180314-coredns-GA-proposal.md
+++ b/keps/sig-network/0010-20180314-coredns-GA-proposal.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 10
 title: Graduate CoreDNS to GA
 authors:
   - "@johnbelamaric"
@@ -16,9 +15,10 @@ editor: "@rajansandeep"
 creation-date: 2018-03-21
 last-updated: 2018-05-18
 status: provisional
-see-also: https://github.com/kubernetes/community/pull/2167
+see-also:
+  - "https://github.com/kubernetes/community/pull/2167"
 ---
- 
+
 # Graduate CoreDNS to GA
 
 ## Table of Contents

--- a/keps/sig-network/0011-ipvs-proxier.md
+++ b/keps/sig-network/0011-ipvs-proxier.md
@@ -1,9 +1,7 @@
 ---
-kep-number: TBD
 title: IPVS Load Balancing Mode in Kubernetes
-status: implemented
 authors:
-    - "@rramkumar1"
+  - "@rramkumar1"
 owning-sig: sig-network
 reviewers:
   - "@thockin"
@@ -11,10 +9,10 @@ reviewers:
 approvers:
   - "@thockin"
   - "@m1093782566"
-editor:
-  - "@thockin"
-  - "@m1093782566"
+editor: "@thockin"
 creation-date: 2018-03-21
+last-updated: 2019-06-27
+status: implemented
 ---
 
 # IPVS Load Balancing Mode in Kubernetes

--- a/keps/sig-network/0012-20180518-coredns-default-proposal.md
+++ b/keps/sig-network/0012-20180518-coredns-default-proposal.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 11
 title: Switch CoreDNS to the default DNS
 authors:
   - "@johnbelamaric"

--- a/keps/sig-network/0015-20180614-SCTP-support.md
+++ b/keps/sig-network/0015-20180614-SCTP-support.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 15
 title: SCTP support
 authors:
   - "@janosi"
@@ -10,8 +9,7 @@ reviewers:
   - "@thockin"
 approvers:
   - "@thockin"
-editor: 
-  - "@janosi"
+editor: "@janosi"
 creation-date: 2018-06-14
 last-updated: 2018-09-14
 status: implemented

--- a/keps/sig-network/0030-nodelocal-dns-cache.md
+++ b/keps/sig-network/0030-nodelocal-dns-cache.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 30
 title: NodeLocal DNS Cache
 authors:
   - "@prameshj"

--- a/keps/sig-network/0031-20181017-kube-proxy-services-optional.md
+++ b/keps/sig-network/0031-20181017-kube-proxy-services-optional.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 31
 title: Make kube-proxy service abstraction optional
 authors:
   - "@bradhoekstra"

--- a/keps/sig-network/0033-service-topology.md
+++ b/keps/sig-network/0033-service-topology.md
@@ -1,9 +1,7 @@
 ---
-kep-number: 33
 title: Topology-aware service routing
-status: implementable
 authors:
-    - "@m1093782566"
+  - "@m1093782566"
 owning-sig: sig-network
 reviewers:
   - "@thockin"
@@ -12,6 +10,7 @@ approvers:
   - "@thockin"
 creation-date: 2018-10-24
 last-updated: 2018-12-03
+status: implementable
 ---
 
 # Topology-aware service routing

--- a/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
+++ b/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
@@ -17,7 +17,6 @@ editor: TBD
 creation-date: 2018-05-21
 last-updated: 2019-05-02
 status: implementable
-
 ---
 
 # IPv4/IPv6 Dual Stack

--- a/keps/sig-node/0008-20180430-promote-sysctl-annotations-to-fields.md
+++ b/keps/sig-node/0008-20180430-promote-sysctl-annotations-to-fields.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 8
 title: Protomote sysctl annotations to fields
 authors:
   - "@ingvagabund"

--- a/keps/sig-node/0009-node-heartbeat.md
+++ b/keps/sig-node/0009-node-heartbeat.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 8
 title: Efficient Node Heartbeat
 authors:
   - "@wojtek-t"
@@ -20,8 +19,8 @@ creation-date: 2018-04-27
 last-updated: 2018-04-27
 status: implementable
 see-also:
-  - https://github.com/kubernetes/kubernetes/issues/14733
-  - https://github.com/kubernetes/kubernetes/pull/14735
+  - "https://github.com/kubernetes/kubernetes/issues/14733"
+  - "https://github.com/kubernetes/kubernetes/pull/14735"
 replaces:
   - n/a
 superseded-by:

--- a/keps/sig-node/0035-20190130-topology-manager.md
+++ b/keps/sig-node/0035-20190130-topology-manager.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 35
 title: Node Topology Manager
 authors:
   - "@ConnorDoyle"
@@ -20,8 +19,8 @@ editor: Louise Daly
 creation-date: 2019-01-30
 last-updated: 2019-01-30
 status: implementable
-see-also: 
-replaces: 
+see-also:
+replaces:
 superseded-by:
 ---
 

--- a/keps/sig-node/20180906-quotas-for-ephemeral-storage.md
+++ b/keps/sig-node/20180906-quotas-for-ephemeral-storage.md
@@ -1,10 +1,8 @@
 ---
-kep-number: 0
 title: Quotas for Ephemeral Storage
 authors:
   - "@RobertKrawitz"
-owning-sig:
-  - sig-node
+owning-sig: sig-node
 participating-sigs:
   - sig-node
 reviewers:

--- a/keps/sig-node/20190129-hugepages.md
+++ b/keps/sig-node/20190129-hugepages.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 34
 title: HugePages
 authors:
   - "@derekwaynecarr"
@@ -11,13 +10,13 @@ participating-sigs:
 reviewers:
   - "@vishnu"
 approvers:
-  - "@dawnchen" 
+  - "@dawnchen"
 editor: Derek Carr
 creation-date: 2019-01-29
 last-updated: 2019-03-05
 status: implemented
-see-also: 
-replaces: 
+see-also:
+replaces:
 superseded-by:
 ---
 

--- a/keps/sig-node/20190129-pid-limiting.md
+++ b/keps/sig-node/20190129-pid-limiting.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 34
 title: Pid Limiting
 authors:
   - "@derekwaynecarr"
@@ -10,13 +9,13 @@ reviewers:
   - "@dashpole"
 approvers:
   - "@dashpole"
-  - "@dchen1107" 
+  - "@dchen1107"
 editor: Derek Carr
 creation-date: 2019-01-29
-last-updated: 2019-03-5
+last-updated: 2019-06-27
 status: implemented
-see-also: 
-replaces: 
+see-also:
+replaces:
 superseded-by:
 ---
 

--- a/keps/sig-node/20190129-pid-limiting.md
+++ b/keps/sig-node/20190129-pid-limiting.md
@@ -12,7 +12,7 @@ approvers:
   - "@dchen1107"
 editor: Derek Carr
 creation-date: 2019-01-29
-last-updated: 2019-06-27
+last-updated: 2019-03-05
 status: implemented
 see-also:
 replaces:

--- a/keps/sig-node/20190130-node-os-arch-labels.md
+++ b/keps/sig-node/20190130-node-os-arch-labels.md
@@ -1,5 +1,5 @@
 ---
-title: 
+title: TBD
 authors:
   - "@yujuhong"
 owning-sig: sig-node

--- a/keps/sig-node/compute-device-assignment.md
+++ b/keps/sig-node/compute-device-assignment.md
@@ -1,7 +1,7 @@
 ---
-title: Kubelet endpoint for device assignment observation details 
+title: Kubelet endpoint for device assignment observation details
 authors:
-  - "@dashpole" 
+  - "@dashpole"
   - "@vikaschoudhary16"
 owning-sig: sig-node
 reviewers:
@@ -11,9 +11,7 @@ reviewers:
   - "@vishh"
 approvers:
   - "@sig-node-leads"
-editors:
-  - "@dashpole"
-  - "@vikaschoudhary16"
+editor: "@dashpole"
 creation-date: "2018-07-19"
 last-updated: "2019-04-30"
 status: implementable

--- a/keps/sig-node/kubelet-resource-metrics-endpoint.md
+++ b/keps/sig-node/kubelet-resource-metrics-endpoint.md
@@ -12,7 +12,7 @@ approvers:
   - dchen1107
   - brancz
 creation-date: 2019-01-24
-last-updated: 2019-06-27
+last-updated: 2019-02-21
 status: implementable
 ---
 

--- a/keps/sig-node/kubelet-resource-metrics-endpoint.md
+++ b/keps/sig-node/kubelet-resource-metrics-endpoint.md
@@ -12,6 +12,7 @@ approvers:
   - dchen1107
   - brancz
 creation-date: 2019-01-24
+last-updated: 2019-06-27
 status: implementable
 ---
 

--- a/keps/sig-node/runtime-class-scheduling.md
+++ b/keps/sig-node/runtime-class-scheduling.md
@@ -13,7 +13,7 @@ approvers:
   - dchen1107
   - derekwaynecarr
 creation-date: 2019-03-14
-last-updated: 2019-07-02
+last-updated: 2019-05-20
 status: implementable
 see-also:
   - "/keps/sig-node/runtime-class.md"

--- a/keps/sig-node/runtime-class-scheduling.md
+++ b/keps/sig-node/runtime-class-scheduling.md
@@ -13,6 +13,7 @@ approvers:
   - dchen1107
   - derekwaynecarr
 creation-date: 2019-03-14
+last-updated: 2019-07-02
 status: implementable
 see-also:
   - "/keps/sig-node/runtime-class.md"

--- a/keps/sig-node/runtime-class.md
+++ b/keps/sig-node/runtime-class.md
@@ -13,7 +13,7 @@ approvers:
   - dchen1107
   - derekwaynecarr
 creation-date: 2018-06-19
-last-updated: 2019-06-27
+last-updated: 2019-01-24
 status: implementable
 ---
 

--- a/keps/sig-node/runtime-class.md
+++ b/keps/sig-node/runtime-class.md
@@ -13,6 +13,7 @@ approvers:
   - dchen1107
   - derekwaynecarr
 creation-date: 2018-06-19
+last-updated: 2019-06-27
 status: implementable
 ---
 

--- a/keps/sig-release/20190219-publishing-packages.md
+++ b/keps/sig-release/20190219-publishing-packages.md
@@ -20,7 +20,7 @@ creation-date: 2019-02-19
 last-updated: 2019-02-27
 status: provisional
 see-also:
-  - https://github.com/kubernetes/enhancements/pull/858
+  - "https://github.com/kubernetes/enhancements/pull/858"
   - "/keps/sig-release/20190121-artifact-management.md"
   - "/keps/sig-release/k8s-image-promoter.md"
 ---

--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -1,26 +1,24 @@
 ---
-kep-number: 34
 title: Scheduling Framework
 authors:
-  - '@bsalamat'
-  - '@misterikkit'
+  - "@bsalamat"
+  - "@misterikkit"
 owning-sig: sig-scheduling
-participating-sigs: []
+participating-sigs:
 reviewers:
-  - '@huang-wei'
-  - '@k82cn'
-  - '@ravisantoshgudimetla'
+  - "@huang-wei"
+  - "@k82cn"
+  - "@ravisantoshgudimetla"
 approvers:
-  - '@k82cn'
+  - "@k82cn"
 editor: TBD
 creation-date: 2018-04-09
 last-updated: 2019-04-30
 status: implementable
-see-also: []
+see-also:
 replaces:
-  - >-
-    https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduling-framework.md
-superseded-by: []
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduling-framework.md"
+superseded-by:
 ---
 # Scheduling Framework
 

--- a/keps/sig-scheduling/20190311-resource_bin_packing_priority_function.md
+++ b/keps/sig-scheduling/20190311-resource_bin_packing_priority_function.md
@@ -1,6 +1,5 @@
 ---
-title: Extending RequestedToCapacityRatio Priority Function to support Resource Bin Packing of Extended Resources
-  - "@sudeshsh"
+title: "Extending RequestedToCapacityRatio Priority Function to support Resource Bin Packing of Extended Resources - @sudeshsh"
 owning-sig: sig-scheduling
 participating-sigs:
   - sig-scheduling

--- a/keps/sig-scheduling/20190409-resource-quota-ga.md
+++ b/keps/sig-scheduling/20190409-resource-quota-ga.md
@@ -20,7 +20,6 @@ creation-date: 2019-04-23
 last-updated: 2019-04-23
 status: implementable
 see-also:
-  - 
 replaces:
 superseded-by:
 ---

--- a/keps/sig-scheduling/34-20180703-coscheduling.md
+++ b/keps/sig-scheduling/34-20180703-coscheduling.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 34
 title: Coscheduling
 authors:
   - "@k82cn"
@@ -12,7 +11,7 @@ reviewers:
 approvers:
   - "@bsalamat"
 creation-date: 2018-07-03
-last-updated: 2019-1-3
+last-updated: 2019-06-27
 status: provisional
 ---
 

--- a/keps/sig-scheduling/34-20180703-coscheduling.md
+++ b/keps/sig-scheduling/34-20180703-coscheduling.md
@@ -11,7 +11,7 @@ reviewers:
 approvers:
   - "@bsalamat"
 creation-date: 2018-07-03
-last-updated: 2019-06-27
+last-updated: 2019-01-03
 status: provisional
 ---
 

--- a/keps/sig-scheduling/node-labels-quota.md
+++ b/keps/sig-scheduling/node-labels-quota.md
@@ -13,7 +13,7 @@ approvers:
   - TBD
 editor: TBD
 creation-date: 2018-08-23
-last-updated: 2019-06-27
+last-updated: 2018-08-30
 status: provisional
 ---
 

--- a/keps/sig-scheduling/node-labels-quota.md
+++ b/keps/sig-scheduling/node-labels-quota.md
@@ -1,11 +1,11 @@
 ---
-kep-number: 27
 title: Resource Quota based on Node Labels
 authors:
   - "@vishh"
   - "@bsalamat"
 owning-sig: sig-scheduling
-participating-sigs: sig-architecture
+participating-sigs:
+  - sig-architecture
 reviewers:
   - "@derekwaynecarr"
   - "@davidopp"
@@ -13,6 +13,7 @@ approvers:
   - TBD
 editor: TBD
 creation-date: 2018-08-23
+last-updated: 2019-06-27
 status: provisional
 ---
 

--- a/keps/sig-storage/20190120-execution-hook-design.md
+++ b/keps/sig-storage/20190120-execution-hook-design.md
@@ -18,8 +18,8 @@ approvers:
   - "@saad-ali"
   - "@liyinan926"
 editor: TBD
-creation-date: 2019-01-16
-last-updated: 2019-06-27
+creation-date: 2019-01-20
+last-updated: 2019-04-25
 status: implementable
 see-also:
   - n/a

--- a/keps/sig-storage/20190120-execution-hook-design.md
+++ b/keps/sig-storage/20190120-execution-hook-design.md
@@ -1,5 +1,5 @@
 ---
-title: ExecutionHook 
+title: ExecutionHook
 authors:
   - "@jingxu97"
   - "@xing-yang"
@@ -18,8 +18,8 @@ approvers:
   - "@saad-ali"
   - "@liyinan926"
 editor: TBD
-creation-date: 2019-1-20
-last-updated: 2019-4-25
+creation-date: 2019-01-16
+last-updated: 2019-06-27
 status: implementable
 see-also:
   - n/a

--- a/keps/sig-storage/20190122-csi-inline-volumes.md
+++ b/keps/sig-storage/20190122-csi-inline-volumes.md
@@ -13,7 +13,7 @@ approvers:
   - "@thockin"
   - "@saad-ali"
 creation-date: 2019-01-22
-last-updated: 2019-06-27
+last-updated: 2019-01-30
 status: implementable
 ---
 

--- a/keps/sig-storage/20190122-csi-inline-volumes.md
+++ b/keps/sig-storage/20190122-csi-inline-volumes.md
@@ -13,6 +13,7 @@ approvers:
   - "@thockin"
   - "@saad-ali"
 creation-date: 2019-01-22
+last-updated: 2019-06-27
 status: implementable
 ---
 

--- a/keps/sig-storage/20190124-local-persistent-volumes.md
+++ b/keps/sig-storage/20190124-local-persistent-volumes.md
@@ -19,9 +19,9 @@ creation-date: 2019-01-24
 last-updated: 2019-01-24
 status: implementable
 see-also:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/volume-topology-scheduling.md
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/volume-topology-scheduling.md"
 replaces:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/local-storage-pv.md
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/local-storage-pv.md"
 superseded-by:
 ---
 

--- a/keps/sig-storage/20190125-online-growing-persistent-volume-size.md
+++ b/keps/sig-storage/20190125-online-growing-persistent-volume-size.md
@@ -16,8 +16,8 @@ creation-date: 2019-01-25
 last-updated: 2019-02-01
 status: implementable
 see-also:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/grow-volume-size.md
-  - https://github.com/kubernetes/community/pull/1535
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/grow-volume-size.md"
+  - "https://github.com/kubernetes/community/pull/1535"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-storage/20190129-csi-migration.md
+++ b/keps/sig-storage/20190129-csi-migration.md
@@ -17,7 +17,7 @@ creation-date: 2019-01-29
 last-updated: 2019-01-29
 status: implementable
 see-also:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
 ---
 
 # In-tree Storage Plugin to CSI Migration Design Doc

--- a/keps/sig-storage/20190129-csi-pod-info-on-mount.md
+++ b/keps/sig-storage/20190129-csi-pod-info-on-mount.md
@@ -15,7 +15,7 @@ creation-date: 2019-01-29
 last-updated: 2019-01-29
 status: implementable
 see-also:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-pod-information.md
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-pod-information.md"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-storage/20190129-csi-skip-attach.md
+++ b/keps/sig-storage/20190129-csi-skip-attach.md
@@ -15,7 +15,7 @@ creation-date: 2019-01-29
 last-updated: 2019-01-29
 status: implementable
 see-also:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-skip-attach.md
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-skip-attach.md"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-storage/20190129-csi-volume-resizing.md
+++ b/keps/sig-storage/20190129-csi-volume-resizing.md
@@ -1,22 +1,22 @@
 ---
 title: Support for CSI volume resizing
 authors:
-  - "@gnufied
+  - "@gnufied"
 owning-sig: sig-storage
 participating-sigs:
   - sig-storage
 reviewers:
-  - @saad-ali
-  - @jsafrane
+  - "@saad-ali"
+  - "@jsafrane"
 approvers:
-  - @saad-ali
-  - @childsb
+  - "@saad-ali"
+  - "@childsb"
 creation-date: 2019-01-29
 last-updated: 2019-01-29
 status: implementable
 see-also:
-    - [Kubernetes Volume expansion](https://github.com/kubernetes/enhancements/issues/284)
-    - [Online resizing design](https://github.com/kubernetes/enhancements/pull/737)
+  - "[Kubernetes Volume expansion](https://github.com/kubernetes/enhancements/issues/284)"
+  - "[Online resizing design](https://github.com/kubernetes/enhancements/pull/737)"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-storage/20190130-csi-raw-block-support.md
+++ b/keps/sig-storage/20190130-csi-raw-block-support.md
@@ -13,9 +13,9 @@ approvers:
 editor: TBD
 creation-date: 2019-01-30
 last-updated: 2019-02-01
-see-also:
-  - https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md
 status: implementable
+see-also:
+  - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md"
 ---
 
 # CSI Raw Block Volumes

--- a/keps/sig-storage/20190204-scale-testing.md
+++ b/keps/sig-storage/20190204-scale-testing.md
@@ -17,8 +17,8 @@ creation-date: 2019-02-04
 last-updated: 2019-03-01
 status: implementable
 see-also:
-- https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md
-- https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/docs/design.md
+  - "https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md"
+  - "https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/docs/design.md"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-storage/20190408-volume-scheduling-limits.md
+++ b/keps/sig-storage/20190408-volume-scheduling-limits.md
@@ -19,8 +19,8 @@ creation-date: 2019-04-08
 last-updated: 2019-04-08
 status: implementable
 see-also:
- - https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190129-csi-migration.md
-replaces: https://github.com/kubernetes/enhancements/pull/730
+  - "https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190129-csi-migration.md"
+replaces:
 superseded-by:
 ---
 

--- a/keps/sig-testing/0028-20180625-new-label-for-trusted-pr-identification.md
+++ b/keps/sig-testing/0028-20180625-new-label-for-trusted-pr-identification.md
@@ -1,5 +1,4 @@
 ---
-kep-number: 28
 title: New label for trusted PR identification
 authors:
   - "@matthyx"

--- a/vendor/github.com/chuckha/kepview/cmd/kepval/main.go
+++ b/vendor/github.com/chuckha/kepview/cmd/kepval/main.go
@@ -42,6 +42,7 @@ func main() {
 		if kep.Error == nil {
 			continue
 		}
+
 		fmt.Printf("%v has an error: %q\n", filename, kep.Error.Error())
 		exit = 1
 	}

--- a/vendor/github.com/chuckha/kepview/keps/proposals.go
+++ b/vendor/github.com/chuckha/kepview/keps/proposals.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"io"
 	"strings"
-	"time"
 
 	"github.com/chuckha/kepview/keps/validations"
 	"github.com/pkg/errors"
@@ -34,19 +33,19 @@ func (p *Proposals) AddProposal(proposal *Proposal) {
 }
 
 type Proposal struct {
-	Title             string    `yaml:"title"`
-	Authors           []string  `yaml:,flow`
-	OwningSIG         string    `yaml:"owning-sig"`
-	ParticipatingSIGs []string  `yaml:"participating-sigs",flow`
-	Reviewers         []string  `yaml:,flow`
-	Approvers         []string  `yaml:,flow`
-	Editor            string    `yaml:"editor"`
-	CreationDate      time.Time `yaml:"creation-date"`
-	LastUpdated       time.Time `yaml:"last-updated"`
-	Status            string    `yaml:"status"`
-	SeeAlso           []string  `yaml:"see-also"`
-	Replaces          []string  `yaml:"replaces"`
-	SupersededBy      []string  `yaml:"superseded-by"`
+	Title             string   `yaml:"title"`
+	Authors           []string `yaml:,flow`
+	OwningSIG         string   `yaml:"owning-sig"`
+	ParticipatingSIGs []string `yaml:"participating-sigs",flow,omitempty`
+	Reviewers         []string `yaml:,flow`
+	Approvers         []string `yaml:,flow`
+	Editor            string   `yaml:"editor,omitempty"`
+	CreationDate      string   `yaml:"creation-date"`
+	LastUpdated       string   `yaml:"last-updated"`
+	Status            string   `yaml:"status"`
+	SeeAlso           []string `yaml:"see-also,omitempty"`
+	Replaces          []string `yaml:"replaces,omitempty"`
+	SupersededBy      []string `yaml:"superseded-by,omitempty"`
 
 	Filename string `yaml:"-"`
 	Error    error  `yaml:"-"`
@@ -64,11 +63,12 @@ func (p *Parser) Parse(in io.Reader) *Proposal {
 			count++
 			continue
 		}
+		if count == 1 {
+			metadata = append(metadata, []byte(line)...)
+		}
 		if count == 2 {
 			break
 		}
-		metadata = append(metadata, []byte(line)...)
-
 	}
 	proposal := &Proposal{}
 	if err := scanner.Err(); err != nil {


### PR DESCRIPTION
Signed-off-by: chuckha <ha.chuck@gmail.com>

There are no more YAML validation errors!

This is broken into two commits, one is a cleanup and one is enabling/updating the kepval metadata check in `verify.sh` so that all incoming PRs must have valid metadata.

Some decisions I made:

* kep-number is obsolete and removed
* If last updated or creation date was missing/invalid I used git to find the date it was added to the repository or the last time it was touched in a commit.
* I kept the diffs as minimal as possible. As in, I didn't add all fields of metadata to every KEP. I also did not remove empty optional fields. I tried to keep each KEP as close to what the author intended as possible.
* There were several instances of multiple editors. I simply took the first in the list and used that to populate the editor field.
* There are a lot of whitespace errors I did not fix.
* Fields were rearranged to match the template, luckily people generally had that order anyway.

This effort was 90% automated (but I don't dare anyone to look at the code found in kepfix in the kepview repo) and 10% done by hand (using `git add -p`)