### PR TITLE
Update graduation criteria for service finalizer KEP

### DIFF
--- a/keps/sig-network/20190423-service-lb-finalizer.md
+++ b/keps/sig-network/20190423-service-lb-finalizer.md
@@ -170,7 +170,8 @@ services.
 Beta: Allow Alpha ("remove finalizer") to soak for at least one release, then
 switch the "add finalizer" logic to be on by default.
 
-GA: TBD
+GA: Allow Beta to soak for at least one release. (There is no behavioral
+differences from the Beta phase.)
 
 ## Implementation History
 


### PR DESCRIPTION
Enhancement issue: https://github.com/kubernetes/enhancements/issues/980

The thinking is to do a lightweight promotion to GA as there is no behavioral changes from the Beta phase.

Let me know if there is any objection, thanks!

/assign @bowei @andrewsykim @thockin 