### PR TITLE
Require Transition from Beta

### DIFF
--- a/keps/sig-architecture/1635-prevent-permabeta/README.md
+++ b/keps/sig-architecture/1635-prevent-permabeta/README.md
@@ -1,36 +1,5 @@
----
-title: Require Transition from Beta
-authors:
-  - "@deads2k"
-owning-sig: sig-architecture
-participating-sigs:
-  - sig-api-machinery
-  - sig-apps
-  - sig-architecture
-  - sig-auth
-  - sig-instrumentation
-  - sig-network
-  - sig-node
-  - sig-scheduling
-reviewers:
-  - "@bgrant0607"
-  - "@liggitt"
-  - "@smarterclayton"
-approvers:
-  - "@dims"
-  - "@derekwaynecarr"
-  - "@johnbelamaric"
-creation-date: 2019-10-01
-last-updated: 2020-03-23
-status: implementable
-see-also:
-replaces:
-superseded-by:
----
 
-# Require Transition from Beta
-
-## Table of Contents
+# KEP-1635: Require Transition from Beta
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
@@ -51,15 +20,22 @@ superseded-by:
 
 ## Release Signoff Checklist
 
-**ACTION REQUIRED:** In order to merge code into a release, there must be an issue in [kubernetes/enhancements] referencing this KEP and targeting a release milestone **before [Enhancement Freeze](https://github.com/kubernetes/sig-release/tree/master/releases)
+<!--
+**ACTION REQUIRED:** In order to merge code into a release, there must be an
+issue in [kubernetes/enhancements] referencing this KEP and targeting a release
+milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
 of the targeted release**.
 
-For enhancements that make changes to code or processes/procedures in core Kubernetes i.e., [kubernetes/kubernetes], we require the following Release Signoff checklist to be completed.
+For enhancements that make changes to code or processes/procedures in core
+Kubernetes i.e., [kubernetes/kubernetes], we require the following Release
+Signoff checklist to be completed.
 
-Check these off as they are completed for the Release Team to track. These checklist items _must_ be updated for the enhancement to be released.
+Check these off as they are completed for the Release Team to track. These
+checklist items _must_ be updated for the enhancement to be released.
+-->
 
-- [ ] kubernetes/enhancements issue in release milestone, which links to KEP (this should be a link to the KEP location in kubernetes/enhancements, not the initial KEP PR)
-- [ ] KEP approvers have set the KEP status to `implementable`
+- [ ] Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] KEP approvers have approved the KEP status as `implementable`
 - [ ] Design details are appropriately documented
 - [ ] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [ ] Graduation criteria is in place
@@ -67,14 +43,14 @@ Check these off as they are completed for the Release Team to track. These check
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
-**Note:** Any PRs to move a KEP to `implementable` or significant changes once it is marked `implementable` should be approved by each of the KEP approvers. If any of those approvers is no longer appropriate than changes to that list should be approved by the remaining approvers and/or the owning SIG (or SIG-arch for cross cutting KEPs).
-
+<!--
 **Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
 
 [kubernetes.io]: https://kubernetes.io/
-[kubernetes/enhancements]: https://github.com/kubernetes/enhancements/issues
-[kubernetes/kubernetes]: https://github.com/kubernetes/kubernetes
-[kubernetes/website]: https://github.com/kubernetes/website
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
 
 ## Summary
 

--- a/keps/sig-architecture/1635-prevent-permabeta/kep.yaml
+++ b/keps/sig-architecture/1635-prevent-permabeta/kep.yaml
@@ -1,0 +1,25 @@
+title: Require Transition from Beta
+kep-number: 1635
+authors:
+  - "@deads2k"
+owning-sig: sig-architecture
+participating-sigs:
+  - sig-api-machinery
+  - sig-apps
+  - sig-architecture
+  - sig-auth
+  - sig-instrumentation
+  - sig-network
+  - sig-node
+  - sig-scheduling
+status: implementable
+creation-date: 2019-10-01
+reviewers:
+  - "@bgrant0607"
+  - "@liggitt"
+  - "@smarterclayton"
+approvers:
+  - "@derekwaynecarr"
+  - "@johnbelamaric"
+see-also:
+replaces:

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -103,6 +103,19 @@ Once an API or feature reaches beta, it has six months to
 If neither of those conditions met, the beta API/feature is deprecated in the second release with a stated intent to remove the feature entirely.
 To avoid removal, the feature must create a new beta version (it cannot go directly from deprecated to GA).
 
