### PR TITLE
Merge kepval into the enhancements repo

### DIFF
--- a/cmd/kepval/main.go
+++ b/cmd/kepval/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -25,16 +24,16 @@ import (
 )
 
 func main() {
-	list := flag.NewFlagSet("list", flag.ExitOnError)
-	list.Parse(os.Args[1:])
+	os.Exit(run())
+}
 
+func run() int {
 	parser := &keps.Parser{}
-	exit := 0
-	for _, filename := range list.Args() {
+	for _, filename := range os.Args[1:] {
 		file, err := os.Open(filename)
 		if err != nil {
 			fmt.Printf("could not open file: %v", err)
-			os.Exit(1)
+			return 1
 		}
 		defer file.Close()
 		kep := parser.Parse(file)
@@ -44,11 +43,9 @@ func main() {
 		}
 
 		fmt.Printf("%v has an error: %q\n", filename, kep.Error.Error())
-		exit = 1
+		return 1
 	}
 
-	if exit == 0 {
-		fmt.Println("No validation errors")
-	}
-	os.Exit(exit)
+	fmt.Println("No validation errors")
+	return 0
 }

--- a/cmd/kepval/main.go
+++ b/cmd/kepval/main.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/enhancements/pkg/kepval/keps"
+)
+
+func main() {
+	list := flag.NewFlagSet("list", flag.ExitOnError)
+	list.Parse(os.Args[1:])
+
+	parser := &keps.Parser{}
+	exit := 0
+	for _, filename := range list.Args() {
+		file, err := os.Open(filename)
+		if err != nil {
+			fmt.Printf("could not open file: %v", err)
+			os.Exit(1)
+		}
+		defer file.Close()
+		kep := parser.Parse(file)
+		// if error is nil we can move on
+		if kep.Error == nil {
+			continue
+		}
+
+		fmt.Printf("%v has an error: %q\n", filename, kep.Error.Error())
+		exit = 1
+	}
+
+	if exit == 0 {
+		fmt.Println("No validation errors")
+	}
+	os.Exit(exit)
+}

--- a/cmd/kepval/main_test.go
+++ b/cmd/kepval/main_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestIntegration(t *testing.T) {
+	tempDir, err := ioutil.TempDir(".", "test")
+	if err != nil {
+		t.Fatalf("%+v", errors.WithStack(err))
+	}
+	defer os.RemoveAll(tempDir)
+	fmt.Println("Cloning...")
+	cmd := exec.Command("git", "clone", "https://github.com/kubernetes/enhancements")
+	cmd.Dir = tempDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out))
+		t.Fatalf("%+v", errors.WithStack(err))
+	}
+	fmt.Println("Building...")
+	cmd = exec.Command("go", "build", "-o", filepath.Join(tempDir, "kepval"), ".")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println(string(out))
+		t.Fatal(err)
+	}
+	fmt.Println("Walking...")
+	if filepath.Walk(
+		filepath.Join(tempDir, "enhancements", "keps"),
+		func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() {
+				return nil
+			}
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			if ignore(info.Name()) {
+				return nil
+			}
+			cmd = exec.Command(filepath.Join(tempDir, "kepval"), path)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				fmt.Println(string(out))
+				t.Fatal(err)
+			}
+			return nil
+		},
+	) != nil {
+		t.Fatal(err)
+	}
+}
+
+func ignore(name string) bool {
+	if !strings.HasSuffix(name, "md") {
+		return true
+	}
+	if name == "0023-documentation-for-images.md" {
+		return true
+	}
+	return false
+}

--- a/docs/kepval.md
+++ b/docs/kepval.md
@@ -1,0 +1,14 @@
+# kepval
+
+`kepval` is a tool that checks the YAML metadata in a KEP (Kubernetes
+Enhancement Proposal) is valid.
+
+## Getting started
+
+1. Install `kepval`: `GO111MODULE=on go get k8s.io/enhancements/cmd/kepval`
+2. [optional] clone the enhancements for test data `git clone https://github.com/kubernetes/enhancements.git`
+3. Run `kepval <path to kep.md>`
+
+## Development
+
+1. Run the tests with `go test -cover ./...`

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module k8s.io/enhancements
+
+go 1.12
+
+require (
+	github.com/pkg/errors v0.8.1
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hack/verify-kep-metadata.sh
+++ b/hack/verify-kep-metadata.sh
@@ -18,30 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TOOL_VERSION=v0.1.0
-
 # cd to the root path
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT}"
 
