### PR TITLE
Add dual-stack phase 3 details

### DIFF
--- a/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
+++ b/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
@@ -546,7 +546,7 @@ For the test that checks pod internet connectivity, the IPv4 and IPv6 tests can 
 
 
 ## Implementation History
-\<TBD\>
+Refer to the [Implementation Plan](#implementation-plan)
 
 ## Alternatives
 

--- a/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
+++ b/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Dual Stack Support
+title: Kubernetes Dual-stack Support
 authors:
   - "leblancd@"
   - "rpothier@"
@@ -15,11 +15,11 @@ approvers:
   - "thockin@"
 editor: TBD
 creation-date: 2018-05-21
-last-updated: 2019-05-02
+last-updated: 2019-09-29
 status: implementable
 ---
 
-# IPv4/IPv6 Dual Stack
+# IPv4/IPv6 Dual-stack
 
 ## Table of Contents
 
@@ -44,17 +44,8 @@ status: implementable
     - ['kubectl get pods -o wide' Command Display for Dual-Stack Pod Addresses](#kubectl-get-pods--o-wide-command-display-for-dual-stack-pod-addresses)
     - ['kubectl describe pod ...' Command Display for Dual-Stack Pod Addresses](#kubectl-describe-pod--command-display-for-dual-stack-pod-addresses)
   - [Container Networking Interface (CNI) Plugin Considerations](#container-networking-interface-cni-plugin-considerations)
+  - [Services](#services)
   - [Endpoints](#endpoints)
-    - [Versioned API Change: EndpointAddress v1 core](#versioned-api-change-endpointaddress-v1-core)
-      - [Default Endpoint IP Selection](#default-endpoint-ip-selection)
-    - [EndpointAddress Internal Representation](#endpointaddress-internal-representation)
-    - [Maintaining Compatible Interworking between Old and New Clients](#maintaining-compatible-interworking-between-old-and-new-clients-1)
-      - [V1 to Core (Internal) Conversion](#v1-to-core-internal-conversion-1)
-      - [Core (Internal) to V1 Conversion](#core-internal-to-v1-conversion-1)
-    - [Configuration of Endpoint IP Family in Service Definitions](#configuration-of-endpoint-ip-family-in-service-definitions)
-    - [Modifying Consumers of EndpointAddress API to Use Dual-Stack Addresses](#modifying-consumers-of-endpointaddress-api-to-use-dual-stack-addresses)
-    - ['kubectl get endpoints' Command Display for Dual-Stack Backend Pods](#kubectl-get-endpoints-command-display-for-dual-stack-backend-pods)
-    - ['kubectl describe service' Command Display for Dual-Stack Backend Pods](#kubectl-describe-service-command-display-for-dual-stack-backend-pods)
   - [kube-proxy Operation](#kube-proxy-operation)
     - [Kube-Proxy Startup Configuration Changes](#kube-proxy-startup-configuration-changes)
       - [Multiple bind addresses configuration](#multiple-bind-addresses-configuration)
@@ -78,20 +69,19 @@ status: implementable
   - [End-to-End Test Support](#end-to-end-test-support)
   - [User Stories](#user-stories)
   - [Risks and Mitigations](#risks-and-mitigations)
-- [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
 - [Alternatives](#alternatives)
-  - [Dual Stack at the Edge](#dual-stack-at-the-edge)
-  - [Variation: Dual-Stack Service CIDRs (a.k.a. Full Dual Stack)](#variation-dual-stack-service-cidrs-aka-full-dual-stack)
+  - [Dual-stack at the Edge](#dual-stack-at-the-edge)
+  - [Variation: Dual-Stack Service CIDRs (a.k.a. Full Dual-stack)](#variation-dual-stack-service-cidrs-aka-full-dual-stack)
     - [Benefits](#benefits)
     - [Changes Required](#changes-required)
 - [Test Plan](#test-plan)
-- [Graduation Criteria](#graduation-criteria-1)
+- [Graduation Criteria](#graduation-criteria)
 <!-- /toc -->
 
 ## Summary
 
-This proposal adds IPv4/IPv6 dual stack functionality to Kubernetes clusters. This includes the following concepts:
+This proposal adds IPv4/IPv6 dual-stack functionality to Kubernetes clusters. This includes the following concepts:
 - Awareness of multiple IPv4/IPv6 address assignments per pod
 - Native IPv4-to-IPv4 in parallel with IPv6-to-IPv6 communications to, from, and within a cluster
 
@@ -105,9 +95,9 @@ The adoption of IPv6 has increased in recent years, and customers are requesting
 
 For scenarios that require legacy IPv4-only clients or services (either internal or external to the cluster), the above restrictions mean that complex and expensive IPv4/IPv6 transition mechanisms (e.g. NAT64/DNS64, stateless NAT46, or SIIT/MAP) will need to be implemented in the data center networking.
 
-One alternative to adding transition mechanisms would be to modify Kubernetes to provide support for IPv4 and IPv6 communications in parallel, for both pods and services, throughout the cluster (a.k.a. "full" dual stack).
+One alternative to adding transition mechanisms would be to modify Kubernetes to provide support for IPv4 and IPv6 communications in parallel, for both pods and services, throughout the cluster (a.k.a. "full" dual-stack).
 
-A second, simpler alternative, which is a variation to the "full" dual stack model, would be to provide dual stack addresses for pods and nodes, but restrict service IPs to be single-family (i.e. allocated from a single service CIDR). In this case, service IPs in a cluster would be either all IPv4 or all IPv6, as they are now. Compared to a full dual-stack approach, this "dual-stack pods / single-family services" approach saves on implementation complexity, but would introduce some minor feature restrictions. (For more details on these tradeoffs, please refer to the "Variation: Dual-Stack Service CIDRs" section under "Alternatives" below).
+A second, simpler alternative, which is a variation to the "full" dual-stack model, would be to provide dual-stack addresses for pods and nodes, but restrict service IPs to be single-family (i.e. allocated from a single service CIDR). In this case, service IPs in a cluster would be either all IPv4 or all IPv6, as they are now. Compared to a full dual-stack approach, this "dual-stack pods / single-family services" approach saves on implementation complexity, but would introduce some minor feature restrictions. (For more details on these tradeoffs, please refer to the "Variation: Dual-Stack Service CIDRs" section under "Alternatives" below).
 
 This proposal aims to add "dual-stack pods / single-family services" support to Kubernetes clusters, providing native IPv4-to-IPv4 communication and native IPv6-to-IPv6 communication to, from and within a Kubernetes cluster.
 
@@ -125,12 +115,12 @@ This proposal aims to add "dual-stack pods / single-family services" support to 
 - Service CIDRs: Dual-stack service CIDRs will not be supported for this proposal. Service access within a cluster will be done via all IPv4 service IPs or all IPv6 service IPs.
 - Single-Family Applications: There may be some some clients or applications that only work with (bind to) IPv4 or or only work with (bind to) IPv6. A cluster can support either IPv4-only applications or IPv6-only applications (not both), depending upon the cluster CIDR's IP family. For example, if a cluster uses an IPv6 service CIDR, then IPv6-only applications will work fine, but IPv4-only applications in that cluster will not have IPv4 service IPs (and corresponding DNS A records) with which to access Kubernetes services. If a cluster needs to support legacy IPv4-only applications, but not IPv6-only applications, then the cluster should be configured with an IPv4 service CIDR.
 - Cross-family connectivity: IPv4-to-IPv6 and IPv6-to-IPv4 connectivity is considered outside of the scope of this proposal. (As a possible future enhancement, the Kubernetes NGINX ingress controller could be modified to load balance to both IPv4 and IPv6 addresses for each endpoint. With such a change, it's possible that an external IPv4 client could access a Kubernetes service via an IPv6 pod address, and vice versa).
-- CNI network plugins: Some plugins other than the Bridge, PTP, and Host-Local IPAM plugins may support Kubernetes dual stack, but the development and testing of dual stack support for these other plugins is considered outside of the scope of this proposal.
+- CNI network plugins: Some plugins other than the Bridge, PTP, and Host-Local IPAM plugins may support Kubernetes dual-stack, but the development and testing of dual-stack support for these other plugins is considered outside of the scope of this proposal.
 - Multiple IPs vs. Dual-Stack: Code changes will be done in a way to facilitate future expansion to more general multiple-IPs-per-pod and multiple-IPs-per-node support. However, this initial release will impose "dual-stack-centric" IP address limits as follows:
   - Pod addresses: 1 IPv4 address and 1 IPv6 addresses per pod maximum
   - Node addresses: 1 IPv4 address and 1 IPv6 addresses per node maximum
   - Service addresses: 1 service IP address per service
-- Kube-DNS is expected to be End-of-Life soon, so dual-stack testing will be performed using coreDNS.
+- Dual-stack service discovery testing will be performed using coreDNS.
 - External load balancers that rely on Kubernetes services for load balancing functionality will only work with the IP family that matches the IP family of the cluster's service CIDR.
 - Dual-stack support for Kubernetes orchestration tools other than kubeadm (e.g. miniKube, KubeSpray, etc.) are considered outside of the scope of this proposal. Communication about how to enable dual-stack functionality will be documented appropriately in-order so that aformentioned tools may choose to enable it for use.
 
@@ -140,37 +130,48 @@ In order to support dual-stack in Kubernetes clusters, Kubernetes needs to have 
 
 - Kubernetes needs to be made aware of multiple IPs per pod (limited to one IPv4 and one IPv6 address per pod maximum).
 - Link Local Addresses (LLAs) on a pod will remain implicit (Kubernetes will not display nor track these addresses).
-- For simplicity, only a single family of service IPs per cluster will be supported (i.e. service IPs are either all IPv4 or all IPv6).
-- Backend pods for a service can be dual stack.
-- Endpoints for a dual-stack backend pod will be represented as a dual-stack address pair (i.e. 1 IPv4/IPv6 endpoint per backend pod, rather than 2 single-family endpoints per backend pod)
+- Service Cluster IP Range `--service-cluster-ip-range=` will support the configuration of one IPv4 and one IPV6 address block) 
+- Service IPs will be allocated from only a single family (either IPv4 or IPv6 as specificate in the Service `spec.ipFamily` OR the first configured address block defined via `--service-cluster-ip-range=`).
+- Backend pods for a service can be dual-stack.
+- Endpoints addresses will match the address family of the Service IP address family (eg. An IPv6 Service IP will only have IPv6 Endpoints)
 - Kube-proxy iptables mode needs to drive iptables and ip6tables in parallel. This is required, even though service IP support is single-family, so that Kubernetes services can be exposed to clients external to the cluster via both IPv4 and IPv6. Support includes:
-  - Service IPs: Single family support (either all IPv4 or all IPv6 service IPs in a cluster)
+  - Service IPs: IPv4 and IPv6 family support
   - NodePort: Support listening on both IPv4 and IPv6 addresses
   - ExternalIPs: Can be IPv4 or IPv6
-- Kube-proxy IPVS mode will support dual-stack functionality similar to kube-proxy iptables mode as described above. IPVS kube-router support for dual stack, on the other hand, is considered outside of the scope of this proposal.
+- Kube-proxy IPVS mode will support dual-stack functionality similar to kube-proxy iptables mode as described above. IPVS kube-router support for dual-stack, on the other hand, is considered outside of the scope of this proposal.
 - For health/liveness/readiness probe support, the default behavior will not change and an additional optional field would be added to the pod specification and is respected by kubelet. This will allow application developers to select a preferred IP family to use for implementing probes on dual-stack pods.
-- The pod status API changes will include a per-IP string map for arbitrary annotations, as a placeholder for future Kubernetes enhancements. This mapping is not required for this dual-stack design, but will allow future annotations, e.g. allowing a CNI network plugin to indicate to which network a given IP address applies. The approriate hooks will be provided to enable CRI/CNI to provide these details.
+- The pod status API changes will include a per-IP string map for arbitrary annotations, as a placeholder for future Kubernetes enhancements. This mapping is not required for this dual-stack design, but will allow future annotations, e.g. allowing a CNI network plugin to indicate to which network a given IP address applies. The appropriate hooks will be provided to enable CRI/CNI to provide these details.
 - Kubectl commands and output displays will need to be modified for dual-stack.
 - Kubeadm support will need to be added to enable spin-up of dual-stack clusters. Kubeadm support is required for implementing dual-stack continuous integration (CI) tests.
 - New e2e test cases will need to be added to test parallel IPv4/IPv6 connectivity between pods, nodes, and services.
 
 ### Implementation Plan
 
-Given the scope of this enhancement, it has been suggested that we break the implementation into descrete phases that may be spread out over the span of many release cycles. The phases are as follows:
+Given the scope of this enhancement, it has been suggested that we break the implementation into discrete phases that may be spread out over the span of many release cycles. The phases are as follows:
 
-Phase 1
+Phase 1 (Kubernetes 1.16)
 - API type modifications
    - Kubernetes types
    - CRI types
 - dual-stack pod networking (multi-IP pod)
 - kubenet multi-family support
 
-Phase 2
+Phase 2 (Kubernetes 1.16)
 - Multi-family services including kube-proxy
 - Working with a CNI provider to enable dual-stack support
 - Change kubelet prober to support multi-address
 - Update component flags to support multiple `--bind-address`
 
+Phase 3 (Planned Kubernetes 1.17)
+- Kube-proxy iptables support for dual-stack
+- Downward API support for Pod.Status.PodIPs
+- Test e2e CNI plugin support for dual-stack
+- Pod hostfile support for IPv6 interface address
+- Kind support for dual-stack
+- e2e testing
+- EndpointSlice API support in kube-proxy for dual-stack (IPVS and iptables)
+- Dual-stack support for kubeadm
+- Expand container runtime support (containerd, CRI-O)
 
 - External dependencies, eg. cloud-provide, CNI, CRI, CoreDNS etc...
 
@@ -232,7 +233,7 @@ In order to maintain backwards compatibility for the core V1 API, this proposal 
 ```
 
 ##### Default Pod IP Selection
-Older servers and clients that were built before the introduction of full dual stack will only be aware of and make use of the original, singular PodIP field above. It is therefore considered to be the default IP address for the pod. When the PodIP and PodIPs fields are populated, the PodIPs[0] field must match the (default) PodIP entry. If a pod has both IPv4 and IPv6 addresses allocated, then the IP address chosen as the default IP address will match the IP family of the cluster's configured service CIDR. For example, if the service CIDR is IPv4, then the IPv4 address will be used as the default address.
+Older servers and clients that were built before the introduction of full dual-stack will only be aware of and make use of the original, singular PodIP field above. It is therefore considered to be the default IP address for the pod. When the PodIP and PodIPs fields are populated, the PodIPs[0] field must match the (default) PodIP entry. If a pod has both IPv4 and IPv6 addresses allocated, then the IP address chosen as the default IP address will match the IP family of the cluster's configured service CIDR. For example, if the service CIDR is IPv4, then the IPv4 address will be used as the default address.
 
 #### PodStatus Internal Representation
 The PodStatus internal representation will be modified to use a slice of PodIPInfo structs rather than a singular IP ("PodIP"):
@@ -290,22 +291,33 @@ The existing "cluster-cidr" option for the [kube-proxy startup configuration](ht
 Only the first address of each IP family will be used; all others will be logged and ignored.
 
 #### 'kubectl get pods -o wide' Command Display for Dual-Stack Pod Addresses
-The output for the 'kubectl get pods -o wide' command will need to be modified to display a comma-separated list of IPs for each pod, e.g.:
+The output for the 'kubectl get pods -o wide' command will not need modification and will only display the primary pod IP address as determined by the first IP address block configured via the `--cluster-cidr=` on kube-controller-manager. eg. The following is expected output for a cluster is configured with an IPv4 address block as the first configured via the `--cluster-cidr=` on kube-controller-manager:
 ```
        kube-master# kubectl get pods -o wide
        NAME               READY     STATUS    RESTARTS   AGE       IP                          NODE
-       nginx-controller   1/1       Running   0          20m       fd00:db8:1::2,192.168.1.3   kube-minion-1
+       nginx-controller   1/1       Running   0          20m       10.244.2.7                  n01
+       kube-master#
+```
+
+For comparison, here expected output for a cluster is configured with an IPv6 address block as the first configured via the `--cluster-cidr=` on kube-controller-manager:
+```
+       kube-master# kubectl get pods -o wide
+       NAME               READY     STATUS    RESTARTS   AGE       IP                          NODE
+       nginx-controller   1/1       Running   0          20m       fd00:db8:1::2               n01
        kube-master#
 ```
 
 #### 'kubectl describe pod ...' Command Display for Dual-Stack Pod Addresses
-The output for the 'kubectl describe pod ...' command will need to be modified to display a comma-separated list of IPs for each pod, e.g.:
+The output for the 'kubectl describe pod ...' command will need to be modified to display a list of IPs for each pod, e.g.:
 ```
        kube-master# kubectl describe pod nginx-controller
        .
        .
        .
-       IPs:     fd00:db8:1::2,192.168.1.3
+        IP:           10.244.2.7
+        IPs:
+          IP:           10.244.2.7
+          IP:           fd00:200::7
        .
        .
        .
@@ -316,151 +328,53 @@ The output for the 'kubectl describe pod ...' command will need to be modified t
 This feature requires the use of the [CNI Networking Plugin API version 0.3.1](https://github.com/containernetworking/cni/blob/spec-v0.3.1/SPEC.md)
 or later. The dual-stack feature requires no changes to this API.
 
-The versions of CNI plugin binaries that must be used for proper dual-stack functionality (and IPv6 functionality in general) depend upon the version of Docker that is used in the cluster nodes (see [CNI issue #531](https://github.com/containernetworking/cni/issues/531) and [CNI plugins PR #113](https://github.com/containernetworking/plugins/pull/113)):
-- Docker versions 17.03 or older require CNI plugin binaries version 0.6.0 or newer
-- Docker versions newer than 17.03 require CNI plugin binaries that are Version 0.7.0 or newer.
+The versions of CNI plugin binaries that must be used for proper dual-stack functionality (and IPv6 functionality in general) depend upon the version of the container runtime that is used in the cluster nodes (see [CNI issue #531](https://github.com/containernetworking/cni/issues/531) and [CNI plugins PR #113](https://github.com/containernetworking/plugins/pull/113)):
 
-### Endpoints
+### Services
 
-The current [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core) (i.e. before the addition of the dual stack feature), supports only a single IP address per endpoint. With the addition of the dual stack feature, pods serving as backends for Kubernetes services may now have both IPv4 and IPv6 addresses. This presents a design choice of how to represent such dual-stack endpoints in the Endpoints API. Two choices worth considering would be:
-- 2 single-family endpoints per backend pod: Make no change to the [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core). Treat each IPv4/IPv6 address as separate, distinct endpoints, and include each address in the comma-separated list of addresses in an 'Endpoints' API object.
-- 1 dual-stack endpoint per backend pod: Modify the [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core) so that each endpoint can be associated with a pair of IPv4/IPv6 addresses.
+Services will only be assigned an address from a single address family (either IPv4 or IPv6). The address family for the Service’s cluster IP is determined by setting the field, `.spec.ipFamily`, on that Service. You can only set this field when creating a new Service. Setting the `.spec.ipFamily` field is optional and should only be used if you plan to enable IPv4 and IPv6 Services and Ingresses on your cluster. The configuration of this field not a requirement for egress traffic. The default address family for your cluster is the address family of the first service cluster IP range configured via the `--service-cluster-ip-range` flag to the kube-controller-manager. The `.spec.ipFamily` field can be set to either IPv4 or IPv6.
 
-Although the first approach would be simpler and quicker to implement, providing two endpoints per backend pod would be problematic for the following ways in which endpoints are used in Kubernetes:
-- Distributed applications use endpoints for peer discovery.
-- Monitoring systems such as Prometheus use endpoints to identify monitoring targets.
-- Users use endpoints to determine how many instances are up.
+For example, the following Service specification includes the `spec.ipFamily` field. Kubernetes will assign an IPv6 address (also known as a “cluster IP”) from the configured service-cluster-ip-range to this Service.
 
-In order to avoid breaking the above uses of the Endpoints API, this design proposes modifying the [Kubernetes EndpointAddress API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpointaddress-v1-core) to support inclusion of both an IPv4 and an IPv6 address to be associated with a given endpoint.
-
-Note that this proposed change retains the singular sense of the API object name "EndpointAddress", even though the object may contain a pair of IPv4/IPv6 addresses. This can be considered a tradeoff in design simplification over clarity. The alternative would be to create a new API object called "EndpointAddresses" (similar to the "EndpointAddress" object, but with multiple IP addresses), and then modify the [Kubernetes EndpointSubset API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpointsubset-v1-core) to include both the existing "EndpointAddress" object and a new "EndpointAddresses" object (for backwards compatibility).
-
-#### Versioned API Change: EndpointAddress v1 core
-In order to maintain backwards compatibility for the core V1 API, this proposal retains the existing (singular) "IP" field in the core V1 version of the [Kubernetes EndpointAddress API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpointaddress-v1-core), and adds a new slice of strings called "IPs" for recording multiple IPs associated with an endpoint:
-```
-// EndpointAddress is a tuple that describes one or more IP addresses for an
-// endpoint.
- type EndpointAddress struct {
-     // The default IP for this endpoint.
-     IP string `json:"ip" protobuf:"bytes,1,opt,name=ip"`
-     // The IPs for this endpoint. The zeroth element (IPs[0] must match
-     // the default value set in the IP field)
-     IPs []string `json:"ips" protobuf:"bytes,5,opt,name=ips"`
-     // The Hostname of this endpoint
-     // +optional
-     Hostname string `json:"hostname,omitempty" protobuf:"bytes,3,opt,name=hostname"`
-     // Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
-     // +optional
-     NodeName *string `json:"nodeName,omitempty" protobuf:"bytes,4,opt,name=nodeName"`
-     // Reference to object providing the endpoint.
-     // +optional
-     TargetRef *ObjectReference `json:"targetRef,omitempty" protobuf:"bytes,2,opt,name=targetRef"`
- }
-```
-
-##### Default Endpoint IP Selection
-Older servers and clients that were built before the introduction of full dual stack will only be aware of and make use of the original, singular IP field above. It is therefore considered to be the default IP address for the endpoint. When the IP and IPs fields are populated, the IPs[0] field must match the (default) IP entry. If a pod has both IPv4 and IPv6 addresses allocated, then the IP address chosen as the default IP address will match the IP family of the cluster's configured service CIDR. For example, if the service CIDR is IPv4, then the IPv4 address will be used as the default endpoint address.
-
-#### EndpointAddress Internal Representation
-The EndpointAddress internal representation will be modified to use a slice of IP strings ("IPs") rather than a singular IP strings ("IP"):
-```
-// EndpointAddress is a tuple that describes one or more IP addresses for an
-// endpoint.
-type EndpointAddress struct {
-	// The IPs for this endpoint.
-	IPs []string
-	// Optional: Hostname of this endpoint
-	// Meant to be used by DNS servers etc.
-	// +optional
-	Hostname string
-	// Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
-	// +optional
-	NodeName *string
-	// Optional: The kubernetes object related to the entry point.
-	TargetRef *ObjectReference
-}
-```
-This internal representation should eventually become part of a versioned API (after a period of deprecation for the singular "IP" field).
-
-#### Maintaining Compatible Interworking between Old and New Clients
-With this API change, we need to consider the scenario where there are a mix of clients that are running old vs. new versions of the API. The old clients would only be aware of the original, singular IP field, whereas newer clients could be writing either just the plural IPs field, or updating both singular IP and plural IPs fields. To cover this case, the API server will need to implement some safeguards/fix-ups for these fields for write operations (in compliance with the guidelines for pluralizing singular API fields that is included in the [Kubernetes API change quidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md):
-
-##### V1 to Core (Internal) Conversion
-- If only V1 IP is provided:
-  - Copy V1 IP to core IPs[0]
-- Else if only V1 IPs[] is provided:
-  - Copy V1 IPs[] to core IPs[]
-- Else if both V1 IP and V1 IPs[] are provided:
-  - Verify that V1 IP matches V1 IPs[0]
-  - Copy V1 IPs[] to core IPs[]
-- Delete any duplicates in core IPs[]
-
-##### Core (Internal) to V1 Conversion
-  - Copy core IPs[0] to V1 IP
-  - Copy core IPs[] to V1 IPs[]
-
-
-#### Configuration of Endpoint IP Family in Service Definitions
-This proposal adds an option to configure an endpoint IP family for a Kubernetes service:
-```
-    endpointFamily: <ipv4|ipv6|dual-stack>       [Default: dual-stack]
-```
-For example, the spec definition for an application that only binds to IPv4 might look like this:
-```
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
 spec:
+  ipFamily: IPv6
   selector:
     app: MyApp
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 9376
-  endpointFamily: ipv4
-```
-This per-service endpoint IP family configuration is required for IPv4-only and IPv6-only Application Support. For example, if there is a legacy application that only binds to IPv4 addresses (IPv4-only application) that is running in an otherwise dual-stack cluster, then we don't want endpoints for the service to include IPv6 addresses that are allocated to backend pods for the service. Otherwise, any IPv6 addresses that are included in endpoints would be "dead ends" (no response will be received from the server) for ingress controller and external load balancer operation. The same reasoning applies to IPv6-only applications.
-
-If a service is configured for an endpointFamily of "ipv4" ("ipv6"), then endpoints for that port for the service will not include any IPv6 (IPv4) addresses that have been allocated to backend pods for the service.
-
-If a service is configured with an endpointFamily of "dual-stack", then both IPv4 and IPv6 endpoints will be created, but the service will only have a single service IP allocated (with a family that matches the cluster's configured service CIDR).
-
-If a service is exposed via nodePort, and the service is configured with an endpointFamily of "dual-stack", then iptables will be configured for both families, allowing both IPv4 and IPv6 forwarding.
-
-#### Modifying Consumers of EndpointAddress API to Use Dual-Stack Addresses
-Any clients that consume the [Kubernetes EndpointAddress API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpointaddress-v1-core) will need to be modified to read the new plural IPs field, if they are to take advantage of the dual-stack feature. This proposal will include dual-stack updates to the following consumers of Kubernetes endpoints:
-- kube-proxy, iptables mode
-- kube-proxy, IPVS mode
-- Nginx Ingress controller
-Other users/consumers of this API may be updated to dual-stack over time, but that work is considered outside of the scope of this proposal.
-
-#### 'kubectl get endpoints' Command Display for Dual-Stack Backend Pods
-The 'kubectl get endpoints ...' command display should be changed so that:
-- IPv4/IPv6 endpoint address pairs appear within curly braces.
-- If dual-stack endpoint address pairs are present, then each pair should be printed on its own line as show below.
-Example:
-```
-       kube-master# kubectl get endpoints
-       NAME            ENDPOINTS                             AGE
-       kubernetes      {[fd00::100]:6443,10.0.0.2:6643}      15m
-       nginx-service   {[fd00:db8:1::2]:80,192.168.1.3:80}   20m
-                       {[fd00:db8:2::2]:80,192.168.2.3:80}   20m
-       kube-master#
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
 ```
 
-#### 'kubectl describe service' Command Display for Dual-Stack Backend Pods
-The 'kubectl describe service ...' command display should be changed so that:
-- IPv4/IPv6 endpoint address pairs appear within curly braces.
-- If dual-stack endpoint address pairs are present, then each pair should be printed on its own line as show below.
-Example:
+Dual-stack services (having both an IPv4 and IPv6 cluster IP) are currently out of scope of this proposal. Should there be use-cases where dual-stack Services are needed then we can revisit.
+
+### Endpoints
+
+The current [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core) (i.e. before the addition of the dual-stack feature), supports only a single IP address per endpoint. With the addition of the dual-stack feature, pods serving as backends for Kubernetes services may now have both IPv4 and IPv6 addresses. This presents a design choice of how to represent such dual-stack endpoints in the Endpoints API. Two choices worth considering would be:
+- 2 single-family endpoints per backend pod: Make no change to the [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core). Treat each IPv4/IPv6 address as separate, distinct endpoints, and include each address in the comma-separated list of addresses in an 'Endpoints' API object. 
+- 1 dual-stack endpoint per backend pod: Modify the [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core) so that each endpoint can be associated with a pair of IPv4/IPv6 addresses.
+
+Given a phased approach, the 2 single-family endpoint approach represents the least distruptive change. Services will select only the endpoints that match the `spec.ipFamily` defined in the Service.
+
+For example, for a Service named `my-service` that has the `spec.ipFamily` set to IPv4 would only have endpoints only from the IPv4 address family.
+
+```bash
+$ kubectl get ep my-service
+NAME         ENDPOINTS                                         AGE
+my-service   10.244.0.6:9376,10.244.2.7:9376,10.244.2.8:9376   84s
 ```
-       kube-master# kubectl describe service nginx-service
-       .
-       .
-       .
-       Endpoints:   {[fd00:db8:1::2]:80,192.168.1.3:80}
-                    {[fd00:db8:2::2]:80,192.168.2.3:80}
-       .
-       .
-       .
-       kube-master#
+
+Likewise, for a Service named `my-service-v6` that has the `spec.ipFamily` set to IPv6 would only have endpoints from the IPv6 address family.
+
+```bash
+$ kubectl get ep my-service-v6
+NAME            ENDPOINTS                                              AGE
+my-service-v6   [fd00:200::7]:9376,[fd00:200::8]:9376,[fd00::6]:9376   3m28s
 ```
 
 ### kube-proxy Operation
@@ -488,7 +402,7 @@ Only the first CIDR for each IP family will be used; all others will be ignored.
 
 ### CoreDNS Operation
 
-CoreDNS will need to make changes in order to support the plural form of endpoint addresses. Some other considerations of CoreDNS support for dual stack:
+CoreDNS will need to make changes in order to support the plural form of endpoint addresses. Some other considerations of CoreDNS support for dual-stack:
 
 - Because service IPs will remain single-family, pods will continue to access the CoreDNS server via a single service IP. In other words, the nameserver entries in a pod's /etc/resolv.conf will typically be a single IPv4 or single IPv6 address, depending upon the IP family of the cluster's service CIDR.
 - Non-headless Kubernetes services: CoreDNS will resolve these services to either an IPv4 entry (A record) or an IPv6 entry (AAAA record), depending upon the IP family of the cluster's service CIDR.
@@ -519,15 +433,15 @@ The ClusterIP service type will be single stack, so for this case there will be 
 
 #### Type NodePort
 
-The NodePort service type uses the nodes IP address, which can be dual stack, and port. If the service type is NodePort and the ipFamily is DualStack [NodePort](#configuration-of-ip-family-in-service-definitions) the load balancer can be configured as dual stack, as both families will get forwarded.
+The NodePort service type uses the nodes IP address, which can be dual-stack, and port. If the service type is NodePort and the ipFamily is DualStack [NodePort](#configuration-of-ip-family-in-service-definitions) the load balancer can be configured as dual-stack, as both families will get forwarded.
 
 #### Type Load Balancer
 
-The cloud provider will provision an external load balancer. If the cloud provider load balancer maps directly to the pod iP's then a dual stack load balancer could be used. Additional information may need to be provided to the cloud provider to configure dual stack. See Implementation Plan for further details.
+The cloud provider will provision an external load balancer. If the cloud provider load balancer maps directly to the pod iP's then a dual-stack load balancer could be used. Additional information may need to be provided to the cloud provider to configure dual-stack. See Implementation Plan for further details.
 
 ### Cloud Provider Plugins Considerations
 
-The [Cloud Providers](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/) may have individual requirements for dual stack in addition to below.
+The [Cloud Providers](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/) may have individual requirements for dual-stack in addition to below.
 
 #### Multiple bind addresses configuration
 
@@ -549,7 +463,7 @@ The cloud_cidr_allocator will be updated to support allocating from multiple CID
 
 ### Container Environment Variables
 
-The [container environmental variables](https://kubernetes.io/docs/concepts/containers/container-environment-variables/#container-environment) should support dual stack.
+The [container environmental variables](https://kubernetes.io/docs/concepts/containers/container-environment-variables/#container-environment) should support dual-stack.
 
 Pod information is exposed through environmental variables on the pod. There are a few environmental variables that are automatically created, and some need to be specified in the pod definition, through the downward api.
 
@@ -561,23 +475,18 @@ Here is an example of how to define a pluralized MY_POD_IPS environmental variab
     valueFrom:
       fieldRef:
         fieldPath: status.podIPs
-  - name: MY_POD_IPS_PROPERTIES_0
-    valueFrom:
-      fieldRef:
-        fieldPath: status.podIPs[0].properties
 ```
 
 This definition will cause an environmental variable setting in the pod similar to the following:
 ```
 MY_POD_IPS=fd00:10:20:0:3::3,10.20.3.3
-MY_POD_IPS_PROPERTIES_<IP_index>=x:y #We assume that colon is not going to used in map values.
 ```
 
 ### Kubeadm Support
 
 Dual-stack support will need to be added to kubeadm both for dual-stack development purposes, and for use in dual-stack continuous integration tests.
 
-- The Kubeadm config options and config file will support dual stack options for apiserver-advertise-address, and podSubnet.
+- The Kubeadm config options and config file will support dual-stack options for apiserver-advertise-address, and podSubnet.
 
 #### Kubeadm Configuration Options
 
@@ -613,9 +522,9 @@ Kubeadm will also need to generate dual-stack CIDRs for the --cluster-cidr argum
 This dual-stack proposal will introduce a new IPNetSlice object to spf13.pflag to allow parsing of comma separated CIDRs. Refer to [https://github.com/spf13/pflag/pull/170](https://github.com/spf13/pflag/pull/170)
 
 ### End-to-End Test Support
-End-to-End tests will be updated for Dual Stack. The Dual Stack E2E tests will use deployment scripts from the kubernetes-sigs/kubeadm-dind-cluster github repo to set up a containerized, multi-node Kubernetes cluster that is running in a Prow container (Docker-in-Docker-in-Docker, or DinDinD configuration), similar to the IPv6-only E2E tests (see [test-infra PR # 7529](https://github.com/kubernetes/test-infra/pull/7529)). The DinDinD cluster will be updated to support dual-stack.
+End-to-End tests will be updated for dual-stack. The dual-stack E2E tests will use deployment scripts from the kubernetes-sigs/kubeadm-dind-cluster github repo to set up a containerized, multi-node Kubernetes cluster that is running in a Prow container (Docker-in-Docker-in-Docker, or DinDinD configuration), similar to the IPv6-only E2E tests (see [test-infra PR # 7529](https://github.com/kubernetes/test-infra/pull/7529)). The DinDinD cluster will be updated to support dual-stack.
 
-The E2E test suite that will be run for dual stack will be based upon the [IPv6-only test suite](https://github.com/CiscoSystems/kube-v6-test) as a baseline. New versions of the network connectivity test cases that are listed below will need to be created so that both IPv4 and IPv6 connectivity to and from a pod can be tested within the same test case. A new dual-stack test flag will be created to control when the dual stack tests are run versus single stack versions of the tests:
+The E2E test suite that will be run for dual-stack will be based upon the [IPv6-only test suite](https://github.com/CiscoSystems/kube-v6-test) as a baseline. New versions of the network connectivity test cases that are listed below will need to be created so that both IPv4 and IPv6 connectivity to and from a pod can be tested within the same test case. A new dual-stack test flag will be created to control when the dual-stack tests are run versus single stack versions of the tests:
 ```
 [It] should function for node-pod communication: udp [Conformance]
 [It] should function for node-pod communication: http [Conformance]
@@ -635,31 +544,29 @@ For the test that checks pod internet connectivity, the IPv4 and IPv6 tests can 
 ### Risks and Mitigations
 \<TBD\>
 
-## Graduation Criteria
-\<TBD\>
 
 ## Implementation History
 \<TBD\>
 
 ## Alternatives
 
-### Dual Stack at the Edge
-Instead of modifying Kubernetes to provide dual-stack functionality within the cluster, one alternative is to run a cluster in IPv6-only mode, and instantiate IPv4-to-IPv6 translation mechanisms at the edge of the cluster. Such an approach can be called "Dual Stack at the Edge". Since the translation mechanisms are mostly external to the cluster, very little changes (or integration) would be required to the Kubernetes cluster itself. (This may be quicker for Kubernetes users to implement than waiting for the changes proposed in this proposal to be implemented).
+### Dual-stack at the Edge
+Instead of modifying Kubernetes to provide dual-stack functionality within the cluster, one alternative is to run a cluster in IPv6-only mode, and instantiate IPv4-to-IPv6 translation mechanisms at the edge of the cluster. Such an approach can be called "Dual-stack at the Edge". Since the translation mechanisms are mostly external to the cluster, very little changes (or integration) would be required to the Kubernetes cluster itself. (This may be quicker for Kubernetes users to implement than waiting for the changes proposed in this proposal to be implemented).
 
 For example, a cluster administrator could configure a Kubernetes cluster in IPv6-only mode, and then instantiate the following external to the cluster:
 - Stateful NAT64 and DNS64 servers: These would handle connections from IPv6 pods to external IPv4-only servers. The NAT64/DNS64 servers would be in the data center, but functionally external to the cluster. (Although one variation to consider would be to implement the DNS64 server inside the cluster as a CoreDNS plugin.)
 - Dual-stack ingress controllers (e.g. Nginx): The ingress controller would need dual-stack access on the external side, but would load balance to IPv6-only endpoints inside the cluster.
 - Stateless NAT46 servers: For access from IPv4-only, external clients to Kubernetes pods, or to exposed services (e.g. via NodePort or ExternalIPs). This may require some static configuration for IPv4-to-IPv6 mappings.
 
-### Variation: Dual-Stack Service CIDRs (a.k.a. Full Dual Stack)
+### Variation: Dual-Stack Service CIDRs (a.k.a. Full Dual-stack)
 
-As a variation to the "Dual-Stack Pods / Single-Family Services" approach outlined above, we can consider supporting IPv4 and IPv6 service CIDRs in parallel (a.k.a. the "full" dual stack approach).
+As a variation to the "Dual-Stack Pods / Single-Family Services" approach outlined above, we can consider supporting IPv4 and IPv6 service CIDRs in parallel (a.k.a. the "full" dual-stack approach).
 
 #### Benefits
 Providing dual-stack service CIDRs would add the following functionality:
 - Dual-Stack Pod-to-Services. Clients would have a choice of using A or AAAA DNS records when resolving Kubernetes services.
 - Simultaneous support for both IPv4-only and IPv6-only applications internal to the cluster. Without dual-stack service CIDRs, a cluster can support either IPv4-only applications or IPv6-only applications, depending upon the cluster CIDR's IP family. For example, if a cluster uses an IPv6 service CIDR, then IPv4-only applications in that cluster will not have IPv4 service IPs (and corresponding DNS A records) with which to access Kubernetes services.
-- External load balancers that use Kubernetes services for load balancing functionality (i.e. by mapping to service IPs) would work in dual stack mode. (Without dual-stack service CIDRs, these external load balancers would only work for the IP family that matches the cluster service CIDR's family.)
+- External load balancers that use Kubernetes services for load balancing functionality (i.e. by mapping to service IPs) would work in dual-stack mode. (Without dual-stack service CIDRs, these external load balancers would only work for the IP family that matches the cluster service CIDR's family.)
 
 #### Changes Required
 - [controller-manager startup configuration](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/): The "--service-cluster-ip-range" startup argument would need to be modified to accept a comma-separated list of CIDRs.
@@ -671,13 +578,16 @@ Providing dual-stack service CIDRs would add the following functionality:
 
 ## Test Plan
 
-* Build and add e2e tests to test-grid.
+* Test-grid e2e tests - https://testgrid.k8s.io/sig-network-dualstack-azure-e2e
+* e2e tests
+  * [sig-network] [Feature:IPv6DualStackAlphaFeature] [LinuxOnly] should create pod, add ipv6 and ipv4 ip to pod ips
+  * [sig-network] [Feature:IPv6DualStackAlphaFeature] [LinuxOnly] should have ipv4 and ipv6 internal node ip
+  * [sig-network] [Feature:IPv6DualStackAlphaFeature] [LinuxOnly] should have ipv4 and ipv6 node podCIDRs
 * e2e tests should cover the following:
   * multi-IP, same family
   * multi-IP, dual-stack
   * single IP, ipv4
   * single IP, ipv6
-
 ## Graduation Criteria
 
 This capability will move to beta when the following criteria have been met.

--- a/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
+++ b/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
@@ -359,7 +359,7 @@ The current [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/gene
 - 2 single-family endpoints per backend pod: Make no change to the [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core). Treat each IPv4/IPv6 address as separate, distinct endpoints, and include each address in the comma-separated list of addresses in an 'Endpoints' API object. 
 - 1 dual-stack endpoint per backend pod: Modify the [Kubernetes Endpoints API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#endpoints-v1-core) so that each endpoint can be associated with a pair of IPv4/IPv6 addresses.
 
-Given a phased approach, the 2 single-family endpoint approach represents the least distruptive change. Services will select only the endpoints that match the `spec.ipFamily` defined in the Service.
+Given a phased approach, the 2 single-family endpoint approach represents the least disruptive change. Services will select only the endpoints that match the `spec.ipFamily` defined in the Service.
 
 For example, for a Service named `my-service` that has the `spec.ipFamily` set to IPv4 would only have endpoints only from the IPv4 address family.
 
@@ -522,7 +522,7 @@ Kubeadm will also need to generate dual-stack CIDRs for the --cluster-cidr argum
 This dual-stack proposal will introduce a new IPNetSlice object to spf13.pflag to allow parsing of comma separated CIDRs. Refer to [https://github.com/spf13/pflag/pull/170](https://github.com/spf13/pflag/pull/170)
 
 ### End-to-End Test Support
-End-to-End tests will be updated for dual-stack. The dual-stack E2E tests will use deployment scripts from the kubernetes-sigs/kubeadm-dind-cluster github repo to set up a containerized, multi-node Kubernetes cluster that is running in a Prow container (Docker-in-Docker-in-Docker, or DinDinD configuration), similar to the IPv6-only E2E tests (see [test-infra PR # 7529](https://github.com/kubernetes/test-infra/pull/7529)). The DinDinD cluster will be updated to support dual-stack.
+End-to-End tests will be updated for dual-stack. The dual-stack e2e tests will utilized kubernetes-sigs/kind along with supported cloud providers. The e2e test-suite for dual-stack is running [here](https://testgrid.k8s.io/sig-network-dualstack-azure-e2e#dualstack-azure-e2e). Once dual-stack support is added to kind, corresponding dual-stack e2e tests will be run on kind similar to [this](https://testgrid.k8s.io/sig-release-master-blocking#kind-ipv6-master-parallel). 
 
 The E2E test suite that will be run for dual-stack will be based upon the [IPv6-only test suite](https://github.com/CiscoSystems/kube-v6-test) as a baseline. New versions of the network connectivity test cases that are listed below will need to be created so that both IPv4 and IPv6 connectivity to and from a pod can be tested within the same test case. A new dual-stack test flag will be created to control when the dual-stack tests are run versus single stack versions of the tests:
 ```

--- a/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
+++ b/keps/sig-network/20180612-ipv4-ipv6-dual-stack.md
@@ -131,7 +131,7 @@ In order to support dual-stack in Kubernetes clusters, Kubernetes needs to have 
 - Kubernetes needs to be made aware of multiple IPs per pod (limited to one IPv4 and one IPv6 address per pod maximum).
 - Link Local Addresses (LLAs) on a pod will remain implicit (Kubernetes will not display nor track these addresses).
 - Service Cluster IP Range `--service-cluster-ip-range=` will support the configuration of one IPv4 and one IPV6 address block) 
-- Service IPs will be allocated from only a single family (either IPv4 or IPv6 as specificate in the Service `spec.ipFamily` OR the first configured address block defined via `--service-cluster-ip-range=`).
+- Service IPs will be allocated from only a single family (either IPv4 or IPv6 as specified in the Service `spec.ipFamily` OR the first configured address block defined via `--service-cluster-ip-range=`).
 - Backend pods for a service can be dual-stack.
 - Endpoints addresses will match the address family of the Service IP address family (eg. An IPv6 Service IP will only have IPv6 Endpoints)
 - Kube-proxy iptables mode needs to drive iptables and ip6tables in parallel. This is required, even though service IP support is single-family, so that Kubernetes services can be exposed to clients external to the cluster via both IPv4 and IPv6. Support includes:
@@ -406,7 +406,7 @@ CoreDNS will need to make changes in order to support the plural form of endpoin
 
 - Because service IPs will remain single-family, pods will continue to access the CoreDNS server via a single service IP. In other words, the nameserver entries in a pod's /etc/resolv.conf will typically be a single IPv4 or single IPv6 address, depending upon the IP family of the cluster's service CIDR.
 - Non-headless Kubernetes services: CoreDNS will resolve these services to either an IPv4 entry (A record) or an IPv6 entry (AAAA record), depending upon the IP family of the cluster's service CIDR.
-- Headless Kubernetes services: CoreDNS will resolve these services to either an IPv4 entry (A record), an IPv6 entry (AAAA record), or both, depending on the service's endpointFamily configuration (see [Configuration of Endpoint IP Family in Service Definitions](#configuration-of-endpoint-ip-family-in-service-definitions)).
+- Headless Kubernetes services: CoreDNS will resolve these services to either an IPv4 entry (A record), an IPv6 entry (AAAA record), or both, depending on the service's `ipFamily`.
 
 ### Ingress Controller Operation
 
@@ -433,7 +433,7 @@ The ClusterIP service type will be single stack, so for this case there will be 
 
 #### Type NodePort
 
-The NodePort service type uses the nodes IP address, which can be dual-stack, and port. If the service type is NodePort and the ipFamily is DualStack [NodePort](#configuration-of-ip-family-in-service-definitions) the load balancer can be configured as dual-stack, as both families will get forwarded.
+The NodePort Service type uses the nodes IP address, which can be dual-stack, and port. If the Service type is NodePort, the `spec.ipFamily` will be used to determine how the the load balancer is configured and only the corresponding address family will be forwarded.
 
 #### Type Load Balancer
 


### PR DESCRIPTION
This PR updates the dual-stack KEP to include phase 3 works and amends the content to match the phase 1 and 2 implementation.

Complete changes list
* Consistent on dual-stack
* Update last-updated
* Add Services proposal
* Update Endpoint proposal
* Remove extra Graduation Criteria section
* Update CoreDNS non-goal
* Update proposal to match phase 1 & 2 implementation
* Update phase 1 & 2 k8s release
* Add phase 3
* Update kubectl get pods outputs
* Update kubectl describe pod output
* Update Downward API implementation details
* Update e2e tests based on phase 2 implementations
* Update container runtime verbiage

/sig network

Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>