### PR TITLE
KEP: 3rd party content in documentation

### DIFF
--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -41,18 +41,30 @@ status: provisional
 - [Alternatives](#alternatives)
 <!-- /toc -->
 
-**Note:** This KEP does not target any release; SIG Docs follows a continuous release process for website content.
+**Note:** This KEP does not target any release; SIG Docs follows a continuous 
+release process for website content.
 
 ## Summary
 
 This KEP seeks consensus on how Kubernetes docs handle two types of content:
-1. Content from third-party providers
+
+1. Content from or about third-party providers ("third-party content")
+
+Minimize and eliminate third-party content except when necessary for Kubernetes 
+to function in-tree.
+
 2. Content hosted on multiple sites ("dual-sourced content")
 
-Kubernetes documentation seeks to teach Kubernetes users about how
+Minimize and eliminate dual-sourced content except when necessary for Kubernetes
+to function in-tree.
+
+## Introduction
+
+Kubernetes documentation teaches Kubernetes users about how
 Kubernetes works, how to use in-tree Kubernetes features, and how to
 build on top of Kubernetes infrastucture.
-Feature docs are not a place for vendor pitches. Nevertheless, SIG Docs
+
+Feature docs are not a place for vendor pitches. Nonetheless, SIG Docs sometimes
 receives pull requests to place advertising-like content on the Kubernetes
 website. Some PRs clearly do not belong in feature docs, but other
 instances are less clear.
@@ -62,7 +74,8 @@ project docs is to host single-sourced content only, and to provide
 links to other providers’ single-sourced content. This simplifies
 version management and reduces the work required to maintain content.
 
-This KEP defines a policy on documentation content, so that authors can
+This KEP defines how to handle third-party and dual-sourced content in 
+documentation, so that authors can
 judge what is appropriate to propose and so that PR approvers can make
 consistent, fair decisions during the review process.
 
@@ -82,9 +95,15 @@ offerings.
 Some third party content is necessary in order for Kubernetes to
 function. For example: Docker, networking policy (CNI plugins), Ingress
 controllers, and logging all require third party components.
-Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) are highly specific to a third party offering and seem more like third party product documentation than Kubernetes open source documentation.
+Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) 
+are highly specific to a third party offering and seem more like third party 
+product documentation than Kubernetes open source documentation.
 
 ### Goals
+
+The goal of Kubernetes documentation is to accurately document in-tree
+functionality for Kubernetes, and to eliminate barriers to effective
+contribution and understanding.
 
 The goal of this KEP is to reach and document a consensus on what
 types of third party content are appropriate for inclusion in Kubernetes
@@ -95,15 +114,55 @@ To address its goal, this KEP focuses on the following issues:
 
 <del>
 