-# create a temporary directory
-TMP_DIR=$(mktemp -d)
-
-# cleanup
-exitHandler() (
-  echo "Cleaning up..."
-  rm -rf "${TMP_DIR}"
-)
-trap exitHandler EXIT
-
-# perform go get in a temp dir as we are not tracking this version in a go module
-# if we do the go get in the repo, it will create / update a go.mod and go.sum
-cd "${TMP_DIR}"
-GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/chuckha/kepview/cmd/kepval@${TOOL_VERSION}"
-export PATH="${TMP_DIR}:${PATH}"
-cd "${ROOT}"
-
-echo "Checking metadata validity..."
-# * ignore "0023-documentation-for-images.md" because it is not a real KEP
-# * ignore "YYYYMMDD-kep-template.md" because it is not a real KEP
-grep --recursive --files-with-matches --regexp '---' --include='*.md' keps | grep --invert-match "YYYYMMDD-kep-template.md" | grep --invert-match "0023-documentation-for-images.md" | xargs kepval
+# run the tests
+GO111MODULE=on go test ./cmd/kepval/...

--- a/pkg/kepval/keps/proposals.go
+++ b/pkg/kepval/keps/proposals.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keps
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	"k8s.io/enhancements/pkg/kepval/keps/validations"
+)
+
+type Proposals []*Proposal
+
+func (p *Proposals) AddProposal(proposal *Proposal) {
+	*p = append(*p, proposal)
+}
+
+type Proposal struct {
+	Title             string   `yaml:"title"`
+	Authors           []string `yaml:,flow`
+	OwningSIG         string   `yaml:"owning-sig"`
+	ParticipatingSIGs []string `yaml:"participating-sigs",flow,omitempty`
+	Reviewers         []string `yaml:,flow`
+	Approvers         []string `yaml:,flow`
+	Editor            string   `yaml:"editor,omitempty"`
+	CreationDate      string   `yaml:"creation-date"`
+	LastUpdated       string   `yaml:"last-updated"`
+	Status            string   `yaml:"status"`
+	SeeAlso           []string `yaml:"see-also,omitempty"`
+	Replaces          []string `yaml:"replaces,omitempty"`
+	SupersededBy      []string `yaml:"superseded-by,omitempty"`
+
+	Filename string `yaml:"-"`
+	Error    error  `yaml:"-"`
+	Contents string `yaml:"-"`
+}
+
+type Parser struct{}
+
+func (p *Parser) Parse(in io.Reader) *Proposal {
+	scanner := bufio.NewScanner(in)
+	count := 0
+	metadata := []byte{}
+	var body bytes.Buffer
+	for scanner.Scan() {
+		line := scanner.Text() + "\n"
+		body.WriteString(line)
+		if count == 2 {
+			continue
+		}
+		if strings.Contains(line, "---") {
+			count++
+			continue
+		}
+		if count == 1 {
+			metadata = append(metadata, []byte(line)...)
+		}
+	}
+	proposal := &Proposal{
+		Contents: body.String(),
+	}
+	if err := scanner.Err(); err != nil {
+		proposal.Error = errors.Wrap(err, "error reading file")
+		return proposal
+	}
+
+	// First do structural checks
+	test := map[interface{}]interface{}{}
+	if err := yaml.Unmarshal(metadata, test); err != nil {
+		proposal.Error = errors.Wrap(err, "error unmarshaling YAML")
+		return proposal
+	}
+	if err := validations.ValidateStructure(test); err != nil {
+		proposal.Error = errors.Wrap(err, "error validating KEP metadata")
+		return proposal
+	}
+
+	proposal.Error = yaml.Unmarshal(metadata, proposal)
+	return proposal
+}

--- a/pkg/kepval/keps/proposals_test.go
+++ b/pkg/kepval/keps/proposals_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keps_test
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/enhancements/pkg/kepval/keps"
+)
+
+func TestValidParsing(t *testing.T) {
+	testcases := []struct {
+		name         string
+		fileContents string
+	}{
+		{
+			"simple test",
+			`---
+title: test
+authors:
+  - "@jpbetz"
+  - "@roycaihw"
+  - "@sttts"
+owning-sig: sig-api-machinery
+participating-sigs:
+  - sig-api-machinery
+  - sig-architecture
+reviewers:
+  - "@deads2k"
+  - "@lavalamp"
+  - "@liggitt"
+  - "@mbohlool"
+  - "@sttts"
+approvers:
+  - "@deads2k"
+  - "@lavalamp"
+creation-date: 2018-04-15
+last-updated: 2018-04-24
+status: provisional
+---`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &keps.Parser{}
+			contents := strings.NewReader(tc.fileContents)
+			out := p.Parse(contents)
+			if out.Error != nil {
+				t.Fatalf("expected no error but got one: %v", out.Error)
+			}
+			if out == nil {
+				t.Fatal("out should not be nil")
+			}
+		})
+	}
+}