+For example, in v1.16, v1beta1 is released. Sample release note and API doc:
+> * "The v1beta1 version of this API will be evaluated during v1.16 and v1.17, then deprecated in v1.18 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.21"
+
+Scenario A - progression to v1beta2 in v1.18. Sample release note and API doc:
+> * "The v1beta1 version of this API is deprecated in favor of v1beta2, and will be removed in v1.21"
+> * "The v1beta2 version of this API will be evaluated during v1.18 and v1.19, then deprecated in v1.20 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.23"
+
+Scenario B - progression to v1 in v1.18. Sample release note and API doc:
+> * "The v1beta1 version of this API is deprecated in favor of v1, and will be removed in v1.21"
+
+Scenario C - deprecation with no replacement. Sample release note and API doc:
+> * "The v1beta1 version of this API is deprecated with no replacement, and will be removed in v1.21"
+
 By regularly having new beta versions, we can ensure that consumers will not grow long running dependencies on particular betas which could pin design decisions.
 It will also create an incentive for feature authors to push their features to GA instead of letting them live in a permanent beta state. 
 

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -8,6 +8,7 @@ participating-sigs:
   - sig-apps
   - sig-architecture
   - sig-auth
+  - sig-instrumentation
   - sig-network
   - sig-node
   - sig-scheduling
@@ -20,7 +21,7 @@ approvers:
   - "@derekwaynecarr"
   - "@johnbelamaric"
 creation-date: 2019-10-01
-last-updated: 2020-03-19
+last-updated: 2020-03-23
 status: implementable
 see-also:
 replaces:
