### PR TITLE
Fix small typo in kep-template: releate -> relate

### DIFF
--- a/keps/YYYYMMDD-kep-template.md
+++ b/keps/YYYYMMDD-kep-template.md
@@ -164,7 +164,7 @@ The goal here is to make this feel real for users without getting bogged down.
 What are the caveats to the implementation?
 What are some important details that didn't come across above.
 Go in to as much detail as necessary here.
-This might be a good place to talk about core concepts and how they releate.
+This might be a good place to talk about core concepts and how they relate.
 
 ### Risks and Mitigations
 

--- a/keps/sig-api-machinery/0006-apply.md
+++ b/keps/sig-api-machinery/0006-apply.md
@@ -143,7 +143,7 @@ The linked documents should be read for a more complete picture.
 What are the caveats to the implementation?
 What are some important details that didn't come across above.
 Go in to as much detail as necessary here.
-This might be a good place to talk about core concepts and how they releate.
+This might be a good place to talk about core concepts and how they relate.
 
 #### Kubectl
 ##### Server-side Apply

--- a/keps/sig-instrumentation/20190425-metrics-watch-api.md
+++ b/keps/sig-instrumentation/20190425-metrics-watch-api.md
@@ -104,7 +104,7 @@ TBD:
 What are the caveats to the implementation?
 What are some important details that didn't come across above.
 Go in to as much detail as necessary here.
-This might be a good place to talk about core concepts and how they releate.
+This might be a good place to talk about core concepts and how they relate.
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
Along with a few KEPs where it was copied-and-pasted, which is why it
feels worth fixing!