### PR TITLE
Mark kubelet metrics migration to standard prometheus collector as done

### DIFF
--- a/keps/sig-instrumentation/20190605-metrics-stability-migration.md
+++ b/keps/sig-instrumentation/20190605-metrics-stability-migration.md
@@ -98,7 +98,7 @@ The [metrics overhaul KEP](https://github.com/kubernetes/enhancements/blob/maste
 
 ## Implementation History
 
-- [ ] [Migrate kubelet metrics to use standard prometheus collectors](https://github.com/kubernetes/kubernetes/issues/79286)
+- [x] [Migrate kubelet metrics to use standard prometheus collectors](https://github.com/kubernetes/kubernetes/issues/79286)
 - [ ] Create migrated variants of shared client metrics
 - [ ] Create migrated variants of shared leader-election metrics
 - [ ] Create migrated variants of shared workqueue metrics


### PR DESCRIPTION
Mark kubelet metrics migration to standard Prometheus collector as done
as a result of this: https://github.com/kubernetes/kubernetes/pull/81573