@@ -39,9 +40,9 @@ superseded-by:
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
 - [Impacted APIs](#impacted-apis)
-  - [sig-apimachinery](#sig-apimachinery)
   - [sig-apps](#sig-apps)
   - [sig-auth](#sig-auth)
+  - [sig-instrumentation](#sig-instrumentation)
   - [sig-network](#sig-network)
   - [sig-node](#sig-node)
   - [sig-scheduling](#sig-scheduling)
@@ -105,6 +106,7 @@ If we're honest with ourselves, a single actor has been cleaning up behind a lot
 2. Control non-k8s.io REST APIs.
 3. Control features that are not REST APIs.
 4. Control fields on otherwise GA REST APIs.
+   This will likely be a future goal, but it isn't the goal of this KEP.
 
 ## Proposal
 
@@ -114,6 +116,8 @@ Once a REST API reaches beta, it has nine months to
 
 If neither of those conditions met, the beta REST API is deprecated in the third release with a stated intent to remove the REST API entirely.
 To avoid removal, the REST API must create a new beta version (it cannot go directly from deprecated to GA).
+
+This means that every beta API will be deprecated in nine months and removed in 18 months.
 
 For example, in v1.16, v1beta1 is released. Sample release note and API doc:
 > * "The v1beta1 version of this API will be evaluated during v1.16, v1.17, and v1.18, then deprecated in v1.19 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.22"
@@ -135,15 +139,15 @@ It will also create an incentive for REST API authors to push their APIs to GA i
 These sigs will need to announce in 1.19 that these APIs will be deprecated no later than 1.22 and removed no later than 1.25.
 This is the same as the standard for new beta APIs introduced in 1.19.
 
-### sig-apimachinery
-1. events.v1beta1.events.k8s.io
-
 ### sig-apps
 1. cronjobs.v1beta1.batch
 
 ### sig-auth
 1. certificatesigningrequests.v1beta1.certificates.k8s.io
 2. podsecuritypolicies.v1beta1.policy
+
+### sig-instrumentation
+1. events.v1beta1.events.k8s.io
 
 ### sig-network
 1. endpointslices.v1beta1.discovery.k8s.io

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -14,7 +14,7 @@ approvers:
   - "@johnbelamaric"
 editor: TBD
 creation-date: 2019-10-01
-last-updated: 2019-10-10
+last-updated: 2019-10-22
 status: implementable
 see-also:
 replaces:
@@ -32,6 +32,7 @@ superseded-by:
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
+- [Drawbacks](#drawbacks)
 <!-- /toc -->
 
 ## Release Signoff Checklist
@@ -117,4 +118,8 @@ Scenario C - deprecation with no replacement. Sample release note and API doc:
 By regularly having new beta versions, we can ensure that consumers will not grow long running dependencies on particular betas which could pin design decisions.
 It will also create an incentive for REST API authors to push their APIs to GA instead of letting them live in a permanent beta state.
 
+## Drawbacks
 
+1. Consumers of beta APIs will be made aware of the status of the APIs and be given clear dates in documentation about
+when they will have to update.  If the maintainers of these beta APIs do not graduate their API, a new beta version will
+need to exist within 18-ish months and early adopters will have to update their manifests to the new version.  

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -1,0 +1,127 @@
+---
+title: Require Transition from Beta
+authors:
+  - "@deads2k"
+owning-sig: sig-architecture
+participating-sigs:
+reviewers:
+  - "@bgrant0607"
+  - "@liggitt"
+  - "@smarterclayton"
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2019-10-01
+last-updated: 2019-10-01
+status: implementable
+see-also:
+replaces:
+superseded-by:
+---
+
+# Require Transition from Beta
+
+## Table of Contents
+
+A table of contents is helpful for quickly jumping to sections of a KEP and for highlighting any additional information provided beyond the standard KEP template.
+
+Ensure the TOC is wrapped with <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code> tags, and then generate with `hack/update-toc.sh`.
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Drawbacks [optional]](#drawbacks-optional)
+- [Alternatives [optional]](#alternatives-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+**ACTION REQUIRED:** In order to merge code into a release, there must be an issue in [kubernetes/enhancements] referencing this KEP and targeting a release milestone **before [Enhancement Freeze](https://github.com/kubernetes/sig-release/tree/master/releases)
+of the targeted release**.
+
+For enhancements that make changes to code or processes/procedures in core Kubernetes i.e., [kubernetes/kubernetes], we require the following Release Signoff checklist to be completed.
+
+Check these off as they are completed for the Release Team to track. These checklist items _must_ be updated for the enhancement to be released.
+
+- [ ] kubernetes/enhancements issue in release milestone, which links to KEP (this should be a link to the KEP location in kubernetes/enhancements, not the initial KEP PR)
+- [ ] KEP approvers have set the KEP status to `implementable`
+- [ ] Design details are appropriately documented
+- [ ] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [ ] Graduation criteria is in place
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+**Note:** Any PRs to move a KEP to `implementable` or significant changes once it is marked `implementable` should be approved by each of the KEP approvers. If any of those approvers is no longer appropriate than changes to that list should be approved by the remaining approvers and/or the owning SIG (or SIG-arch for cross cutting KEPs).
+
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://github.com/kubernetes/enhancements/issues
+[kubernetes/kubernetes]: https://github.com/kubernetes/kubernetes
+[kubernetes/website]: https://github.com/kubernetes/website
+
+## Summary
+
+APIs and features should not languish in beta.  They should take feedback and progress towards GA by either
+1. meeting GA criteria and getting promoted, or
+2. having a new beta and deprecating the previous beta
+  
+This must happen within six months (two releases).  If it does not,
+the API will be deprecated with an announced intent to remove the feature per the deprecation policy.
+
+## Motivation
+
+When a feature reaches beta, it is turned on by default.  This is great for getting feedback, but it can also lead to state
+where users and vendors start building important infrastructure against APIs that are not considered stable.
+In addition, once a feature is on by default, the incentive to further stabilize appears to diminish.
+See the features that have been beta for a long time: CSRs and Ingresses as examples.
+If we're honest with ourselves, a single actor has been cleaning up behind a lot of the project to unstick perma-beta APIs.
+
+[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
+
+### Goals
+
+1. Prevent APIs and features from being in a single beta version for more than six months.
+2. Prevent beta APIs from being treated as GA by users and vendors.
+
+### Non-Goals
+
+1. Promote APIs to GA before they are ready.
+
+## Proposal
+
+Once an API or feature reaches beta, it has six months to 
+1. reach GA and deprecate the beta or 
+2. have a new beta version and deprecate the previous beta.
+
+If neither of those conditions met, the beta API/feature is deprecated in the second release with a stated intent to remove the feature entirely.
+To avoid removal, the feature must create a new beta version (it cannot go directly from deprecated to GA).
+
+By regularly having new beta versions, we can ensure that consumers will not grow long running dependencies on particular betas which could pin design decisions.
+It will also create an incentive for feature authors to push their features to GA instead of letting them live in a permanent beta state. 
+
+### Risks and Mitigations
+
+What are the risks of this proposal and how do we mitigate.
+Think broadly.
+For example, consider both security and how this will impact the larger kubernetes ecosystem.
+
+How will security be reviewed and by whom?
+How will UX be reviewed and by whom?
+
+Consider including folks that also work outside the SIG or subproject.
+
+## Drawbacks [optional]
+
+Why should this KEP _not_ be implemented.
+
+## Alternatives [optional]
+
+Similar to the `Drawbacks` section the `Alternatives` section is used to highlight and record other possible approaches to delivering the value proposed by a KEP.
+

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -4,6 +4,13 @@ authors:
   - "@deads2k"
 owning-sig: sig-architecture
 participating-sigs:
+  - sig-api-machinery
+  - sig-apps
+  - sig-architecture
+  - sig-auth
+  - sig-network
+  - sig-node
+  - sig-scheduling
 reviewers:
   - "@bgrant0607"
   - "@liggitt"
@@ -12,9 +19,8 @@ approvers:
   - "@dims"
   - "@derekwaynecarr"
   - "@johnbelamaric"
-editor: TBD
 creation-date: 2019-10-01
-last-updated: 2019-10-22
+last-updated: 2020-03-19
 status: implementable
 see-also:
 replaces:
@@ -32,6 +38,13 @@ superseded-by:
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
+- [Impacted APIs](#impacted-apis)
+  - [sig-apimachinery](#sig-apimachinery)
+  - [sig-apps](#sig-apps)
+  - [sig-auth](#sig-auth)
+  - [sig-network](#sig-network)
+  - [sig-node](#sig-node)
+  - [sig-scheduling](#sig-scheduling)
 - [Drawbacks](#drawbacks)
 <!-- /toc -->
 
@@ -117,6 +130,35 @@ Scenario C - deprecation with no replacement. Sample release note and API doc:
 
 By regularly having new beta versions, we can ensure that consumers will not grow long running dependencies on particular betas which could pin design decisions.
 It will also create an incentive for REST API authors to push their APIs to GA instead of letting them live in a permanent beta state.
+
+## Impacted APIs
+These sigs will need to announce in 1.19 that these APIs will be deprecated no later than 1.22 and removed no later than 1.25.
+This is the same as the standard for new beta APIs introduced in 1.19.
+
+### sig-apimachinery
+1. events.v1beta1.events.k8s.io
+
+### sig-apps
+1. jobtemplates.v1beta1.batch
+2. cronjobs.v1beta1.batch
+
+### sig-auth
+1. certificatesigningrequests.v1beta1.certificates.k8s.io
+2. podsecuritypolicies.v1beta1.policy
+
+### sig-network
+1. endpointslices.v1beta1.discovery.k8s.io
+2. ingresses.v1beta1.networking.k8s.io
+3. ingressclasses.v1beta1.networking.k8s.io
+
+### sig-node
+1. runtimeclasses.v1beta1.node.k8s.io
+
+### sig-scheduling
+1. poddisruptionbudgets.v1beta1.policy
+2. evictions.v1beta1.policy
+
+
 
 ## Drawbacks
 

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -9,10 +9,12 @@ reviewers:
   - "@liggitt"
   - "@smarterclayton"
 approvers:
-  - TBD
+  - "@dims"
+  - "@derekwaynecarr"
+  - "@johnbelamaric"
 editor: TBD
 creation-date: 2019-10-01
-last-updated: 2019-10-01
+last-updated: 2019-10-10
 status: implementable
 see-also:
 replaces:
@@ -23,10 +25,6 @@ superseded-by:
 
 ## Table of Contents
 
-A table of contents is helpful for quickly jumping to sections of a KEP and for highlighting any additional information provided beyond the standard KEP template.
-
-Ensure the TOC is wrapped with <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code> tags, and then generate with `hack/update-toc.sh`.
-
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
 - [Summary](#summary)
@@ -34,9 +32,6 @@ Ensure the TOC is wrapped with <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
-  - [Risks and Mitigations](#risks-and-mitigations)
-- [Drawbacks [optional]](#drawbacks-optional)
-- [Alternatives [optional]](#alternatives-optional)
 <!-- /toc -->
 
 ## Release Signoff Checklist
@@ -68,73 +63,58 @@ Check these off as they are completed for the Release Team to track. These check
 
 ## Summary
 
-APIs and features should not languish in beta.  They should take feedback and progress towards GA by either
+k8s.io REST APIs should not languish in beta.  They should take feedback and progress towards GA by either
 1. meeting GA criteria and getting promoted, or
 2. having a new beta and deprecating the previous beta
   
-This must happen within six months (two releases).  If it does not,
-the API will be deprecated with an announced intent to remove the feature per the deprecation policy.
+This must happen within nine months (three releases).  If it does not,
+the REST API will be deprecated with an announced intent to remove the API per the [deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).
 
 ## Motivation
 
-When a feature reaches beta, it is turned on by default.  This is great for getting feedback, but it can also lead to state
+When a REST API reaches beta, it is turned on by default.  This is great for getting feedback, but it can also lead to state
 where users and vendors start building important infrastructure against APIs that are not considered stable.
-In addition, once a feature is on by default, the incentive to further stabilize appears to diminish.
-See the features that have been beta for a long time: CSRs and Ingresses as examples.
+In addition, once a REST API is on by default, the incentive to further stabilize appears to diminish.
+See the REST API that have been beta for a long time: CSRs and Ingresses as examples.
 If we're honest with ourselves, a single actor has been cleaning up behind a lot of the project to unstick perma-beta APIs.
 
 [experience reports]: https://github.com/golang/go/wiki/ExperienceReports
 
 ### Goals
 
-1. Prevent APIs and features from being in a single beta version for more than six months.
+1. Prevent k8s.io REST APIs from being in a single beta version for more than nine months.
 2. Prevent beta APIs from being treated as GA by users and vendors.
 
 ### Non-Goals
 
 1. Promote APIs to GA before they are ready.
+2. Control non-k8s.io REST APIs.
+3. Control features that are not REST APIs.
+4. Control fields on otherwise GA REST APIs.
 
 ## Proposal
 
-Once an API or feature reaches beta, it has six months to 
+Once a REST API reaches beta, it has nine months to 
 1. reach GA and deprecate the beta or 
 2. have a new beta version and deprecate the previous beta.
 
-If neither of those conditions met, the beta API/feature is deprecated in the second release with a stated intent to remove the feature entirely.
-To avoid removal, the feature must create a new beta version (it cannot go directly from deprecated to GA).
+If neither of those conditions met, the beta REST API is deprecated in the second release with a stated intent to remove the REST API entirely.
+To avoid removal, the REST API must create a new beta version (it cannot go directly from deprecated to GA).
 
 For example, in v1.16, v1beta1 is released. Sample release note and API doc:
-> * "The v1beta1 version of this API will be evaluated during v1.16 and v1.17, then deprecated in v1.18 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.21"
+> * "The v1beta1 version of this API will be evaluated during v1.16, v1.17, and v1.18, then deprecated in v1.19 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.22"
 
-Scenario A - progression to v1beta2 in v1.18. Sample release note and API doc:
-> * "The v1beta1 version of this API is deprecated in favor of v1beta2, and will be removed in v1.21"
-> * "The v1beta2 version of this API will be evaluated during v1.18 and v1.19, then deprecated in v1.20 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.23"
+Scenario A - progression to v1beta2 in v1.19. Sample release note and API doc:
+> * "The v1beta1 version of this API is deprecated in favor of v1beta2, and will be removed in v1.22"
+> * "The v1beta2 version of this API will be evaluated during v1.19, v1.20, and v1.21, then deprecated in v1.22 (in favor of a new beta version, a GA version, or with no replacement), then removed in v1.25"
 
-Scenario B - progression to v1 in v1.18. Sample release note and API doc:
-> * "The v1beta1 version of this API is deprecated in favor of v1, and will be removed in v1.21"
+Scenario B - progression to v1 in v1.19. Sample release note and API doc:
+> * "The v1beta1 version of this API is deprecated in favor of v1, and will be removed in v1.22"
 
 Scenario C - deprecation with no replacement. Sample release note and API doc:
-> * "The v1beta1 version of this API is deprecated with no replacement, and will be removed in v1.21"
+> * "The v1beta1 version of this API is deprecated with no replacement, and will be removed in v1.22"
 
 By regularly having new beta versions, we can ensure that consumers will not grow long running dependencies on particular betas which could pin design decisions.
-It will also create an incentive for feature authors to push their features to GA instead of letting them live in a permanent beta state. 
+It will also create an incentive for REST API authors to push their APIs to GA instead of letting them live in a permanent beta state.
 
-### Risks and Mitigations
-
-What are the risks of this proposal and how do we mitigate.
-Think broadly.
-For example, consider both security and how this will impact the larger kubernetes ecosystem.
-
-How will security be reviewed and by whom?
-How will UX be reviewed and by whom?
-
-Consider including folks that also work outside the SIG or subproject.
-
-## Drawbacks [optional]
-
-Why should this KEP _not_ be implemented.
-
-## Alternatives [optional]
-
-Similar to the `Drawbacks` section the `Alternatives` section is used to highlight and record other possible approaches to delivering the value proposed by a KEP.
 

--- a/keps/sig-architecture/20191001-prevent-permabeta.md
+++ b/keps/sig-architecture/20191001-prevent-permabeta.md
@@ -112,7 +112,7 @@ Once a REST API reaches beta, it has nine months to
 1. reach GA and deprecate the beta or 
 2. have a new beta version and deprecate the previous beta.
 
-If neither of those conditions met, the beta REST API is deprecated in the second release with a stated intent to remove the REST API entirely.
+If neither of those conditions met, the beta REST API is deprecated in the third release with a stated intent to remove the REST API entirely.
 To avoid removal, the REST API must create a new beta version (it cannot go directly from deprecated to GA).
 
 For example, in v1.16, v1beta1 is released. Sample release note and API doc:
@@ -139,8 +139,7 @@ This is the same as the standard for new beta APIs introduced in 1.19.
 1. events.v1beta1.events.k8s.io
 
 ### sig-apps
-1. jobtemplates.v1beta1.batch
-2. cronjobs.v1beta1.batch
+1. cronjobs.v1beta1.batch
 
 ### sig-auth
 1. certificatesigningrequests.v1beta1.certificates.k8s.io
@@ -156,9 +155,6 @@ This is the same as the standard for new beta APIs introduced in 1.19.
 
 ### sig-scheduling
 1. poddisruptionbudgets.v1beta1.policy
-2. evictions.v1beta1.policy
-
-
 
 ## Drawbacks
 


### PR DESCRIPTION
When a feature reaches beta, it is turned on by default.  This is great for getting feedback, but it can also lead to state where users and vendors start building important infrastructure against APIs that are not considered stable. In addition, once a feature is on by default, the incentive to further stabilize appears to diminish. See the features that have been beta for a long time: CSRs as a for instance.

APIs and features should not languish in beta.  They should take feedback and progress towards GA by either
1. meeting GA criteria and getting promoted, or
2. having a new beta and deprecating the previous beta
  
This must happen within six months (two releases).  If it does not, the API will be deprecated with an announced intent to remove the feature per the deprecation policy.

@kubernetes/sig-architecture-api-reviews @kubernetes/api-approvers 
@liggitt @bgrant0607 @smarterclayton @derekwaynecarr 