### PR TITLE
Modified proposal for configurable HPA to use a single field to specify allowed changes

### DIFF
--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -2,6 +2,7 @@
 title: Configurable scale up/down velocity for HPA
 authors:
   - "@gliush"
+  - "@arjunrn"
 owning-sig: sig-autoscaling
 participating-sigs:
 reviewers:
@@ -10,7 +11,7 @@ approvers:
   - TBD
 editor: TBD
 creation-date: 2019-03-07
-last-updated: 2019-03-07
+last-updated: 2019-09-16
 status: provisional
 superseded-by:
 ---
@@ -33,7 +34,7 @@ superseded-by:
     - [Story 5: Delay Before Scaling Down](#story-5-delay-before-scaling-down)
   - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
     - [Algorithm Pseudocode](#algorithm-pseudocode)
-    - [Introducing <code>delay</code> Option](#introducing--option)
+    - [Introducing <code>stabilizationWindowSeconds</code> Option](#introducing--option)
     - [Default Values](#default-values)
     - [The Motivation To “Pick The Largest Constraint” Concept](#the-motivation-to-pick-the-largest-constraint-concept)
     - [Stabilization Window](#stabilization-window)
@@ -44,7 +45,9 @@ superseded-by:
 
 ## Summary
 
-[Horizontal Pod Autoscaler][] (HPA) automatically scales the number of pods in a replication controller, deployment or replica set based on observed CPU utilization (or, with custom metrics support, on some other application-provided metrics). This proposal adds scale velocity configuration parameters to the HPA.
+[Horizontal Pod Autoscaler][] (HPA) automatically scales the number of pods in any resource which supports the `scale` subresource based on observed CPU utilization 
+(or, with custom metrics support, on some other application-provided metrics). This proposal adds scale velocity configuration parameters to the HPA to control the 
+rate of scaling in both directions.
 
 [Horizontal Pod Autoscaler]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 
@@ -55,18 +58,18 @@ I can name at least three types of applications:
 
 - Applications that handle business-critical web traffic. They should scale up as fast as possible (false positive signals to scale up are ok), and scale down very slowly (waiting for another traffic spike).
 - Applications that process critical data. They should scale up as fast as possible (to reduce the data processing time), and scale down as soon as possible (to reduce the costs). False positives signals to scale up/down are ok.
-- Applications that process regular data/web traffic. It is not that important and may scale up and down in a usual way to minimize jitter.
+- Applications that process regular data/web traffic. These are not very critical and may scale up and down in a usual way to minimize jitter.
 
 At the moment, there’s only one cluster-level configuration parameter that influence how fast the cluster is scaled down:
 
 - [--horizontal-pod-autoscaler-downscale-stabilization-window][]   (default to 5 min)
 
-And a couple of hard-coded constants that specify how fast the cluster can scale up:
+And a couple of hard-coded constants that specify how fast the target can scale up:
 
 - [scaleUpLimitFactor][] = 2.0
 - [scaleUpLimitMinimum][] = 4.0
 
-As a result, users can't influence scale velocity, and that is a problem for many people. There're several open issues in tracker about that:
+As a result, users cannot influence scale velocity, and that is a problem for many applications. There are several open issues in the tracker about this issue:
 
 - [#39090][]
 - [#65097][]
@@ -85,29 +88,30 @@ As a result, users can't influence scale velocity, and that is a problem for man
 
 ### Non-Goals
 
-TBA
+- Persist the scaling events so that the HPA behavior is consistent even when the controller is restarted.
 
 ## Proposal
 
-We need to introduce an algorithm-agnostic HPA object configuration that will configure each particular HPA scaling behavior.
-For both direction (scale up and scale down) there should be a `Constraint` field with the following parameters:
+We need to introduce an algorithm-agnostic HPA object configuration that will allow configuration of individual HPAs.
+To customize the scaling behavior we should add a `behavior` object with the following fields:
 
-- `periodSeconds` - a parameter to specify the time period for the constraint, in seconds
-- `percent` - a parameter to specify the relative speed, in percentages:
-    i.e., if ScaleUpPercent = 150 , then we can add 150% more pods (10 -> 25 pods)
-- `pods` - a parameter to specify the absolute speed, in the number of pods:
-    i.e., if ScaleUpPods = 5 , then we can add 5 more pods (10 -> 15)
-- `delay` - a parameter to specify the window over which the max (or min) recommendation is used. It behaves the same as the [Stabilization Window][].
+- `stabilizationWindowSeconds` - this value indicates the amount of time the HPA controller should consider
+  previous recommendations to prevent flapping of the number of replicas.
+- `scaleUp` specifies the rules which are used to control scaling behavior while scaling up.
+  - `choosePolicy` can be `min` or `max` and specifies which value from the policies should be selected. The `max` value is used by default.
+  - `policies` a list of policies which regulate the amount of scaling. Each item has the following fields
+    - `type` can have the value `pods` or `percent` which indicates the allowed changed in terms of absolute number of pods or percentage of current replicas.
+    - `periodSeconds` the amount of time in seconds for which the rule should hold true.
+    - `value` the value for the policy
+- `scaleDown` similar to the `scaleUp` but specifies the rules for scaling down.
 
 A user will specify the parameters for the HPA, thus controlling the HPA logic.
 
-If the user specifies two parameters, two constraints are calculated, and the largest is used (see the [The motivation to pick the largest constraint][] section below).
+The `choosePolicy` field indicates which policy should be applied. By default the `max` policy is chosen or in other words while scaling up the highest
+possible number of replicas is used and while scaling down the lowest possible number of replicas is chosen. If the user does not specify policies for 
+either `scaleUp` or `scaleDown` then default value for that policy is used (see the [Default Values] [] section below). Setting the `value` to `0` for
+`scaleUp` or `scaleDown` disables scaling in that direction.
 
-If the user doesn't specify any parameter, the default value for that parameter is used (see the [Default Values][] section below).
-
-If the user set both `percent` and `pods` to `0`, it means that the corresponding resource (e.g. `deploy`, `rs`) should not be scaled in that direction.
-
-[The motivation to pick the largest constraint]: #the-motivation-to-pick-the-largest-constraint-concept
 [Default Values]: #default-values
 [Stabilization Window]: #stabilization-window
 
@@ -119,59 +123,64 @@ This mode is essential when you want to respond to a traffic increase quickly.
 
 Create an HPA with the following configuration:
 
-- `constraints`:
-  - `scaleUp`:
-    - `percent = 900`    (i.e., to increase the number of pods 10 times per minute is ok).
+```yaml
+behavior:
+  scaleUp:
+    policies:
+    - type: percent
+      value: 900%
+```
 
-All other parameters are not specified (default values are used)
+The `900%` implies that 9 times the current number of pods can be added, effectively making the number
+of replicas 10 times the current size. All other parameters are not specified (default values are used)
 
 If the application is started with 1 pod, it will scale up with the following number of pods:
 
     1 -> 10 -> 100 -> 1000
 
-So, it can reach `maxReplicas` very fast.
+This way the target can reach `maxReplicas` very quickly.
 
-Scale down will be done a usual way (check stabilization window in the [Stabilization Window][] section below and the [Algorithm details][] in the official HPA documentation)
+Scale down will be done in the usual way (check stabilization window in the [Stabilization Window][] section below and the [Algorithm details][] in the official HPA documentation)
 
 [Stabilization Window]: #stabilization-window
 [Algorithm details]: https://v1-14.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
 
 #### Story 2: Scale Up As Fast As Possible, Scale Down Very Gradually
 
-This mode is essential when you don’t want to risk scaling down very quickly.
+This mode is essential when you do not want to risk scaling down very quickly.
 
-Create an HPA with the constraints:
+Create an HPA with the following behavior:
 
-- `constraints`:
-  - `scaleUp`:
-    - `percent = 900` (i.e. increase number of pods 10 times per minute is ok).
-  - `scaleDown`:
-    - `pods = 1`
-    - `periodSeconds = 600` (i.e., scale down one pod every 10 min)
+```yaml
+behavior:
+  scaleUp:
+    policies:
+    - type: percent
+      value: 900%
+  scaleDown:
+    policies:
+    - type: pods
+      value: 1
+      periodSeconds: 600 # (i.e., scale down one pod every 10 min)
+```
 
-All other parameters are not specified (default values are used)
-
-If the application is started with 1 pod, it will scale up with the following number of pods:
-
-    1 -> 10 -> 100 -> 1000
-
-So, it can reach `maxReplicas` very fast.
-
-Scaling down will be by one pod each 10 min:
+This `behavior` has the same scale-up pattern as the previous example. However the `behavior` for scaling down is also specified.
+The `scaleUp` behavior will be fast as explained in the previous example. However the target will scale down by only one pod every 10 minutes.
 
     1000 -> 1000 -> 1000 -> … (7 more min) -> 999
 
 #### Story 3: Scale Up Very Gradually, Usual Scale Down Process
 
 This mode is essential when you want to increase capacity, but you want it to be very pessimistic.
+Create an HPA with the following behavior:
 
-Create an HPA with the constraints:
-
-- `constraints`:
-  - `scaleUp`:
-    - `pods = 1`    (i.e., increase only by one pod per minute)
-
-All other parameters are not specified (default values are used)
+```yaml
+behavior:
+  scaleUp:
+    policies:
+    - type: pods
+      value: 1
+```
 
 If the application is started with 1 pod, it will scale up very gradually:
 
@@ -183,38 +192,40 @@ Scale down will be done a usual way (check stabilization window in [Algorithm de
 
 #### Story 4: Scale Up As Usual, Do Not Scale Down
 
-This mode is essential when you don’t want to risk scaling down at all.
+This mode is essential when scale down should not happen or should be controlled by a separate process.
 
 Create an HPA with the following constraints:
 
-- `constraints`:
-  - `scaleDown`:
-    - `percent = 0`
-    - `pods = 0`
-
-i.e., set both constraints to 0, so that the HPA controller would never scale the cluster down
-
-All other parameters are not specified (default values are used)
+```yaml
+behavior:
+  scaleDown:
+    policies:
+    - type: pods
+      value: 0
+```
 
 The cluster will scale up as usual (default values), but will never scale down.
 
-#### Story 5: Delay Before Scaling Down
+#### Story 5: Stabilization when the traffic has a fluctuating pattern
 
-This mode is used when the user expects a lot of flapping
-or doesn't want to turn off pods too early expecting some late load spikes.
+This mode is used when the user expects a lot of flapping or does not want to scale down pods too early expecting some late load spikes.
 
-Create an HPA with the following constraints:
+Create an HPA with the following behavior:
 
-- `constraints`:
-  - `scaleDown`:
-    - `pods = 5`
-  - `delaySeconds = 600`
+```yaml
+behavior:
+  stabilizationWindowSeconds: 600
+  scaleDown:
+    policies:
+    - type: pods
+      value: 5
+```
 
 i.e., the algorithm will:
 
-- gather recommendations for 600 seconds (by default: 300)
+- gather recommendations for 600 seconds _(default: 300 seconds)_
 - pick the largest one
-- turn off no more than 5 pods per minute
+- scale down no more than 5 pods per minute
 
 Example for `CurReplicas = 10` and HPA controller cycle once per a minute:
 
@@ -233,9 +244,13 @@ Example for `CurReplicas = 10` and HPA controller cycle once per a minute:
 
     recommendations = [9, 8, 9, 9, 8, 9, 8, 9, 8, 7]
 
-  The algorithm picks the largest value `9` and change the number of replicas `10 -> 9`
+  The algorithm picks the largest value `9` and changes the number of replicas `10 -> 9`
 
 ### Implementation Details/Notes/Constraints
+
+To minimize the impact of new changes on existing code the HPA controller will be modified in a such
+a way that the scaling calculations will have separate code paths for existing HPA and HPAs with
+the `behavior` field set. The new code path will be as shown below.
 
 #### Algorithm Pseudocode
 
@@ -244,52 +259,62 @@ The algorithm to find the number of pods will look like this:
 ```golang
   for { // infinite cycle inside the HPA controller
     desiredReplicas = AnyAlgorithmInHPAController(...)
-    if desiredReplicas > curReplicas:
-      constraint1 = CurReplicas * (1 + ScaleUpPercent/100)
-      constraint2 = CurReplicas + ScaleUpPods
-      scaleUpLimit = max(constraint1, constraint2)
-      limitedReplicas = min(scaleUpLimit, desiredReplicas)
-      storeRecommendation(limitedReplicas, scaleUpRecommendations)
-      recommendations = getLastRecommendations(scaleUpRecommendations, ScaleUpDelaySeconds) // get recommendations for the last ScaleUpDelaySeconds
-      nextReplicas = min(recommendations)
-    if desiredReplicas < curReplicas:
-      constraint1 = curReplicas * (1 - ScaleDownPercent/100)
-      constraint2 = CurReplicas - ScaleDownPods
-      scaleDownLimit = max(constraint1, constraint2)
-      limitedReplicas = max(scaleDownLimit, desiredReplicas)
-      storeRecommendation(limitedReplicas, scaleDownRecommendations)
-      recommendations = getLastRecommendations(scaleDownRecommendations, ScaleDownDelaySeconds) // get recommendations for the last ScaleDownDelaySeconds
-      nextReplicas = max(recommendations)
+    if desiredReplicas > curReplicas {
+      replicas = []int{}
+      for _, policy := range behavior.ScaleUp.Policies {
+        if policy.type == "pods" {
+          replicas = append(replicas, CurReplicas + policy.Value)
+        } else if policy.type == "percent" {
+          replicas = append(CurReplicas * (1 + policy.Value/100))
+        }
+      }
+      if behavior.ScaleUp.selectPolicy == "max" {
+        scaleUpLimit = max(replicas)
+      } else {
+        scaleUpLimit = min(replicas)
+      }
+      limitedReplicas = min(max, desiredReplicas)
+    }
+    if desiredReplicas < curReplicas {
+      for _, policy := range behaviro.scaleDown.Policies {
+        replicas = []int{}
+        if policy.type == "pods" {
+          replicas = append(replicas, CurReplicas - policy.Value)
+        } else if policy.type == "percent" {
+          replicas = append(replicas, CurReplicas * (1 - policy.Value /100))
+        }
+        if behavior.ScaleDown.SelectPolicy == "max" {
+          scaleDownLimit = min(replicas)
+        } else {
+          scaleDownLimit = max(replicas)
+        }
+        limitedReplicas = max(min, desiredReplicas)
+      }
+    }
+    storeRecommend(limitedReplicas, scaleDownRecommendations)
     setReplicas(nextReplicas)
     sleep(ControllerSleepTime)
   }
 
 ```
 
-I.e., from the two provided constraints the larger one is always used.
-
-If you don’t want to scale, you should set both parameters to zero for the appropriate direction (Up/Down).
-
-If only one parameter is given and the other is 0, then use the only defined constraint.
-
-If no value is given, the default one is chosen, see the [Default Values][] section.
+If no scaling policy is specified then the default policy is chosen(see the [Default Values][] section).
 
 [Default Values]: #default-values
 
-#### Introducing `delay` Option
+#### Introducing `stabilizationWindowSeconds` Option
 
-Effectively, the `delay` option is a full copy of the current [Stabilization Window][] algorithm:
+Effectively the `stabilizationWindowSeconds` option is a full copy of the current [Stabilization Window][] algorithm:
 
-- While scaling up, we should pick the safest (smallest) "desiredReplicas" number during last `delaySeconds`.
-- While scaling down, we should pick the safest (largest) "desiredReplicas" number during last `delaySeconds`.
+- While scaling down, we should pick the safest (largest) "desiredReplicas" number during last `stabilizationWindowSeconds`.
 
 Check the [Algorithm Pseudocode][] section if you need more details.
 
-If delay is `0`, it means that no delay should be used. And we should instantly change the number of replicas.
+If the window is `0`, it means that no delay should be used. And we should instantly change the number of replicas.
 
-If no delay is specified, the default value is used, see the [Default Values][] section.
+If no value is specified, the default value is used, see the [Default Values][] section.
 
-The “Stabilization Window" as a result becomes an alias for the `constraints.scaleDown.delaySeconds`.
+The __“Stabilization Window"__ as a result becomes an alias for the `behavior.stabilizationWindowSeconds`.
 
 [Stabilization Window]: #stabilization-window
 [Algorithm Pseudocode]: #algorithm-pseudocode
@@ -299,80 +324,46 @@ The “Stabilization Window" as a result becomes an alias for the `constraints.s
 
 For smooth transition it makes sense to set the following default values:
 
-- `constraints.scaleUp.delaySeconds = 0`, the delay is not used, instantly scale up
-- `constraints.scaleDown.delaySeconds = 300`, wait 5 min for the largest recommendation and then scale down to that value.
-- `constraints.scaleUp.rate.periodSeconds = 60`, one minute period for scaleUp
-- `constraints.scaleDown.rate.periodSeconds = 60`, one minute period for scaleDown
-- `constraints.scaleUp.rate.percent = 100`, allow to twice the number of pods
-- `constraints.scaleUp.rate.pods = 4`, i.e. allow adding up to 4 pods
-- `constraints.scaleDown.rate.percent = nil`, allow to remove all the pods
-- `constraints.scaleDown.rate.pods = nil`, allow to remove all the pods
+- `behavior.stabilizationWindowSeconds = 300`, wait 5 min for the largest recommendation and then scale down to that value.
+- `behavior.scaleUp.policies` has the following policies
+   - Percentage policy
+      - `policy = percent`
+      - `periodSeconds = 60`, one minute period for scaleUp
+      - `value = 100` which means the number of replicas can be doubled every minute.
+   - Pod policy
+      - `policy = pods`
+      - `periodSeconds = 60`, one minute period for scaleUp
+      - `value = 4` which means the 4 replicas can be added every minute.
+- `behaviour.scaleDown.policies` has the following policies
+  - Percentage Policy
+    - `policy = percent`
+    - `periodSeconds = 60` one minute period for scaleDown
+    - `value = 100`  which means all the replicas can be scaled down in one minute.
 
 Please note that:
 
-`constraints.ScaleDown.delaySeconds` value is picked in the following order:
+`behavior.stabilizationWindowSeconds` value is picked in the following order:
 
-- from the HPA configuration, use that value
-- from the command-line options. Check the [Command Line Option Changes][] section.
+- from the HPA configuration if specified
+- from the command-line options for the controller. Check the [Command Line Option Changes][] section.
 - from the hardcoded default value `300`.
 
-For the `scaleDown` constraint both `pods` and `percent` default values are set to maximum possible values.
-Because currently (as of k8s-1.14) the scale down is only limited by [Stabilization Window][].
-In order to repeat the default behavior we set `constraints.scaleDown.delaySeconds` to 5min
-(the default value for Stabilization window), and let it rule the number of pods.
-
-We should differentiate "not given" value and `0`-value.
-For `pods` and `percent`, `0`-value means that we shouldn't scale.
-While "not given" value means that we should use the default.
-Hence we should use pointers `*int32` ("nillable" type) instead of just `int32` for all the introduced values.
+The `scaleDown` behavior has a single `percent`policy with a value of `100` because
+the current scale down behavior is only limited by [Stabilization Window][] which means after
+the stabilization window has passed the target can be scaled down to the minimum specified replicas.
+In order to replicate the default behavior we set `behavior.stabilizationWindowSeconds` to 300
+(the default value for Stabilization window), and let it determine the number of pods.
 
 [Stabilization Window]: #stabilization-window
 
-#### The Motivation To “Pick The Largest Constraint” Concept
-
-Take a look at the example:
-
-- `curReplicas = 10`
-- `calculatedReplicas = 20`
-
-The user specifies only one HPA parameter `constraints.scaleUp.pods = 5` and expects that number of replicas to be set to 15 during the next HPA controller loop.
-But the algorithm picks the largest change instead:
-
-    Constraint1 = 10 * 2 = 20 (as constraints.scaleUp.percent = 100 by default)
-    Constraint2 = 10 + 5 = 15 (as constraints.scaleUp.pods = 5, set by the user)
-    scaleUpLimit = max(20, 15) = 20
-    desiredReplicas = 20
-
-The user might expect that the autoscaler would use the smallest constraint (15), not the largest one (20). This behavior is not intuitive, but it does make sense if considered thoroughly.
-
-The main idea of the HPA is to autoscale because of a load increase to avoid request failures. It should work on both small clusters and large ones. For small clusters, the absolute number constraint works better (ScaleUpPods), for large clusters the percentage works better (ScaleUpPercentage).
-
-Example: If the current cluster size is `1` and calculated cluster size for this particular load is `20`, then we should reach it ASAP.
-
-For default values (ScaleUpPercent = 100, ScaleUpPods = 4) and “pick the largest constraint” concept, we’ll increase 1 -> 20 in 3 steps
-
-    1 -> 5 -> 10 -> 20
-
-The first step will use “scaleUp.pods” constraint; the next steps will use “scaleUp.percent” one.
-
-In case of more intuitive “pick the hardest limit” concept, we’ll increase the cluster in 6 steps:
-
-    1 -> 2 -> 4 -> 8 -> 12 -> 16 -> 20
-
-Given that each step takes [90 sec in worst case], we’ll respond to the load increase in `(6-3)*90 sec = ~ 5 min`.
-
-That’s too much, we should respond faster than that.
-
-[90 sec in worst case]: https://dzone.com/articles/kubernetes-autoscaling-101-cluster-autoscaler-hori-1
-
-The scale down constraints are a method to prevent too rapid loss of capacity. Hence, it makes sense to pick the maximum of two constraints.
-
 #### Stabilization Window
 
-Currently stabilization window ([PR][], [RFC][], [Algorithm Details][]) is used to gather “scale-down-recommendations” during some time (default is 5min),
-and a new number of replicas is set to the maximum of all recommendations.
+Currently the stabilization window ([PR][], [RFC][], [Algorithm Details][]) is used to gather __scale-down-recommendations__
+during a fixed interval (default is 5min), and a new number of replicas is set to the maximum of all recommendations
+in that interval. This is done to prevent a constant fluctuation in the number of pods if the traffic/load fluctuates
+over a short period.
 
-It may be defined by command line option `--horizontal-pod-autoscaler-downscale-stabilization-window`.
+It may be specified by command line option `--horizontal-pod-autoscaler-downscale-stabilization-window`.
 
 [PR]: https://github.com/kubernetes/kubernetes/pull/68122
 [RFC]: https://docs.google.com/document/d/1IdG3sqgCEaRV3urPLA29IDudCufD89RYCohfBPNeWIM/edit#heading=h.3tdw2jxiu42f
@@ -382,24 +373,37 @@ It may be defined by command line option `--horizontal-pod-autoscaler-downscale-
 
 The following API changes are needed:
 
-We should add `Scale{Up,Down}{Percent,Pods}` fields into the HPA spec
+- `HorizontalPodAutoscalerBehavior` should be added as a field to the HPA spec. It will contain fields
+  which describe the scaling behavior for both scale up and scale down. In the future other aspects of
+  the scaling behavior could be customized by adding fields here.
+- `HPAScaleConstraint` specifies the maximum change in the number of pods while scaling up or down
+  during autoscaling.
 
-The resulting solution will look like this:
+The resulting data structures will look like this:
 
 ```golang
-type HPAScaleConstraintValue struct {
-    Rate         *HPAScaleConstraintRateValue
-    DelaySeconds *int32
+type HPAScalingPolicyType string
 
-type HPAScaleConstraintRateValue struct {
-    Pods          *int32
-    Percent       *int32
-    PeriodSeconds *int32
+const (
+  PercentPolicy HPAScalingPolicyType = "percent"
+  PodsPolicy    HPAScalingPolicyType = "pods"
+)
+
+type HPAScalingPolicy struct {
+  Type          HPAScalingPolicyType
+  Value         int32
+  PeriodSeconds int32
 }
 
-type HPAScaleConstraints struct {
-    ScaleUp   *HPAScaleConstraintValue
-    ScaleDown *HPAScaleConstraintValue
+type HPAScalingRules struct {
+  Policies     []HpaScalingPolicy
+  SelectPolicy *string
+}
+
+type HorizontalPodAutoscalerBehavior struct {
+    StabilizationWindowSeconds *int32
+    ScaleUp   *HPAScalingRules
+    ScaleDown *HPAScalingRules
 }
 
 type HorizontalPodAutoscalerSpec struct {
@@ -407,32 +411,19 @@ type HorizontalPodAutoscalerSpec struct {
     MinReplicas    *int32
     MaxReplicas    int32
     Metrics        []MetricSpec
-    Constraints    *HPAScaleConstraints
+    Behavior      *HorizontalPodAutoscalerBehavior
 }
 ```
 
 #### HPA Controller State Changes
 
-To store not only scale down recommendations, we need to replace
-
-```golang
-    recommendations map[string][]timestampedRecommendation
-```
-
-with
-
-```golang
-    scaleUpRecommendations   map[string][]timestampedRecommendation
-    scaleDownRecommendations map[string][]timestampedRecommendation
-```
-
-To store the information about last scale action, the HPA need an additional field (similar to the list of “recommendations”)
+To store the history of scaling events, the HPA controller needs an additional field __(similar to the list of “recommendations”)__
 
 ```golang
 scaleEvents map[string][]timestampedScaleEvent
 ```
 
-Where
+where `timestampedScaleEvent` is
 
 ```golang
 type timestampedScaleEvent struct {
@@ -441,27 +432,29 @@ type timestampedScaleEvent struct {
 }
 ```
 
-It will store last scale events, and it will be used to make decisions about next scale events.
+It will store last scale events and will be used to make decisions about next scale actions.
 
 Say, if 30 seconds ago the number of replicas was increased by one, and we forbid to scale up for more than 1 pod per minute,
-then during the next 30 seconds, we won’t scale up again.
+then during the next 30 seconds, the HPA controller will not scale up the target again.
 
-If the HPA is restarted, the state information is lost so that it might scale the cluster instantly after the restart.
+If the controller is restarted, the state information is lost so the behavior is not guaranteed anymore and the 
+controller may scale a target instantly after the restart.
+
 Though, I don’t think this is a problem, as:
 
-- It shouldn’t happen often, or you have some cluster problem
+- It should not happen often, or you have some cluster problem
 - It requires quite a lot of time to start an HPA pod, for HPA pod to become live and ready, to get and process metrics.
 - If you have a large discrepancy between what is a desired number of replicas according to metrics and what is your current number of replicas and you DON’T want to scale - probably, you shouldn’t want to use the HPA. As the HPA goal is the opposite.
+- The stabilization algorithm already stores recommendations in memory and this has not yet been reported as an issue
+  so far.
 
 As the added parameters have default values, we don’t need to update the API version, and may stay on the same `pkg/apis/autoscaling/v2beta2`.
 
 #### Command Line Options Changes
 
-It should be noted that the
-current [--horizontal-pod-autoscaler-downscale-stabilization-window][] option
-defines the default value for the `constraints.scaleDown.delaySeconds`
-As it becomes part of the HPA specification, the option is not needed anymore.
-So we should make it obsolete.
+It should be noted that the current [--horizontal-pod-autoscaler-downscale-stabilization-window][] option defines the default value for the 
+`behavior.stabilizationWindowSeconds`. As it becomes part of the HPA specification, the option is not needed anymore.
+So we should make it obsolete but we should keep the existing flag till user have a chance to migrate.
 
 Check the [Default Values][] section for more information about how to determine the delay (priorities of options).
 

--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -385,7 +385,7 @@ For smooth transition it makes sense to set the following default values:
       - `policy = pods`
       - `periodSeconds = 60`, one minute period for scaleUp
       - `value = 4` which means the 4 replicas can be added every minute.
-- `behaviour.scaleDown.policies` has the following policies
+- `behavior.scaleDown.policies` has the following policies
   - Percentage Policy
     - `policy = percent`
     - `periodSeconds = 60` one minute period for scaleDown

--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -12,7 +12,7 @@ approvers:
 editor: TBD
 creation-date: 2019-03-07
 last-updated: 2019-09-16
-status: provisional
+status: implementable
 superseded-by:
 ---
 

--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -43,6 +43,7 @@ superseded-by:
         - [API Changes](#api-changes)
         - [HPA Controller State Changes](#hpa-controller-state-changes)
         - [Command Line Options Changes](#command-line-options-changes)
+- [Graduation Criteria](#graduation-criteria)
 
 <!-- /TOC -->
 
@@ -92,6 +93,7 @@ As a result, users cannot influence scale velocity, and that is a problem for ma
 ### Non-Goals
 
 - Persist the scaling events so that the HPA behavior is consistent even when the controller is restarted.
+- Add `tolerance` paramter to the new `behavior` section for both `scaleUp` and `scaleDown`
 
 ## Proposal
 
@@ -509,3 +511,8 @@ Check the [Default Values][] section for more information about how to determine
 
 [--horizontal-pod-autoscaler-downscale-stabilization-window]: https://v1-14.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details
 [DefaultValues]: #default-values
+
+## Graduation Criteria
+
+All the new configuration will be added to the `autoscaling/v2beta2` API which has not yet graduated to GA. So these changes do not need a separate
+Graduation Criteria and will be part of the existing beta API.

--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -93,7 +93,7 @@ As a result, users cannot influence scale velocity, and that is a problem for ma
 ### Non-Goals
 
 - Persist the scaling events so that the HPA behavior is consistent even when the controller is restarted.
-- Add `tolerance` paramter to the new `behavior` section for both `scaleUp` and `scaleDown`
+- Add `tolerance` parameter to the new `behavior` section for both `scaleUp` and `scaleDown`
 
 ## Proposal
 


### PR DESCRIPTION
I have update the proposal with changes to make the configurable scaling behavior more intuitive and in line with suggestions received during when this proposal was initial made #853 
The changes I have made are:

1. ~~Remove the `delaySeconds` options for scale down and scale up. This option is mean to prevent flapping of the replicas. But as suggested in the original PR this is a stabilization feature and I have changed the name to indicate this. I also believe there is no reason anyone would want to stabilize while scaling up. In fact this is non-intuitive because it looks similar to the `periodSeconds` use to specify the scaling rules. So now there is only one place where the `stabilizationWindow` can be specified and it is at the same level as the scale up and scale down behavior.~~ The `delaySeconds` field has been renamed to `stabilizationWindowSeconds`.
 2. Renamed the `constraints` field to `behavior` because this configuration specifies how scaling behaves. And also it could be used in the future to specify other aspects of scaling like the tolerances.
3. ~~Instead of specifying a `pod` and `percent` fields for scaling I have changed it to a single field called `maxAllowedChange`. This is similar to `maxSurge` and `maxUnavailable` in a deployment where the value is percent or absolute number of pods. I believe this more intuitive than have 2 fields and one of the values being chosen based on which one is higher at a certain point of time.~~ The `pod` and `percent` changes can be specified as a list of policies and the user can specify which policy will be selected based on evaluation at runtime.

__Note:__ There is one downside to the new scheme. It cannot replicate the current scale up behavior because the current behavior adds 4 pods if there are less than 4 pods and 100% of the pods after that. This behavior is currently unspecified in the documentation and probably nobody relies on it. Also this behavior will only change if the user explicitly uses the new `behavior` field.