### PR TITLE
KEP for promoting seccomp to GA

### DIFF
--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -193,7 +193,7 @@ for new profile sources to be added in the future (e.g. Kubernetes predefined pr
 profiles). The seccomp options struct leaves room for future extensions, such as defining the
 behavior when a profile cannot be set.
 
-<UNRESOLVED>
+<<[UNRESOLVED]>>
 What to do with the localhost profile type, given that we want to deprecate it? Alternative for
 consideration:
 
@@ -207,9 +207,9 @@ annotation.
 The one gotcha is how to handle annotation update in this case. I'm tempted to say allow the update,
 and if the kubelet goes to enforce it and the annotation isn't set to localhost anymore, just treat
 it as an invalid localhost path (fail the pod).
-</UNRESOLVED>
+<<[/UNRESOLVED]>>
 
-<UNRESOLVED>
+<<[UNRESOLVED]>>
 What to do with RuntimeProfile field? There aren't any runtimes that support multiple built in
 profiles, and this feature has never been requested.
 
@@ -217,7 +217,7 @@ If we dropped this field for now (just assume it's runtime/default), how bad wou
 back at some point in the future if it was needed? As long as we defaulted the new field to
 "default" and it's immutable, it doesn't seem like it would be that problematic? Or am I forgetting
 something?
-</UNRESOLVED>
+<<[/UNRESOLVED]>>
 
 #### PodSecurityPolicy API
 

--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -4,7 +4,7 @@ authors:
   - "@tallclair"
 owning-sig: sig-node
 participating-sigs:
-  - sig-apimachinery
+  - sig-api-machinery
   - sig-auth
 reviewers:
   - "@liggitt"
@@ -16,7 +16,7 @@ approvers:
   - "@derekwaynecarr"
 editor: TBD
 creation-date: 2019-07-17
-status: implementable
+status: provisional
 ---
 
 # Seccomp to GA

--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -44,7 +44,6 @@ status: provisional
     - [Upgrade / Downgrade](#upgrade--downgrade)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
-  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)

--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -16,7 +16,7 @@ approvers:
   - "@derekwaynecarr"
 editor: TBD
 creation-date: 2019-07-17
-status: provisional
+status: implementable
 ---
 
 # Seccomp to GA

--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -36,6 +36,7 @@ status: provisional
     - [Pod Update](#pod-update)
     - [PodSecurityPolicy Creation](#podsecuritypolicy-creation)
     - [PodSecurityPolicy Update](#podsecuritypolicy-update)
+    - [PodSecurityPolicy Enforcement](#podsecuritypolicy-enforcement)
     - [PodTemplates](#podtemplates)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
@@ -237,9 +238,6 @@ to the API fields. The cases to consider are: pod create, pod update, PSP create
 All API skew is resolved in the API server. New Kubelets will only use the seccomp values specified
 in the fields, and ignore the annotations.
 
-The PodSecurityPolicy admission controller **must continue to check for annotations** if the fields
-are unset, in order to handle upgrade & version skew scenarios.
-
 #### Pod Creation
 
 If no seccomp annotations or fields are specified, no action is necessary.
@@ -298,6 +296,19 @@ corresponding fields & annotations (even if one was previously unset).
 
 If both the fields _and_ annotations are changed, the new values MUST match. Enforced in API
 validation.
+
+#### PodSecurityPolicy Enforcement
+
+The PodSecurityPolicy admission controller must continue to check the PSP object for annotations if
+the fields are unset, in order to handle upgrade & version skew scenarios.
+
+When setting default profiles, PSP only needs to set the field. The API machinery will handle
+setting the annotation as necessary.
+
+When enforcing allowed profiles, the PSP should check BOTH the annotations & fields. In most cases,
+they should be consistent. On pod update, the seccomp annotations may differ from the fields. In
+that case, the PSP enforcement should check both values as the effective value depends on the node
+version running the pod.
 
 #### PodTemplates
 

--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -8,9 +8,12 @@ participating-sigs:
   - sig-auth
 reviewers:
   - "@liggitt"
-  - TBD
+  - "@derekwaynecarr"
+  - "@dchen1107"
+  - "@mrunalp"
 approvers:
-  - TBD
+  - "@liggitt"
+  - "@derekwaynecarr"
 editor: TBD
 creation-date: 2019-07-17
 status: provisional

--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -170,9 +170,8 @@ type SeccompOptions struct {
 // Only one profile source may be set.
 // +union
 type SeccompProfile struct {
-    // No seccomp profile should be set.
-    // +optional
-    Unconfined *bool
+    // +unionDescriminator
+    Type SeccompProfileType
     // Use a predefined profile defined by the runtime.
     // Most runtimes only support "default"
     // +optional
@@ -182,6 +181,14 @@ type SeccompProfile struct {
     // +optional
     LocalhostProfile *string
 }
+
+type SeccompProfileType string
+
+const (
+    SeccompProfileUnconfined SeccompProfileType = "Unconfined"
+    SeccompProfileRuntime    SeccompProfileType = "Runtime"
+    SeccompProfileLocalhost  SeccompProfileType = "Localhost"
+)
 ```
 
 This API makes the options more explicit than the stringly-typed annotation values, and leaves room
@@ -217,9 +224,9 @@ type SeccompStrategyOptions struct {
 // All values are optional, and an unspecified field excludes all profiles of
 // that type from the set.
 type SeccompProfileSet struct {
-    // Whether the unconfined profile is included in this set.
+    // The allowed seccomp profile types.
     // +optional
-    Unconfined *bool
+    Types []SeccompProfileType
     // The allowed runtimeProfiles. A value of '*' allows all runtimeProfiles.
     // +optional
     RuntimeProfiles []string


### PR DESCRIPTION
This is a proposal to upgrade the seccomp annotation on pods & pod security policies to a field, and
mark the feature as GA. This proposal aims to do the _bare minimum_ to clean up the feature, without
blocking future enhancements.

/sig-node
/sig-auth

/priority important-longterm

/assign @liggitt @dchen1107 @derekwaynecarr 
/cc @jessfraz 