### PR TITLE
Update sig-scheduling owners.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -88,7 +88,7 @@ aliases:
     - wojtek-t
     - shyamjvs
   sig-scheduling-leads:
-    - bsalamat
+    - ahg-g
     - k82cn
   sig-service-catalog-leads:
     #- kibbles-n-bytes # not an org member


### PR DESCRIPTION
We updated the leads in [community ](https://github.com/kubernetes/community/pull/4051), but seems that it didn't get propagated to enhancements repo