### PR TITLE
Modify GetTopologyHints() for per-resource hints in the TopologyManager

### DIFF
--- a/keps/sig-node/0035-20190130-topology-manager.md
+++ b/keps/sig-node/0035-20190130-topology-manager.md
@@ -251,9 +251,11 @@ type TopologyHint struct {
 // topology-related resource assignments. The Topology Manager consults each
 // hint provider at pod admission time.
 type HintProvider interface {
-  // Returns hints if this hint provider has a preference; otherwise
-  // returns `nil` to indicate "don't care".
-  GetTopologyHints(pod v1.Pod, containerName string) []TopologyHint
+  // Returns hints if this hint provider has a preference for any of the
+  // resource types that it governs; otherwise returns `nil` to indicate "don't
+  // care". Hints for different resource types are indexed by their name in the
+  // returned map.
+  GetTopologyHints(pod v1.Pod, containerName string) map[string][]TopologyHint
 }
 
 // Store manages state related to the Topology Manager.


### PR DESCRIPTION
At present, there is no way for a hint provider to return distinct hints
for different resource types via a call to `GetTopologyHints()`. This
means that hint providers that govern multiple resource types (e.g. the
devicemanager) must do some sort of "pre-merge" on the hints it
generates for each resource type before passing them back to the
`TopologyManager`.

This seems counter-intuitive, since there is no practical reason that a
"pre-merge" should be necessary -- it just happens to be necessary
because of the way the current interface is designed.

It would be better to allow a hint provider to pass back raw hints for
each resource type, and allow the `TopologyManager` to merge them using
a single unified strategy.

This patch makes a simple change to the `GetTopologyHints()` interface
to allow this to occur.

Moreover, this change allows the `TopologyManager` to recognize which
resource type a set of hints originated from, should this information
become useful in the future.