### PR TITLE
Fix hack/update-toc.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module k8s.io/enhancements
+
+go 1.12
+
+require github.com/tallclair/mdtoc v0.0.0-20190627191617-4dc3d6f90813 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ekalinin/github-markdown-toc v0.0.0-20190514155158-83fadb60a7f1/go.mod h1:XfZS1iyC28CnllR54Ou2Ero6qs4Rmn7GpVumNSj1DZo=
+github.com/gomarkdown/markdown v0.0.0-20190222000725-ee6a7931a1e4 h1:vELsocEzlhM4lk2nhxolEaQrMp25u7/i9IX8s9uLads=
+github.com/gomarkdown/markdown v0.0.0-20190222000725-ee6a7931a1e4/go.mod h1:gmFANS06wAVmF0B9yi65QKsRmPQ97tze7FRLswua+OY=
+github.com/mmarkdown/mmark v2.0.40+incompatible h1:vMeUeDzBK3H+/mU0oMVfMuhSXJlIA+DE/DMPQNAj5C4=
+github.com/mmarkdown/mmark v2.0.40+incompatible/go.mod h1:Uvmoz7tvsWpr7bMVxIpqZPyN3FbOtzDmnsJDFp7ltJs=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tallclair/mdtoc v0.0.0-20190627191617-4dc3d6f90813 h1:1Q3NGZNH8/oSGhSe0J8WjkFCeIOb0JSy7M4RpqY64XI=
+github.com/tallclair/mdtoc v0.0.0-20190627191617-4dc3d6f90813/go.mod h1:BjDk9nfX4091pXLHhvf6Ejr4/r//9NslWmweWb2Hkbs=

--- a/hack/update-toc.sh
+++ b/hack/update-toc.sh
@@ -18,17 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-
-# Install tools we need, but only from vendor/...
-cd ${KUBE_ROOT}
-go install ./vendor/github.com/tallclair/mdtoc
-if ! which mdtoc >/dev/null 2>&1; then
-    echo "Can't find mdtoc - is your GOPATH 'bin' in your PATH?" >&2
-    echo "  GOPATH: ${GOPATH}" >&2
-    echo "  PATH:   ${PATH}" >&2
-    exit 1
-fi
+# cd to the root path
+ROOT=$(dirname "${BASH_SOURCE}")/..
+cd ${ROOT}
 
 # Update tables of contents if necessary.
-grep --include='*.md' -rl keps -e '<!-- toc -->' | xargs mdtoc --inplace
+export GO111MODULE=on
+grep --include='*.md' -rl keps -e '<!-- toc -->' | xargs go run github.com/tallclair/mdtoc --inplace

--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -18,13 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TOOL_VERSION=4dc3d6f908138504b02a1766f1f8ea282d6bdd7c
-
-# cd to the root path
-ROOT=$(dirname "${BASH_SOURCE}")/..
-cd ${ROOT}
-GO111MODULE=on go get "github.com/tallclair/mdtoc@${TOOL_VERSION}"
-
 echo "Checking table of contents are up to date..."
 # Verify tables of contents are up-to-date
-grep --include='*.md' -rl keps -e '<!-- toc -->' | xargs mdtoc --inplace --dryrun
+export GO111MODULE=on
+grep --include='*.md' -rl keps -e '<!-- toc -->' | xargs go run github.com/tallclair/mdtoc --inplace --dryrun


### PR DESCRIPTION
We mostly switched to go.mod, but hack/update-toc.sh was not updated.

We now don't really need to install the binary, we can simply `go run`
it (it can be slower, but for the one-off use case it shouldn't much
matter).

Rather than having each script `go get` at a particular SHA, it seems
easier just to use go.mod / go.sum.