### PR TITLE
Set CRDs to GA KEP status to implementable

### DIFF
--- a/keps/sig-api-machinery/20180415-crds-to-ga.md
+++ b/keps/sig-api-machinery/20180415-crds-to-ga.md
@@ -20,7 +20,7 @@ approvers:
 editor: TBD
 creation-date: 2018-04-15
 last-updated: 2018-04-24
-status: provisional
+status: implementable
 see-also:
   - "[Umbrella Issue](https://github.com/kubernetes/kubernetes/issues/58682)"
   - "[Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)"


### PR DESCRIPTION
Now that all the updates for the `CRDs to GA` KEP have merged, set its status to implementable.

cc @sttts @liggitt @roycaihw @lavalamp @deads2k @caesarxuchao   