### PR TITLE
Adding Janet Kuo to the SIG Apps owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,6 +6,7 @@ aliases:
     - mattfarina
     - prydonius
     - kow3ns
+    - janetkuo
   sig-architecture-leads:
     - derekwaynecarr
     - dims


### PR DESCRIPTION
@janetkuo is one of the SIG Apps chairs. You can see it at https://github.com/kubernetes/community/blob/master/sigs.yaml#L128-L141. Adding to the SIG Apps owners over here.