-1. What third party content is appropriate for inclusion in the Kubernetes documentation?
-1. Does third party content in sections such as [Getting Started](https://kubernetes.io/docs/setup/) in the docs provide sufficient value to the reader that they should remain?
-1. Is there a list of content pages that are so focused on third party product usage that they should be removed or updated from the Kubernetes documentation?
-1. When should the Kubernetes documentation host third party documents that we are not the source/authority of?
-1. How does the Kubernetes project handle third party content that is not kept up to date or hosts?
-1. Can feature owners flag when third party content is *required*, as opposed to preferable or common?
+1. What third party content is appropriate for inclusion in the Kubernetes
+documentation?
+
+Proposed: Third-party content is permitted if it's required for Kubernetes to
+function in-tree.
+
+1. Does third party content in sections such as [Getting Started](https://kubernetes.io/docs/setup/)
+in the docs provide sufficient value to the reader that they should remain?
+
+Casual consensus says yes.
+
+1. Is there a list of content pages that are so focused on third party product
+usage that they should be removed or updated from the Kubernetes documentation?
+
+See https://github.com/kubernetes/website/issues/15748.
+
+1. When should the Kubernetes documentation host third party content that isn't
+maintained by a Kubernetes SIG?
+
+As infrequently as possible, with linking preferred to hosting. 
+
+1. How does the Kubernetes project handle third party content that is not kept
+up to date or hosts?
+
+If content isn't refreshed within 180 days, notify stakeholders of 90 days to 
+update content or migrate it elsewhere before removing it.
+
+1. Can feature owners flag when third party content is *required*, as opposed to
+preferable or common?
+
+Is this capability required for KEP approval?
+
 1. Who decides when to include third-party content?
-1. What standard of quality and review must be met before docs include third-party content?
-1. To what extent should SIG Docs advocate for third-party content providers to host their own content, or decline to host third-party content altogether?
+
+SIGs responsible for particular features can include third-party content at
+their discretion, preferably by linking to the third party's own documentation.
+
+1. What standard of quality and review must be met before docs include
+third-party content?
+
+Third-party content must be necessary for Kubernetes to function in-tree.
+
+1. To what extent should SIG Docs advocate for third-party content providers to 
+host their own content, or decline to host third-party content altogether?
+
+Third-party content should be linked rather than hosted whenever possible.
+
+Third-party content isn't accepted unless it's necessary for Kubernetes to
+function in-tree.
 
 </del>
 
@@ -118,17 +177,32 @@ To address its goal, this KEP focuses on the following issues:
 
 ## Proposal
 
-Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to achieve the KEP goal:
+1. Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to achieve the KEP goal:
 
-- Guidelines for contributors and reviewers on what content is
-  unambiguously OK. Quote or paraphrase the [goal(s)](#goals) from this
-  KEP.
-- Achieve consensus that SIG Docs and specifically approvers for
-  [k/website](https://github.com/kubernetes/website/) are gatekeepers for including
-  content that doesn't meet the core goal of this KEP.
+- Specify that Kubernetes docs are limited to content required for Kubernetes to
+function in-tree. Docs may include third-party content for components that 
+require a third-party solution to function. Third-party content should be linked
+to whenever possible, rather than duplicated or hosted in k/website.
+
+2. Revise the documentation when the KEP is approved:
+
+- **Third-party content:** Notify stakeholders via GitHub issues in k/website
+that third-party content will be removed after 90 days if content isn't required
+for Kubernetes to function in-tree.
+
+This limits the impact to out-of-tree content and gives current stakeholders 
+approximately one Kubernetes release cycle to migrate 
+third-party content to an alternate platform before removing content from 
+Kubernetes docs.
+
+- **Dual-sourced content:** Where sourcing is obvious, replace dual-sourced
+content with links to an authoritative single source. Where sourcing is unclear,
+notify stakeholders via GitHub issues in k/website that dual-sourced content
+
+In all cases where content would be removed, provide adequate time for the
+relevant SIG to review changes in content.
 
 ### User Stories
-
 
 #### Story 1 (fictional)
 
@@ -187,13 +261,12 @@ As [hyperkube transitions to third-party maintenance](https://github.com/kuberne
 
 ### Implementation Details/Notes/Constraints
 
-SIG Docs approvers may occasionally need to consider intent. The policies produced
-by this KEP aim to be clear enough so that important / essential topics are
-accepted and documented, and so that reviews rarely need to consider contributor
-intent as a factor in approval.
+This KEP originally included language around considering intent of contributors.
+Because intent is effectively impossible to judge (and because contributions
+are nearly always made with the best intent), this KEP now specifies that 
+third-party content is limited to what's required for in-tree functionality.
 
-SIG Docs can adds its own guidelines for writing and reviewing content outside the
-"unambiguously OK" area.
+SIG Docs may add its own guidelines for writing and reviewing ambiguous content.
 
 For example:
 > Kubernetes requires out-of-tree software and tools to implement: cluster
@@ -222,7 +295,7 @@ Pages to review and possibly revise, if that guideline were in place:
 
 ### Risks and Mitigations
 
-TBD
+None known
 
 ## Design Details
 
@@ -233,8 +306,7 @@ TBD
 Once the community have reached consensus, prepare a PR to update the
 existing [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content).
 
-Once the KEP is approved, merge the KEP and then the website update PR.
-That's all that's needed.
+Once the KEP is approved, merge the KEP and then update website content accordingly.
 
 # Drawbacks
 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -10,7 +10,7 @@ reviewers:
   - TBD
 approvers:
   - TBD
-editor: TBD
+editor: "@zacharysarah"
 creation-date: 2019-10-20
 last-updated: 2019-10-20
 status: provisional
@@ -328,12 +328,8 @@ Once the KEP is approved, merge the KEP and then update website content accordin
 
 # Drawbacks
 
-_Why should this KEP _not_ be implemented._
-
-TBD
+SIG Docs identified no meaningful drawbacks.
 
 ## Alternatives
 
-_Similar to the `Drawbacks` section the `Alternatives` section is used to highlight and record other possible approaches to delivering the value proposed by a KEP._
-
-TBD
+The only real alternative&mdash;approving third-party content without a vetting policy&mdash;is unacceptable, and would degrade site outcomes across metrics of quality, searchability, and trust.

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -1,0 +1,168 @@
+---
+title: doc-policies-for-third-party-content
+authors:
+  - "@jimangel"
+  - "@sftim"
+  - "@zacharysarah"
+owning-sig: sig-docs
+reviewers:
+  - TBD
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2019-10-20
+last-updated: 2019-10-20
+status: provisional
+---
+
+# doc-policies-for-third-party-content
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1 (fictional)](#story-1-fictional)
+    - [Story 2 (fictional)](#story-2-fictional)
+    - [Story 3 (actual)](#story-3-actual)
+    - [Story 4 (actual)](#story-4-actual)
+    - [Story 5 (actual)](#story-5-actual)
+  - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Graduation Criteria](#graduation-criteria)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+**Note:** This KEP does not target any release; SIG Docs follows a continuous release process for website content.
+
+## Summary
+
+This KEP seeks consensus on how Kubernetes docs handle two types of content:
+1. Content from third-party providers
+2. Content hosted on multiple sites ("dual-sourced content")
+
+Feature docs are not a place for vendor pitches. Nevertheless, SIG Docs receives pull requests to place advertising content on the Kubernetes website. Some PRs clearly do not belong in feature docs, but other instances are less clear.
+
+Feature docs also contain dual-sourced content. A good practice for code project docs is to host single-sourced content only, and to provide links to other providers’ single-sourced content. This simplifies version management and reduces the work required to maintain content.
+This KEP defines a policy on documentation content, so that authors can judge what is appropriate to propose and so that PR approvers can make consistent, fair decisions during the review process.
+
+## Motivation
+
+SIG Docs publishes Kubernetes documentation on kubernetes.io in line with its [charter](https://github.com/kubernetes/community/blob/master/sig-docs/charter.md#scope) and sets standards for website content. Prior to this KEP, there are no clear guidelines or standards for third-party and dual-sourced content.
+
+The Kubernetes documentation is currently a mix of both 1) documentation describing the Kubernetes open source project; and 2) content describing how to install or use Kubernetes on several third party Kubernetes offerings.
+
+Some third party content is necessary in order for Kubernetes to function. For example: Docker, networking policy (CNI plugins), Ingress controllers, and logging all require third party components.
+Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) are highly specific to a third party offering and seem more like third party product documentation than Kubernetes open source documentation.
+
+The goal of this KEP is to reach and document a consensus on what types of third party content are appropriate for inclusion in Kubernetes documentation; standards for including third-party content; and to create consistent policies for docs handle third-party and dual-sourced content.
+This KEP focuses on the following issues:
+
+1. What third party content is appropriate for inclusion in the Kubernetes documentation?
+1. Does third party content in sections such as [Getting Started](https://kubernetes.io/docs/setup/) in the docs provide sufficient value to the reader that they should remain?
+1. Is there a list of content pages that are so focused on third party product usage that they should be removed or updated from the Kubernetes documentation?
+1. When should the Kubernetes documentation host third party documents that we are not the source/authority of?
+1. How does the Kubernetes project handle third party content that is not kept up to date or hosts?
+1. Can feature owners flag when third party content is *required*, as opposed to preferable or common?
+1. Who decides when to include third-party content?
+1. What standard of quality and review must be met before docs include third-party content?
+1. To what extent should SIG Docs advocate for third-party content providers to host their own content, or decline to host third-party content altogether?
+
+### Goals
+
+- Create a policy for how to include or exclude third party content in Kubernetes documentation.
+- Create a policy for how to handle dual-sourced content.
+- Publish clear, transparent guidelines for contributors and reviewers on how to handle third-party and dual-sourced content.
+- Published guidelines for contributors and reviewers that clarify requirements for third party content and allow documentation reviewers to reject advertising.
+
+
+### Non-Goals
+
+- Outright removal of all content relating to vendors and projects outside the CNCF ecosystem.
+
+## Proposal
+
+TBD. Detailed policies will come out of the discussion around this KEP.
+
+### User Stories
+
+
+#### Story 1 (fictional)
+
+Alice works for ACME, Inc and wants to gain visibility for ACME Cloud Services, which has just launched a managed Kubernetes cluster product. Alice drafts a change to a concept page so that that it mentions ACME Cloud Services’ Kubernetes product, and submits a pull request.
+Bob is a documentation approver. Bob explains that Alice’s proposed change does not meet community standards, because it is functionally an advertisement.
+
+#### Story 2 (fictional)
+
+Charlie uses Linux, specifically Ubuntu. Charlie notices that the page about installing `kubethingy` has instructions for installing `kubethingy` on Windows and on CentOS/RHEL but not on Ubuntu. Charlie reads the guidelines on content and sees that this kind of change is acceptable (Ubuntu is one of the most popular Linux distributions, and `kubethingy` documentation is acceptable as it is already documented). Charlie drafts a change and submits a pull request.
+
+#### Story 3 (actual)
+
+Rafael wanted to share a Kubernetes course from an online education provider. He submitted [PR #15962](https://github.com/kubernetes/website/pull/15962) to add the course to [Overview of Kubernetes Online Training](https://kubernetes.io/docs/tutorials/online-training/overview/). The PR was not approved because SIG Docs didn’t want to add a link to third-party content over which SIG Docs have no control.
+
+#### Story 4 (actual)
+
+[PR #16203](https://github.com/kubernetes/website/pull/16203) removes Stackdriver and Elasticsearch vendor content. Since logging falls into the external add-ons category, SIG Docs decided to remove this vendor-specific content. That , which has not been meaningfully updated in three years. SIG Docs had buy-in from SIG Instrumentation Bugs for removal; however that PR was held pending the outcome of this KEP.
+
+#### Story 5 (actual)
+
+In [PR #16766](https://github.com/kubernetes/website/pull/16766) @pouledodue proposed adding Hertzner Cloud Controller to the list of vendors that have implemented a cloud controller manager. That PR was held pending the outcome of this KEP.
+
+### Implementation Details/Notes/Constraints
+
+While SIG Docs approvers may occasionally need to consider intent, any policies produced by this KEP must be clear enough to minimize cases where intent needs to be considered.
+
+(At the time of writing) Kubernetes requires external software to implement Cluster Networking, Ingress, Persistent Storage, and Logging. Hyperlinking to vendor software and documentation _is_ allowed; creating “how to use” content is not.
+
+Examples of allowed content:
+ - Cluster Networking
+   - https://kubernetes.io/docs/concepts/cluster-administration/networking/
+   - https://kubernetes.io/docs/concepts/cluster-administration/addons/
+ - Ingress Controllers
+   - https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#additional-controllers
+ - Persistent Volumes
+   - https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims
+
+Examples of content that would not be allowed:
+ - [Install a Network Policy Provider](https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/) and child pages: how to use Calico, Cilium, Kube-router, Romana, and Weave Net for NetworkPolicy
+ - [Audit](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/)
+ - [Use fluentd to collect and distribute audit events from log file](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#use-fluentd-to-collect-and-distribute-audit-events-from-log-file) (dual-sourced)
+ - [Use logstash to collect and distribute audit events from webhook backend](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#use-logstash-to-collect-and-distribute-audit-events-from-webhook-backend) (vendor-specific content)
+ - [Auditing with Falco](https://kubernetes.io/docs/tasks/debug-application-cluster/falco/) (dual-sourced)
+ - [Events in Stackdriver](https://kubernetes.io/docs/tasks/debug-application-cluster/events-stackdriver/) (vendor-specific content)
+ - [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) (vendor-specific content)
+ - [Logging using Stackdriver](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-stackdriver/) (vendor-specific content)
+
+### Risks and Mitigations
+
+- Rejecting a change that is ultimately deemed acceptable.
+- Accepting a change that is ultimately judged to be unacceptable vendor promotion.
+- It may not always be possible to achieve consensus on whether specific third-party content should be included.
+  This may lead to resentment/resistance to future third party content.
+  *Mitigation*: consider including folks that also work outside the relevant SIG or subproject.
+
+## Design Details
+
+### Graduation Criteria
+
+**Note:** *this KEP does not target any release*
+
+TBD
+
+## Drawbacks
+
+_Why should this KEP _not_ be implemented._
+
+TBD
+
+## Alternatives
+
+_Similar to the `Drawbacks` section the `Alternatives` section is used to highlight and record other possible approaches to delivering the value proposed by a KEP._
+
+TBD

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -21,27 +21,28 @@ status: provisional
 ## Table of Contents
 
 <!-- toc -->
-- [Summary](#summary)
-- [Motivation](#motivation)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-- [Proposal](#proposal)
-  - [User Stories](#user-stories)
-    - [Story 1 (fictional)](#story-1-fictional)
-    - [Story 2 (fictional)](#story-2-fictional)
-    - [Story 3 (actual)](#story-3-actual)
-    - [Story 4 (actual)](#story-4-actual)
-    - [Story 5 (actual)](#story-5-actual)
-    - [Story 6 (actual)](#story-6-actual)
-  - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
-  - [Risks and Mitigations](#risks-and-mitigations)
-- [Design Details](#design-details)
-  - [Graduation Criteria](#graduation-criteria)
+  - [Summary](#summary)
+  - [Introduction](#introduction)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [User Stories](#user-stories)
+      - [Story 1 (fictional)](#story-1-fictional)
+      - [Story 2 (fictional)](#story-2-fictional)
+      - [Story 3 (actual)](#story-3-actual)
+      - [Story 4 (actual)](#story-4-actual)
+      - [Story 5 (actual)](#story-5-actual)
+      - [Story 6 (actual)](#story-6-actual)
+    - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
+    - [Risks and Mitigations](#risks-and-mitigations)
+  - [Design Details](#design-details)
+    - [Graduation Criteria](#graduation-criteria)
 - [Drawbacks](#drawbacks)
-- [Alternatives](#alternatives)
+  - [Alternatives](#alternatives)
 <!-- /toc -->
 
-**Note:** This KEP does not target any release; SIG Docs follows a continuous 
+**Note:** This KEP does not target any release; SIG Docs follows a continuous
 release process for website content.
 
 ## Summary

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -52,17 +52,21 @@ This KEP seeks consensus on how Kubernetes docs handle two types of content:
 1. Content from or about third-party providers ("third-party content")
 
 Minimize and eliminate third-party content except when necessary for Kubernetes 
-to function in-tree.
+to function in-project.
 
 2. Content hosted on multiple sites ("dual-sourced content")
 
 Minimize and eliminate dual-sourced content except when necessary for Kubernetes
-to function in-tree.
+to function in-project.
+
+**Note:** This KEP defines "in project" to mean projects in the Kubernetes org, 
+which includes the [kubernetes](https://github.com/kubernetes) and 
+[kubernetes-sigs](https://github.com/kubernetes) repositories.
 
 ## Introduction
 
 Kubernetes documentation teaches Kubernetes users about how
-Kubernetes works, how to use in-tree Kubernetes features, and how to
+Kubernetes works, how to use in-project Kubernetes features, and how to
 build on top of Kubernetes infrastucture.
 
 Feature docs are not a place for vendor pitches. Nonetheless, SIG Docs sometimes
@@ -74,6 +78,10 @@ Feature docs also contain dual-sourced content. A good practice for code
 project docs is to host single-sourced content only, and to provide
 links to other providers’ single-sourced content. This simplifies
 version management and reduces the work required to maintain content.
+
+This KEP proposes that Kubernetes documentation sets these boundaries:
+
+- Kubernetes documentation includes 
 
 This KEP defines how to handle third-party and dual-sourced content in 
 documentation, so that authors can
@@ -102,12 +110,12 @@ product documentation than Kubernetes open source documentation.
 
 ### Goals
 
-The goal of Kubernetes documentation is to accurately document in-tree
+The goal of Kubernetes documentation is to accurately document in-project
 functionality for Kubernetes, and to eliminate barriers to effective
 contribution and understanding.
 
 The goal of this KEP is to reach and document a consensus on what
-types of third party content are appropriate for inclusion in Kubernetes
+types of third-party content are appropriate for inclusion in Kubernetes
 documentation; standards for including third-party content; and to create
 consistent policies for docs handle third-party and dual-sourced content.
 
@@ -119,12 +127,14 @@ To address its goal, this KEP focuses on the following issues:
 documentation?
 
 Proposed: Third-party content is permitted if it's required for Kubernetes to
-function in-tree.
+function in-project.
 
 1. Does third party content in sections such as [Getting Started](https://kubernetes.io/docs/setup/)
 in the docs provide sufficient value to the reader that they should remain?
 
-Casual consensus says yes.
+Casual consensus says yes, with one modification:
+- Eliminate the [production environment table](https://kubernetes.io/docs/setup/#production-environment)
+with a link to [certified conformance partners](https://kubernetes.io/partners/#conformance).
 
 1. Is there a list of content pages that are so focused on third party product
 usage that they should be removed or updated from the Kubernetes documentation?
@@ -155,21 +165,27 @@ their discretion, preferably by linking to the third party's own documentation.
 1. What standard of quality and review must be met before docs include
 third-party content?
 
-Third-party content must be necessary for Kubernetes to function in-tree.
+Third-party content must be necessary for Kubernetes to function in-project.
 
 1. To what extent should SIG Docs advocate for third-party content providers to 
 host their own content, or decline to host third-party content altogether?
 
-Third-party content should be linked rather than hosted whenever possible.
+Kubernetes docs publish third-party content only if:
 
-Third-party content isn't accepted unless it's necessary for Kubernetes to
-function in-tree.
+- It's necessary for Kubernetes to function. For example: Docker, networking 
+policy (CNI plugins), Ingress controllers, and logging.
+
+- It's an applied example of another project in the Kubernetes GitHub org. This
+includes the [kubernetes](https://github.com/kubernetes) and 
+[kubernetes-sigs](https://github.com/kubernetes-sigs) repositories.
+
+Third-party content should be linked instead of hosted whenever possible. 
 
 </del>
 
 1. Clearly define what documentation is required so that readers understand
    how to deploy, operate and consume Kubernetes clusters using features from
-   in-tree code and its mandatory dependencies.
+   in-project code and its mandatory dependencies.
 
 ### Non-Goals
 
@@ -181,17 +197,18 @@ function in-tree.
 1. Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to achieve the KEP goal:
 
 - Specify that Kubernetes docs are limited to content required for Kubernetes to
-function in-tree. Docs may include third-party content for components that 
-require a third-party solution to function. Third-party content should be linked
-to whenever possible, rather than duplicated or hosted in k/website.
+function in-project. Docs may include third-party content for components that 
+require a third-party solution to function. Docs may include content for 
+other projects in the Kubernetes org. Third-party content must be linked 
+whenever possible, rather than duplicated or hosted in k/website.
 
 2. Revise the documentation when the KEP is approved:
 
 - **Third-party content:** Notify stakeholders via GitHub issues in k/website
 that third-party content will be removed after 90 days if content isn't required
-for Kubernetes to function in-tree.
+for Kubernetes to function in-project.
 
-This limits the impact to out-of-tree content and gives current stakeholders 
+This limits the impact to out-of-project content and gives current stakeholders 
 approximately one Kubernetes release cycle to migrate 
 third-party content to an alternate platform before removing content from 
 Kubernetes docs.
@@ -265,7 +282,7 @@ As [hyperkube transitions to third-party maintenance](https://github.com/kuberne
 This KEP originally included language around considering intent of contributors.
 Because intent is effectively impossible to judge (and because contributions
 are nearly always made with the best intent), this KEP now specifies that 
-third-party content is limited to what's required for in-tree functionality.
+third-party content is limited to what's required for in-project functionality.
 
 SIG Docs may add its own guidelines for writing and reviewing ambiguous content.
 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -7,9 +7,12 @@ authors:
   - "@zacharysarah"
 owning-sig: sig-docs
 reviewers:
-  - TBD
+  - "@jaredbhatti"
+  - "@kbarnard10"
 approvers:
-  - TBD
+  - "@cblecker"
+  - "@derekwaynecarr"
+  - "@dims"
 editor: "@zacharysarah"
 creation-date: 2019-10-20
 last-updated: 2019-10-20
@@ -102,9 +105,9 @@ how to install or use Kubernetes on several third party Kubernetes
 offerings.
 
 Some third party content is necessary in order for Kubernetes to
-function. For example: Docker, networking policy (CNI plugins), Ingress
-controllers, and logging all require third party components.
-Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) 
+function. For example: container runtimes (containerd, CRI-o, Docker), 
+networking policy (CNI plugins), Ingress controllers, and logging all require 
+third party components. Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) 
 are highly specific to a third party offering and seem more like third party 
 product documentation than Kubernetes open source documentation.
 
@@ -172,8 +175,9 @@ host their own content, or decline to host third-party content altogether?
 
 Kubernetes docs publish third-party content only if:
 
-- It's necessary for Kubernetes to function. For example: Docker, networking 
-policy (CNI plugins), Ingress controllers, and logging.
+- It's necessary for Kubernetes to function. For example: container runtimes 
+(containerd, CRI-o, Docker), networking policy (CNI plugins), Ingress 
+controllers, and logging.
 
 - It's an applied example of another project in the Kubernetes GitHub org. This
 includes the [kubernetes](https://github.com/kubernetes) and 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -64,7 +64,7 @@ to function in-project.
 
 **Note:** This KEP defines "in project" to mean projects in the Kubernetes org, 
 which includes the [kubernetes](https://github.com/kubernetes) and 
-[kubernetes-sigs](https://github.com/kubernetes) repositories.
+[kubernetes-sigs](https://github.com/kubernetes-sigs) repositories.
 
 ## Introduction
 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -49,7 +49,13 @@ This KEP seeks consensus on how Kubernetes docs handle two types of content:
 1. Content from third-party providers
 2. Content hosted on multiple sites ("dual-sourced content")
 
-Feature docs are not a place for vendor pitches. Nevertheless, SIG Docs receives pull requests to place advertising content on the Kubernetes website. Some PRs clearly do not belong in feature docs, but other instances are less clear.
+Kubernetes documentation seeks to teach Kubernetes users about how
+Kubernetes works, how to use in-tree Kubernetes features, and how to
+build on top of Kubernetes infrastucture.
+Feature docs are not a place for vendor pitches. Nevertheless, SIG Docs
+receives pull requests to place advertising-like content on the Kubernetes
+website. Some PRs clearly do not belong in feature docs, but other
+instances are less clear.
 
 Feature docs also contain dual-sourced content. A good practice for code project docs is to host single-sourced content only, and to provide links to other providers’ single-sourced content. This simplifies version management and reduces the work required to maintain content.
 This KEP defines a policy on documentation content, so that authors can judge what is appropriate to propose and so that PR approvers can make consistent, fair decisions during the review process.

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -57,20 +57,43 @@ receives pull requests to place advertising-like content on the Kubernetes
 website. Some PRs clearly do not belong in feature docs, but other
 instances are less clear.
 
-Feature docs also contain dual-sourced content. A good practice for code project docs is to host single-sourced content only, and to provide links to other providers’ single-sourced content. This simplifies version management and reduces the work required to maintain content.
-This KEP defines a policy on documentation content, so that authors can judge what is appropriate to propose and so that PR approvers can make consistent, fair decisions during the review process.
+Feature docs also contain dual-sourced content. A good practice for code
+project docs is to host single-sourced content only, and to provide
+links to other providers’ single-sourced content. This simplifies
+version management and reduces the work required to maintain content.
+
+This KEP defines a policy on documentation content, so that authors can
+judge what is appropriate to propose and so that PR approvers can make
+consistent, fair decisions during the review process.
 
 ## Motivation
 
-SIG Docs publishes Kubernetes documentation on kubernetes.io in line with its [charter](https://github.com/kubernetes/community/blob/master/sig-docs/charter.md#scope) and sets standards for website content. Prior to this KEP, there are no clear guidelines or standards for third-party and dual-sourced content.
+SIG Docs publishes Kubernetes
+documentation on kubernetes.io in line with its
+[charter](https://github.com/kubernetes/community/blob/master/sig-docs/charter.md#scope)
+and sets standards for website content. Prior to this KEP, there are no
+clear guidelines or standards for third-party and dual-sourced content.
 
-The Kubernetes documentation is currently a mix of both 1) documentation describing the Kubernetes open source project; and 2) content describing how to install or use Kubernetes on several third party Kubernetes offerings.
+The Kubernetes documentation is currently a mix of both 1) documentation
+describing the Kubernetes open source project; and 2) content describing
+how to install or use Kubernetes on several third party Kubernetes
+offerings.
 
-Some third party content is necessary in order for Kubernetes to function. For example: Docker, networking policy (CNI plugins), Ingress controllers, and logging all require third party components.
+Some third party content is necessary in order for Kubernetes to
+function. For example: Docker, networking policy (CNI plugins), Ingress
+controllers, and logging all require third party components.
 Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) are highly specific to a third party offering and seem more like third party product documentation than Kubernetes open source documentation.
 
-The goal of this KEP is to reach and document a consensus on what types of third party content are appropriate for inclusion in Kubernetes documentation; standards for including third-party content; and to create consistent policies for docs handle third-party and dual-sourced content.
-This KEP focuses on the following issues:
+### Goals
+
+The goal of this KEP is to reach and document a consensus on what
+types of third party content are appropriate for inclusion in Kubernetes
+documentation; standards for including third-party content; and to create
+consistent policies for docs handle third-party and dual-sourced content.
+
+To address its goal, this KEP focuses on the following issues:
+
+<del>
 
 1. What third party content is appropriate for inclusion in the Kubernetes documentation?
 1. Does third party content in sections such as [Getting Started](https://kubernetes.io/docs/setup/) in the docs provide sufficient value to the reader that they should remain?
@@ -82,57 +105,103 @@ This KEP focuses on the following issues:
 1. What standard of quality and review must be met before docs include third-party content?
 1. To what extent should SIG Docs advocate for third-party content providers to host their own content, or decline to host third-party content altogether?
 
-### Goals
+</del>
 
-- Create a policy for how to include or exclude third party content in Kubernetes documentation.
-- Create a policy for how to handle dual-sourced content.
-- Publish clear, transparent guidelines for contributors and reviewers on how to handle third-party and dual-sourced content.
-- Published guidelines for contributors and reviewers that clarify requirements for third party content and allow documentation reviewers to reject advertising.
-
+1. Clearly define what documentation is required so that readers understand
+   how to deploy, operate and consume Kubernetes clusters using features from
+   in-tree code and its mandatory dependencies.
 
 ### Non-Goals
 
-- Outright removal of all content relating to vendors and projects outside the CNCF ecosystem.
+1. Outright removal of all content relating to vendors and projects
+   outside the CNCF ecosystem.
 
 ## Proposal
 
-Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to address community concerns
+Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to achieve the KEP goal:
+
+- Guidelines for contributors and reviewers on what content is
+  unambiguously OK. Quote or paraphrase the [goal(s)](#goals) from this
+  KEP.
+- Achieve consensus that SIG Docs and specifically approvers for
+  [k/website](https://github.com/kubernetes/website/) are gatekeepers for including
+  content that doesn't meet the core goal of this KEP.
 
 ### User Stories
 
 
 #### Story 1 (fictional)
 
-Alice works for ACME, Inc and wants to gain visibility for ACME Cloud Services, which has just launched a managed Kubernetes cluster product. Alice drafts a change to a concept page so that that it mentions ACME Cloud Services’ Kubernetes product, and submits a pull request.
-Bob is a documentation approver. Bob explains that Alice’s proposed change does not meet community standards, because it is functionally an advertisement.
+Alice works for ACME, Inc and wants to gain visibility for ACME
+Cloud Services, which has just launched a managed Kubernetes cluster
+product. Alice drafts a change to a concept page so that that it mentions
+ACME Cloud Services’ Kubernetes product, and submits a pull request.
+
+Bob is a documentation approver. Bob explains that Alice’s proposed
+change does not meet community standards, because it is functionally
+an advertisement.
 
 #### Story 2 (fictional)
 
-Charlie uses Linux, specifically Ubuntu. Charlie notices that the page about installing `kubethingy` has instructions for installing `kubethingy` on Windows and on CentOS/RHEL but not on Ubuntu. Charlie reads the guidelines on content and sees that this kind of change is acceptable (Ubuntu is one of the most popular Linux distributions, and `kubethingy` documentation is acceptable as it is already documented). Charlie drafts a change and submits a pull request.
+Charlie uses Linux, specifically Ubuntu. Charlie notices that the page
+about installing `kubethingy` has instructions for installing `kubethingy`
+on Windows and on CentOS/RHEL but not on Ubuntu. Charlie reads the
+guidelines on content and sees that this kind of change is acceptable
+(Ubuntu is one of the most popular Linux distributions, and `kubethingy`
+documentation is acceptable as it is already documented).
+
+Charlie drafts a change and submits a pull request.
 
 #### Story 3 (actual)
 
-Rafael wanted to share a Kubernetes course from an online education provider. He submitted [PR #15962](https://github.com/kubernetes/website/pull/15962) to add the course to [Overview of Kubernetes Online Training](https://kubernetes.io/docs/tutorials/online-training/overview/). The PR was not approved because SIG Docs didn’t want to add a link to third-party content over which SIG Docs have no control.
+Rafael wanted to share a Kubernetes course from
+an online education provider. Rafael submitted
+[PR #15962](https://github.com/kubernetes/website/pull/15962)
+to add the course to [Overview of Kubernetes Online
+Training](https://kubernetes.io/docs/tutorials/online-training/overview/).
+
+The PR was not approved because SIG Docs didn’t want to add a link to
+third-party content over which SIG Docs have no control.
 
 #### Story 4 (actual)
 
-Website [PR #16203](https://github.com/kubernetes/website/pull/16203) removes Stackdriver and Elasticsearch vendor content. Since logging falls into the external add-ons category, SIG Docs decided to remove this vendor-specific content that had not been meaningfully updated in three years. SIG Docs had buy-in from SIG Instrumentation Bugs for removal; however that PR was held pending the outcome of this KEP.
+[Website PR #16203](https://github.com/kubernetes/website/pull/16203)
+removes Stackdriver and Elasticsearch vendor content. Since logging
+falls into the external add-ons category, SIG Docs decided to remove this
+vendor-specific content that had not been meaningfully updated in three
+years.
+
+SIG Docs had buy-in from SIG Instrumentation Bugs for removal; however,
+that PR was held pending the outcome of this KEP and later closed.
 
 #### Story 5 (actual)
 
-In [PR #16766](https://github.com/kubernetes/website/pull/16766) @pouledodue proposed adding Hertzner Cloud Controller to the list of vendors that have implemented a cloud controller manager. That PR was held pending the outcome of this KEP.
+In [PR #16766](https://github.com/kubernetes/website/pull/16766)
+@pouledodue proposed adding Hertzner Cloud Controller to the list of
+vendors that have implemented a cloud controller manager. That PR was
+held pending the outcome of this KEP, then later merged.
 
 #### Story 6 (actual)
 
-As [hyperkube transitions to [third-party maintenance](https://github.com/kubernetes/kubeadm/issues/1889), it's unclear how to handle [hyperkube content in the Kubernetes docs](https://github.com/kubernetes/website/search?q=hyperkube&unscoped_q=hyperkube) or re-point related links.
+As [hyperkube transitions to third-party maintenance](https://github.com/kubernetes/kubeadm/issues/1889), it's unclear how to handle [hyperkube content in the Kubernetes docs](https://github.com/kubernetes/website/search?q=hyperkube&unscoped_q=hyperkube) or re-point related links.
 
 ### Implementation Details/Notes/Constraints
 
-While SIG Docs approvers may occasionally need to consider intent, any policies produced by this KEP must be clear enough to minimize cases where intent needs to be considered.
+SIG Docs approvers may occasionally need to consider intent. The policies produced
+by this KEP aim to be clear enough so that important / essential topics are
+accepted and documented, and so that reviews rarely need to consider contributor
+intent as a factor in approval.
 
-(At the time of writing) Kubernetes requires external software to implement Cluster Networking, Ingress, Persistent Storage, and Logging. Hyperlinking to vendor software and documentation _is_ allowed; creating “how to use” content is not.
+SIG Docs can adds its own guidelines for writing and reviewing content outside the
+"unambiguously OK" area.
 
-Examples of allowed content:
+For example:
+> Kubernetes requires out-of-tree software and tools to implement: cluster
+> networking, Ingress, persistent storage, and logging. Hyperlinking to vendor software
+> and documentation _is_ allowed; creating “how to use” content for a specific vendor
+> is discouraged.
+
+Pages that fit with that example guideline:
  - Cluster Networking
    - https://kubernetes.io/docs/concepts/cluster-administration/networking/
    - https://kubernetes.io/docs/concepts/cluster-administration/addons/
@@ -141,7 +210,7 @@ Examples of allowed content:
  - Persistent Volumes
    - https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims
 
-Examples of content that would not be allowed:
+Pages to review and possibly revise, if that guideline were in place:
  - [Install a Network Policy Provider](https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/) and child pages: how to use Calico, Cilium, Kube-router, Romana, and Weave Net for NetworkPolicy
  - [Audit](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/)
  - [Use fluentd to collect and distribute audit events from log file](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#use-fluentd-to-collect-and-distribute-audit-events-from-log-file) (dual-sourced)
@@ -153,11 +222,7 @@ Examples of content that would not be allowed:
 
 ### Risks and Mitigations
 
-- Rejecting a change that is ultimately deemed acceptable.
-- Accepting a change that is ultimately judged to be unacceptable vendor promotion.
-- It may not always be possible to achieve consensus on whether specific third-party content should be included.
-  This may lead to resentment/resistance to future third party content.
-  *Mitigation*: consider including folks that also work outside the relevant SIG or subproject.
+TBD
 
 ## Design Details
 
@@ -165,9 +230,13 @@ Examples of content that would not be allowed:
 
 **Note:** *this KEP does not target any release*
 
-TBD
+Once the community have reached consensus, prepare a PR to update the
+existing [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content).
 
-## Drawbacks
+Once the KEP is approved, merge the KEP and then the website update PR.
+That's all that's needed.
+
+# Drawbacks
 
 _Why should this KEP _not_ be implemented._
 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -82,10 +82,6 @@ project docs is to host single-sourced content only, and to provide
 links to other providers’ single-sourced content. This simplifies
 version management and reduces the work required to maintain content.
 
-This KEP proposes that Kubernetes documentation sets these boundaries:
-
-- Kubernetes documentation includes 
-
 This KEP defines how to handle third-party and dual-sourced content in 
 documentation, so that authors can
 judge what is appropriate to propose and so that PR approvers can make
@@ -107,7 +103,7 @@ offerings.
 Some third party content is necessary in order for Kubernetes to
 function. For example: container runtimes (containerd, CRI-o, Docker), 
 networking policy (CNI plugins), Ingress controllers, and logging all require 
-third party components. Pages like [Logging Using Elasticsearch and Kibana](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/) 
+third party components. Pages like [Logging Using Stackdriver](https://kubernetes.io/docs/tasks/debug-application-cluster/logging-stackdriver/) 
 are highly specific to a third party offering and seem more like third party 
 product documentation than Kubernetes open source documentation.
 
@@ -129,7 +125,7 @@ To address its goal, this KEP focuses on the following issues:
 1. What third party content is appropriate for inclusion in the Kubernetes
 documentation?
 
-Proposed: Third-party content is permitted if it's required for Kubernetes to
+Proposed: Third-party content is permitted if it is required for Kubernetes to
 function in-project.
 
 1. Does third party content in sections such as [Getting Started](https://kubernetes.io/docs/setup/)
@@ -153,7 +149,13 @@ As infrequently as possible, with linking preferred to hosting.
 up to date or hosts?
 
 If content isn't refreshed within 180 days, notify stakeholders of 90 days to 
-update content or migrate it elsewhere before removing it.
+update content or migrate it elsewhere before removing it. Notification
+specifically includes:
+
+- Mailing an initial list of affected pages to kubernetes-dev@googlegroups.com
+- Announcing the policy change in two Kubernetes community meetings in a row
+- Posting a notification of the policy change on the Kubernetes blog
+- Notifying SIG PR review aliases on GitHub in PRs that remove affected content
 
 1. Can feature owners flag when third party content is *required*, as opposed to
 preferable or common?
@@ -193,24 +195,26 @@ Third-party content should be linked instead of hosted whenever possible.
 
 ### Non-Goals
 
-1. Outright removal of all content relating to vendors and projects
-   outside the CNCF ecosystem.
+1. Outright removal of all content relating to vendors and projects outside the 
+   Kubernetes project.
 
 ## Proposal
 
 1. Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to achieve the KEP goal:
 
 - Specify that Kubernetes docs are limited to content required for Kubernetes to
-function in-project. Docs may include third-party content for components that 
+function in-project. Docs may include third-party OSS content for components that 
 require a third-party solution to function. Docs may include content for 
-other projects in the Kubernetes org. Third-party content must be linked 
+other projects in the Kubernetes org, and content from other OSS projects that
+are necessary for Kubernetes to function. Third-party content must be linked 
 whenever possible, rather than duplicated or hosted in k/website.
 
 2. Revise the documentation when the KEP is approved:
 
-- **Third-party content:** Notify stakeholders via GitHub issues in k/website
-that third-party content will be removed after 90 days if content isn't required
-for Kubernetes to function in-project.
+- **Third-party content:** Notify stakeholders of all affected content via 
+GitHub issues and via a single message containing a summary of all affected
+content to kubernetes-dev@googlegroups.com that non-conforming content will be 
+removed after 90 days.
 
 This limits the impact to out-of-project content and gives current stakeholders 
 approximately one Kubernetes release cycle to migrate 
@@ -219,10 +223,12 @@ Kubernetes docs.
 
 - **Dual-sourced content:** Where sourcing is obvious, replace dual-sourced
 content with links to an authoritative single source. Where sourcing is unclear,
-notify stakeholders via GitHub issues in k/website that dual-sourced content
+notify stakeholders via GitHub issues in k/website and via a single message 
+containing a summary of all affected content to kubernetes-dev@googlegroups.com
+that non-conforming content will be removed after 90 days.
 
 In all cases where content would be removed, provide adequate time for the
-relevant SIG to review changes in content.
+relevant SIG to review changes and notify stakeholders.
 
 ### User Stories
 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -32,6 +32,7 @@ status: provisional
     - [Story 3 (actual)](#story-3-actual)
     - [Story 4 (actual)](#story-4-actual)
     - [Story 5 (actual)](#story-5-actual)
+    - [Story 6 (actual)](#story-6-actual)
   - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -89,7 +90,7 @@ This KEP focuses on the following issues:
 
 ## Proposal
 
-TBD. Detailed policies will come out of the discussion around this KEP.
+Revise the [content guide](https://github.com/kubernetes/website/blob/master/content/en/docs/contribute/style/content-guide.md#contributing-content) to address community concerns
 
 ### User Stories
 
@@ -109,11 +110,15 @@ Rafael wanted to share a Kubernetes course from an online education provider. He
 
 #### Story 4 (actual)
 
-[PR #16203](https://github.com/kubernetes/website/pull/16203) removes Stackdriver and Elasticsearch vendor content. Since logging falls into the external add-ons category, SIG Docs decided to remove this vendor-specific content. That , which has not been meaningfully updated in three years. SIG Docs had buy-in from SIG Instrumentation Bugs for removal; however that PR was held pending the outcome of this KEP.
+Website [PR #16203](https://github.com/kubernetes/website/pull/16203) removes Stackdriver and Elasticsearch vendor content. Since logging falls into the external add-ons category, SIG Docs decided to remove this vendor-specific content that had not been meaningfully updated in three years. SIG Docs had buy-in from SIG Instrumentation Bugs for removal; however that PR was held pending the outcome of this KEP.
 
 #### Story 5 (actual)
 
 In [PR #16766](https://github.com/kubernetes/website/pull/16766) @pouledodue proposed adding Hertzner Cloud Controller to the list of vendors that have implemented a cloud controller manager. That PR was held pending the outcome of this KEP.
+
+#### Story 6 (actual)
+
+As [hyperkube transitions to [third-party maintenance](https://github.com/kubernetes/kubeadm/issues/1889), it's unclear how to handle [hyperkube content in the Kubernetes docs](https://github.com/kubernetes/website/search?q=hyperkube&unscoped_q=hyperkube) or re-point related links.
 
 ### Implementation Details/Notes/Constraints
 

--- a/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
+++ b/keps/sig-docs/20191020-doc-policies-for-third-party-content.md
@@ -1,6 +1,7 @@
 ---
 title: doc-policies-for-third-party-content
 authors:
+  - "@aimeeu"
   - "@jimangel"
   - "@sftim"
   - "@zacharysarah"


### PR DESCRIPTION
Feature docs are not a place for vendor pitches. Nevertheless, SIG Docs has seen pull requests that are more or less a request to place advertising content on the Kubernetes website.

Feature docs also contain content hosted in multiple places (“dual-sourced content”). A good practice for code project docs is to host single-sourced content only, and to provide links to other providers’ single-sourced content.
This ~draft~ KEP defines a policy on documentation content, so that authors can judge what is appropriate to propose, and so that PR approvers can make consistent, fair decisions during the review process.

Related issue: #1326

/kind kep
/sig docs