### PR TITLE
Graduate IPv6 support to beta

### DIFF
--- a/keps/sig-network/20190714-IPv6-beta-proposal.md
+++ b/keps/sig-network/20190714-IPv6-beta-proposal.md
@@ -1,0 +1,94 @@
+---
+title: graduate-ipv6-to-beta
+authors:
+  - "@aojea"
+owning-sig: sig-network
+participating-sigs:
+reviewers:
+  - "@bentheelder"
+  - "@andrewsykim"
+  - "@khenidak"
+approvers:
+  - "@lachie83"
+  - "@thockin"
+editor: TBD
+creation-date: 2019-07-14
+last-updated: 2019-07-23
+status: implementable
+see-also:
+replaces:
+superseded-by:
+---
+
+# Graduate IPv6 to beta
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [User Stories](#user-stories)
+- [Proposal](#proposal)
+- [Design](#design)
+  - [Test Plan](#test-plan)
+    - [Needed Tests](#needed-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+<!-- /toc -->
+
+## Summary
+
+Support for IPv6-only clusters was added in Kubernetes 1.9 as an alpha feature, with version 1.13 the Kubernetes default DNS server changed to CoreDNS which has full IPv6 support, there are several CNI plugins with IPv6 support and Dual Stack support is being implemented during the 1.16 cycle.
+
+
+## Motivation
+
+IPv6 adoption is ramping up with the advances in IoT space and explosion in number of mobile devices, this adoption will continue to grow as we can observe at the Google IPv6 adoption statistics https://www.google.com/intl/en/ipv6/statistics.html.
+
+There are cloud providers that are starting to support IPv6 clusters, the dual stack implementation will facilitate the migration from IPv4 to IPv6 and CI testing was implemented using the kind project.
+
+Therefore, we would like to graduate IPv6 support from Alpha to Beta.
+
+### Goals
+
+* Promote IPv6 to beta version.
+
+### Non-Goals
+
+* IPv6 is NOT Dual-stack  
+
+### User Stories
+
+* A user can deploy, operate and use a kubernetes cluster in an IPv6 only environment.
+
+## Proposal
+
+* Make kind IPv6 e2e jobs mandatory for all PRs
+* Have signal on IPv6 e2e jobs running in at least one Cloud Provider
+
+## Design
+
+### Test Plan
+
+#### Needed Tests
+
+- Run a CI with conformance E2E tests on an IPv6 only kubernetes cluster.
+- Run a CI with conformance E2E tests on a cloud provider.
+
+### Graduation Criteria
+- [x] It has IPv4 feature parity
+- [x] It has CI
+- [x] It has passed all e2e conformance tests
+- [x] It is documented
+- [ ] It is being used at least by one Cloud Provider
+
+
+## Implementation History
+
+- [IPv6 Support was introduced as alpha in kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md)
+- [IPv6 Support enhancement request](https://github.com/kubernetes/enhancements/issues/508)
+- [IPv6 implementation tracking issue](https://github.com/kubernetes/kubernetes/issues/1443)
+- [IPv6 CI](https://testgrid.k8s.io/conformance-kind#kind%20(IPv6),%20master%20(dev)) 
+- [Kind IPv6 support](https://github.com/kubernetes-sigs/kind/pull/636)

--- a/keps/sig-network/20190714-IPv6-beta-proposal.md
+++ b/keps/sig-network/20190714-IPv6-beta-proposal.md
@@ -13,7 +13,7 @@ approvers:
   - "@thockin"
 editor: TBD
 creation-date: 2019-07-14
-last-updated: 2019-07-23
+last-updated: 2019-07-27
 status: implementable
 see-also:
 replaces:
@@ -33,61 +33,65 @@ superseded-by:
 - [Proposal](#proposal)
 - [Design](#design)
   - [Test Plan](#test-plan)
-    - [Needed Tests](#needed-tests)
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 <!-- /toc -->
 
 ## Summary
 
-Support for IPv6-only clusters was added in Kubernetes 1.9 as an alpha feature, with version 1.13 the Kubernetes default DNS server changed to CoreDNS which has full IPv6 support, there are several CNI plugins with IPv6 support and Dual Stack support is being implemented during the 1.16 cycle.
-
+Support for IPv6-only clusters was added in Kubernetes 1.9 as an alpha feature, allowing full Kubernetes capabilities using IPv6 networking instead of IPv4 networking. It also included support for Kubernetes IPv6 cluster deployments using kubeadm and support for the iptables kube-proxy backend using ip6tables. With version 1.13 the Kubernetes default DNS server changed to CoreDNS which has full IPv6 support.
 
 ## Motivation
 
-IPv6 adoption is ramping up with the advances in IoT space and explosion in number of mobile devices, this adoption will continue to grow as we can observe at the Google IPv6 adoption statistics https://www.google.com/intl/en/ipv6/statistics.html.
+IPv6 adoption is ramping up with the advances in IoT space and explosion in number of mobile devices, this adoption will continue to grow as we can observe at the [Google IPv6 adoption statistics](https://www.google.com/intl/en/ipv6/statistics.html).
 
-There are cloud providers that are starting to support IPv6 clusters, the dual stack implementation will facilitate the migration from IPv4 to IPv6 and CI testing was implemented using the kind project.
+There are cloud providers that already support IPv6 and can deploy kubernetes IPv6 only clusters, a new CI with e2e testing is running all conformance tests using [kind](https://kind.sigs.k8s.io/) and dual stack support will be added during this release cycle (1.16), that will facilitate the migration from IPv4 to IPv6.
 
 Therefore, we would like to graduate IPv6 support from Alpha to Beta.
 
 ### Goals
 
-* Promote IPv6 to beta version.
+* Promote IPv6 to beta.
 
 ### Non-Goals
 
-* IPv6 is NOT Dual-stack  
+* IPv6 is NOT Dual-stack.
 
 ### User Stories
 
-* A user can deploy, operate and use a kubernetes cluster in an IPv6 only environment.
+* A user can deploy, operate and use an IPv6-only kubernetes cluster.
 
 ## Proposal
 
-* Make kind IPv6 e2e jobs mandatory for all PRs
-* Have signal on IPv6 e2e jobs running in at least one Cloud Provider
+The IPv6 support introduced in 1.9 allowed full Kubernetes capabilities using IPv6 networking instead of IPv4 networking. For beta we will provide enough e2e testing to guarantee it:
+
+* CI jobs with e2e and conformance testing will be implemented, using a virtual test environment with Kind and at least in one Cloud Provider.
+
+* The CI jobs will publish the results on testgrid.
+
+* The CI jobs running e2e conformance tests will be promoted to release-blokcing following the standard process, proving that they are stable and contacting SIG-release.
+
+* To ensure there are no regression, an IPv6 e2e job will be added as a presubmit job.
 
 ## Design
 
 ### Test Plan
 
-#### Needed Tests
+There is no need to develop new tests, IPv6 only clusters should pass the same e2e tests that IPv4 only clusters, guaranteeing the feature parity.
 
-- Run a CI with conformance E2E tests on an IPv6 only kubernetes cluster.
-- Run a CI with conformance E2E tests on a cloud provider.
+- Run E2E tests on an IPv6 only kubernetes cluster using kind.
+- Run E2E tests on an IPv6 only kubernetes on at least one cloud provider.
 
 ### Graduation Criteria
 - [x] It has IPv4 feature parity
-- [x] It has CI
+- [x] It has CI using a kubernetes testing environment
+- [ ] It has CI using at least one Cloud Provider
 - [x] It has passed all e2e conformance tests
 - [x] It is documented
-- [ ] It is being used at least by one Cloud Provider
-
 
 ## Implementation History
 
-- [IPv6 Support was introduced as alpha in kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md)
+- [IPv6 Support was introduced as alpha in kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#ipv6)
 - [IPv6 Support enhancement request](https://github.com/kubernetes/enhancements/issues/508)
 - [IPv6 implementation tracking issue](https://github.com/kubernetes/kubernetes/issues/1443)
 - [IPv6 CI](https://testgrid.k8s.io/conformance-kind#kind%20(IPv6),%20master%20(dev)) 


### PR DESCRIPTION
Graduate IPv6 support to beta, it was in alpha status since 1.9 and a CI system was added to avoid regressions and guarantee the quality

Ref: https://github.com/kubernetes/enhancements/issues/1138