### PR TITLE
Update SIG Docs leads to match k/org

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -47,9 +47,9 @@ aliases:
     - cblecker
     - nikhita
   sig-docs-leads:
-    - jaredbhatti
-    - zacharysarah
     - bradamant3
+    - jimangel
+    - zacharysarah
   sig-gcp-leads:
     - abgworrall
   sig-ibmcloud-leads:


### PR DESCRIPTION
Per the [OWNERS cleanup email](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ) from @mrbobbytables, this PR updates the leads for SIG Docs to match [kubernetes/org](https://github.com/kubernetes/org/blob/master/OWNERS_ALIASES#L39-L42).

/assign @Bradamant3 @jimangel 
/cc @kbarnard10 