### PR TITLE
Update SCTP KEP with Graduation Criteria

### DIFF
--- a/keps/sig-network/0015-20180614-SCTP-support.md
+++ b/keps/sig-network/0015-20180614-SCTP-support.md
@@ -9,10 +9,10 @@ reviewers:
   - "@thockin"
 approvers:
   - "@thockin"
-editor: "@janosi"
+editor: "@danwinship"
 creation-date: 2018-06-14
-last-updated: 2018-09-14
-status: implemented
+last-updated: 2019-09-20
+status: implementable
 see-also:
   - PR64973
 replaces:
@@ -49,10 +49,13 @@ superseded-by:
       - [Problem definition](#problem-definition)
       - [The solution in the Kubernetes SCTP support implementation](#the-solution-in-the-kubernetes-sctp-support-implementation)
   - [Risks and Mitigations](#risks-and-mitigations)
+- [Test Plan](#test-plan)
+  - [Basic tests](#basic-tests)
+  - [SCTP Connectivity Tests](#sctp-connectivity-tests)
 - [Graduation Criteria](#graduation-criteria)
+  - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
+  - [Beta -&gt; GA Graduation](#beta---ga-graduation)
 - [Implementation History](#implementation-history)
-- [Drawbacks [optional]](#drawbacks-optional)
-- [Alternatives [optional]](#alternatives-optional)
 <!-- /toc -->
 
 ## Summary
@@ -297,11 +300,107 @@ We describe in the Kubernetes documentation the mutually exclusive nature of use
 
 ### Risks and Mitigations
 
+## Test Plan
+
+Unlike with UDP and TCP, we can't necessarily just test that SCTP
+connections work, because some machines won't have the SCTP kernel
+module installed (or will have it blocked from being loaded). So we
+want to have some tests that are just "make sure kube-proxy, etc are
+doing what we expect them to" that can run everywhere, and then
+another set of "SCTP connections actually work" tests that are behind
+a separate feature tag.
+
+### Basic tests
+
+These will be tagged `[Feature:SCTP]`.
+
+- `"Pods, Services, and NetworkPolicies can declare SCTP ports"`
+
+  - Just checks that resources can be created using `SCTP` as a
+    `Protocol` value.
+
+- `"Pods can declare SCTP HostPorts when using kubenet"`
+
+  - Confirms that adding an SCTP HostPort creates an appropriate
+    iptables rule.
+
+  - Will be Skipped if SSH is not available or kubenet is not in use.
+
+- `"Services can declare SCTP ServicePorts when using the iptables proxier"`
+
+  - Confirms that appropriate iptables rules are created for SCTP
+    services.
+
+  - Will be Skipped if SSH is not available or the `iptables` proxier
+    is not in use.
+
+- `"A NetworkPolicy matching an SCTP port does not allow TCP or UDP
+  traffic [Feature:NetworkPolicy]"`
+
+If SSH is available, then each test will also ensure that if `sctp.ko`
+is not loaded before the test, then it is also not loaded after the
+test.
+
+Since the tests will initially require the `SCTPSupport` feature gate
+to be enabled, we will create a periodic job to run just the SCTP
+tests (and perhaps a few other network conformance tests, just to
+confirm that enabling SCTP does not break other things.) After SCTP
+reaches GA, the tests could run as part of the normal presubmit job
+and the periodic job could be retired.
+
+### SCTP Connectivity Tests
+
+These will be tagged "`[Feature:SCTPConnectivity]`". They can be run
+by network plugin developers but will not run as part of any of the
+standard Kubernetes test runs. They should all be marked
+`[Disruptive]` since they may cause the SCTP kernel module to be
+loaded, which may interfere with the Basic Tests' "make sure the SCTP
+kernel module doesn't get loaded" checks.
+
+We will need to vendor
+[github.com/ishidawataru/sctp](https://github.com/ishidawataru/sctp)
+and use it from `agnhost` and `e2e.test` to create SCTP client and
+server sockets.
+
+- `"A pod can connect directly to another pod via SCTP"`
+
+- `"A pod can connect to another pod via SCTP via a Service IP"`
+
+- `"A pod can connect to another pod via SCTP via a Load Balancer"`,
+
+  - Will be Skipped on bare metal, and clouds that don't support SCTP
+    LoadBalancers.
+
+- `"NetworkPolicy can be used to allow or deny traffic to SCTP ports
+  [Feature:NetworkPolicy]"`
+
 ## Graduation Criteria
+
+### Alpha -> Beta Graduation
+
+Graduation criteria:
+
+- The e2e tests described in the Test Plan have been written.
+
+- A periodic job has been created to run the "Basic Tests", and it
+  passes.
+
+### Beta -> GA Graduation
+
+Graduation criteria:
+
+- At least 2 out-of-tree network plugins can pass the
+  `[Feature:SCTPConnectivity]` tests.
+
+- Both `iptables` and `ipvs` proxiers have been demonstrated to work
+  with SCTP.
 
 ## Implementation History
 
-## Drawbacks [optional]
-
-## Alternatives [optional]
-
+- 2018-06-11 Initial [code PR](https://github.com/kubernetes/kubernetes/pull/64973)
+- 2018-06-16 Initial [KEP PR](https://github.com/kubernetes/community/pull/2276)
+- 2018-08-24 Initial KEP merged
+- 2018-08-28 Initial code merged
+- 2018-09-11 [Feature proposal](https://github.com/kubernetes/enhancements/issues/614) filed
+- 2018-09-27 Kubernetes 1.12.0 released with Alpha SCTP support
+- 2019-10-02 Test Plan and Graduation Criteria added


### PR DESCRIPTION
There don't seem to be any docs on what the KEP `status` values mean, but I assume it shouldn't be `implemented` until it's GA? So I bumped it back to `implementable`.

There are two "FIXME"s to figure out, plus I'm pretty unsure about the beta->GA criteria. (Especially the "2 implementations" part.)

/assign @thockin 
cc @kubernetes/sig-network-misc 