### PR TITLE
set update-toc.sh version and add a note to keep in sync

### DIFF
--- a/hack/update-toc.sh
+++ b/hack/update-toc.sh
@@ -18,6 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# keep in sync with hack/verify-toc.sh
+TOOL_VERSION=4dc3d6f908138504b02a1766f1f8ea282d6bdd7c
+
 # cd to the root path
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT}"

--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# keep in sync with hack/verify-toc.sh
 TOOL_VERSION=4dc3d6f908138504b02a1766f1f8ea282d6bdd7c
 
 # cd to the root path


### PR DESCRIPTION
follow up to https://github.com/kubernetes/enhancements/pull/1181

_actually_ fixes hack/update.toc.sh

in the future we should consider using a go.mod instead like https://github.com/kubernetes/enhancements/pull/1175 (though note comments there regarding tools.go..)