--- a/pkg/kepval/keps/validations/yaml.go
+++ b/pkg/kepval/keps/validations/yaml.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validations
+
+import (
+	"fmt"
+	"strings"
+)
+
+type KeyMustBeString struct {
+	key interface{}
+}
+
+func (k *KeyMustBeString) Error() string {
+	return fmt.Sprintf("key %[1]v must be a string but it is a %[1]T", k.key)
+}
+
+type ValueMustBeString struct {
+	key   string
+	value interface{}
+}
+
+func (v *ValueMustBeString) Error() string {
+	return fmt.Sprintf("%q must be a string but it is a %T: %v", v.key, v.value, v.value)
+}
+
+type ValueMustBeListOfStrings struct {
+	key   string
+	value interface{}
+}
+
+func (v *ValueMustBeListOfStrings) Error() string {
+	return fmt.Sprintf("%q must be a list of strings: %v", v.key, v.value)
+}
+
+type MustHaveOneValue struct {
+	key string
+}
+
+func (m *MustHaveOneValue) Error() string {
+	return fmt.Sprintf("%q must have a value", m.key)
+}
+
+type MustHaveAtLeastOneValue struct {
+	key string
+}
+
+func (m *MustHaveAtLeastOneValue) Error() string {
+	return fmt.Sprintf("%q must have at least one value", m.key)
+}
+func ValidateStructure(parsed map[interface{}]interface{}) error {
+	for key, value := range parsed {
+		// First off the key has to be a string. fact.
+		k, ok := key.(string)
+		if !ok {
+			return &KeyMustBeString{k}
+		}
+		empty := value == nil
+
+		// figure out the types
+		switch strings.ToLower(k) {
+		// optional strings
+		case "editor":
+			if empty {
+				continue
+			}
+			fallthrough
+		case "title", "owning-sig", "status", "creation-date", "last-updated":
+			switch v := value.(type) {
+			case []interface{}:
+				return &ValueMustBeString{k, v}
+			}
+			v, ok := value.(string)
+			if ok && v == "" {
+				return &MustHaveOneValue{k}
+			}
+			if !ok {
+				return &ValueMustBeString{k, v}
+			}
+		// These are optional lists, so skip if there is no value
+		case "participating-sigs", "replaces", "superseded-by", "see-also":
+			if empty {
+				continue
+			}
+			switch v := value.(type) {
+			case []interface{}:
+				if len(v) == 0 {
+					continue
+				}
+			case interface{}:
+				// This indicates an empty item is valid
+				continue
+			}
+			fallthrough
+		case "authors", "reviewers", "approvers":
+			switch v := value.(type) {
+			case []interface{}:
+				if len(v) == 0 {
+					return &MustHaveAtLeastOneValue{k}
+				}
+			case interface{}:
+				return &ValueMustBeListOfStrings{k, v}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/kepval/keps/validations/yaml_test.go
+++ b/pkg/kepval/keps/validations/yaml_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validations
+
+import (
+	"bytes"
+	"html/template"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+type proposal struct {
+	Title             string   `yaml:"title"`
+	Authors           []string `yaml:,flow`
+	OwningSIG         string   `yaml:"owning-sig"`
+	ParticipatingSIGs []string `yaml:"participating-sigs",flow`
+	Reviewers         []string `yaml:,flow`
+	Approvers         []string `yaml:,flow`
+	Editor            string   `yaml:"editor"`
+	CreationDate      string   `yaml:"creation-date"`
+	LastUpdated       string   `yaml:"last-updated"`
+	Status            string   `yaml:"status"`
+	SeeAlso           []string `yaml:"see-also"`
+	Replaces          []string `yaml:"replaces"`
+	SupersededBy      []string `yaml:"superseded-by"`
+}
+
+// YAMLDoc is entirely for testing purposes
+func (p *proposal) YAMLDoc() []byte {
+	t, err := template.New("yaml").Parse(`title: {{.Title}}
+authors:
+  {{- range .Authors }}
+  - "{{.}}"
+  {{- end }}
+owning-sig: {{ .OwningSIG }}
+{{- if .ParticipatingSIGs }}
+participating-sigs:
+  {{- range .ParticipatingSIGs }}
+  - "{{.}}"
+  {{- end }}
+{{- end }}
+reviewers:
+  {{- range .Reviewers }}
+  - "{{.}}"
+  {{- end }}
+approvers:
+  {{- range .Approvers }}
+  - "{{.}}"
+  {{- end }}
+{{- if .Editor }}
+editor: {{ .Editor }}
+{{- end }}
+creation-date: {{ .CreationDate }}
+last-updated: {{ .LastUpdated }}
+status: {{ .Status }}
+{{- if .SeeAlso }}
+see-also:
+  {{- range .SeeAlso }}
+  - "{{.}}"
+  {{- end }}
+{{- end }}
+{{- if .Replaces }}
+replaces:
+  {{- range .Replaces }}
+  - "{{.}}"
+  {{- end }}
+{{- end }}
+{{- if .SupersededBy }}
+superseded-by:
+  {{- range .SupersededBy }}
+  - "{{.}}"
+  {{- end }}
+{{- end }}
+`)
+	if err != nil {
+		panic(err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, p); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+func TestUnmarshalSuccess(t *testing.T) {
+	yamlDoc := &proposal{
+		Title:        "test",
+		Authors:      []string{"test", "test", "test"},
+		Reviewers:    []string{"my reviewer"},
+		OwningSIG:    "my-sig",
+		Status:       "some status",
+		Approvers:    []string{"my approvers"},
+		LastUpdated:  "at some point",
+		CreationDate: "a while ago",
+	}
+	p := map[interface{}]interface{}{}
+
+	if err := yaml.Unmarshal(yamlDoc.YAMLDoc(), p); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateStructure(p); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateStructureSuccess(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input map[interface{}]interface{}
+	}{
+		{
+			name: "Participating sigs is optional",
+			input: map[interface{}]interface{}{
+				"participating-sigs": "",
+			},
+		},
+		{
+			name: "replaces can be empty",
+			input: map[interface{}]interface{}{
+				"replaces": nil,
+			},
+		},
+		{
+			name: "editor can be empty",
+			input: map[interface{}]interface{}{
+				"editor": nil,
+			},
+		},
+		{
+			name: "editor can have a value",
+			input: map[interface{}]interface{}{
+				"editor": "hello",
+			},
+		},
+		{
+			name: "see also can be an empty list",
+			input: map[interface{}]interface{}{
+				"see-also": []interface{}{},
+			},
+		},
+		{
+			name: "superseded-by can be nil",
+			input: map[interface{}]interface{}{
+				"superseded-by": nil,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateStructure(tc.input)
+			if err != nil {
+				t.Fatalf("did not expect an error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateStructureFailures(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input map[interface{}]interface{}
+	}{
+		{
+			name: "Non string key",
+			input: map[interface{}]interface{}{
+				1: "hello",
+			},
+		},
+		{
+			name: "empty title",
+			input: map[interface{}]interface{}{
+				"title": "",
+			},
+		},
+		{
+			name: "non string title",
+			input: map[interface{}]interface{}{
+				"title": 3,
+			},
+		},
+		{
+			name: "title is a list",
+			input: map[interface{}]interface{}{
+				"title": []interface{}{1, 2, 3},
+			},
+		},
+		{
+			name: "authors is an empty list",
+			input: map[interface{}]interface{}{
+				"authors": []interface{}{},
+			},
+		},
+		{
+			name: "authors is just one string",
+			input: map[interface{}]interface{}{
+				"authors": "me",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateStructure(tc.input)
+			if err == nil {
+				t.Fatal("expecting an error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This moves kepval and the go definition of a KEP into the enhancements repo.

The hack script is fixed to use go test to test validations instead of installing an external script simplifying the process greatly.

This will fail golint as I have not documented the series of custom errors created in validation to good spec. However, as none of the verification tools have been set up so there will not be any failing test.

I can make an issue to add those scripts as a followup item *or* I can do it as part of this PR, but it might add an additional 500-600 lines of bash. The decision is up to the owners preference. I've watched @neolit123 do it 3 times in the past month or so and am pretty sure I know how it goes!

cc @justaugustus 

please tag anyone else you like