### PR TITLE
fix scripts and go modules

### DIFF
--- a/hack/update-toc.sh
+++ b/hack/update-toc.sh
@@ -18,17 +18,26 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+# cd to the root path
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
 
-# Install tools we need, but only from vendor/...
-cd ${KUBE_ROOT}
-go install ./vendor/github.com/tallclair/mdtoc
-if ! which mdtoc >/dev/null 2>&1; then
-    echo "Can't find mdtoc - is your GOPATH 'bin' in your PATH?" >&2
-    echo "  GOPATH: ${GOPATH}" >&2
-    echo "  PATH:   ${PATH}" >&2
-    exit 1
-fi
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# perform go get in a temp dir as we are not tracking this version in a go module
+# if we do the go get in the repo, it will create / update a go.mod and go.sum
+cd "${TMP_DIR}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/tallclair/mdtoc@${TOOL_VERSION}"
+export PATH="${TMP_DIR}:${PATH}"
+cd "${ROOT}"
 
 # Update tables of contents if necessary.
 grep --include='*.md' -rl keps -e '<!-- toc -->' | xargs mdtoc --inplace

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -21,8 +21,8 @@ set -o pipefail
 TOOL_VERSION="v0.3.4"
 
 # cd to the root path
-ROOT=$(dirname "${BASH_SOURCE}")/..
-cd ${ROOT}
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
 
 # create a temporary directory
 TMP_DIR=$(mktemp -d)
@@ -34,7 +34,12 @@ exitHandler() (
 )
 trap exitHandler EXIT
 
-GO111MODULE=on go get "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+# perform go get in a temp dir as we are not tracking this version in a go module
+# if we do the go get in the repo, it will create / update a go.mod and go.sum
+cd "${TMP_DIR}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+export PATH="${TMP_DIR}:${PATH}"
+cd "${ROOT}"
 
 # check spelling
 RES=0

--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -21,9 +21,25 @@ set -o pipefail
 TOOL_VERSION=4dc3d6f908138504b02a1766f1f8ea282d6bdd7c
 
 # cd to the root path
-ROOT=$(dirname "${BASH_SOURCE}")/..
-cd ${ROOT}
-GO111MODULE=on go get "github.com/tallclair/mdtoc@${TOOL_VERSION}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# perform go get in a temp dir as we are not tracking this version in a go module
+# if we do the go get in the repo, it will create / update a go.mod and go.sum
+cd "${TMP_DIR}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/tallclair/mdtoc@${TOOL_VERSION}"
+export PATH="${TMP_DIR}:${PATH}"
+cd "${ROOT}"
 
 echo "Checking table of contents are up to date..."
 # Verify tables of contents are up-to-date


### PR DESCRIPTION
- fix all scripts to get the repo root correctly
- create a tempdir in all scripts and use this to perform go get in module mode and store output binaries
- fix some minor quoting issues

avoids creating go.mod / go.sum in the repo when running these scripts locally, fixes non-functional `hack/update-toc.sh` which was using (non-existent) vendor instead of go modules