### PR TITLE
In-Place Vertical Pod Scaling KEP to implementable, and mini-KEP for CRI extensions

### DIFF
--- a/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
@@ -23,8 +23,8 @@ approvers:
   - "@mwielgus"
 editor: TBD
 creation-date: 2018-11-06
-last-updated: 2018-11-06
-status: provisional
+last-updated: 2019-10-25
+status: implementable
 see-also:
 replaces:
 superseded-by:
@@ -48,6 +48,7 @@ superseded-by:
   - [Scheduler and API Server Interaction](#scheduler-and-api-server-interaction)
   - [Flow Control](#flow-control)
     - [Container resource limit update ordering](#container-resource-limit-update-ordering)
+    - [Container resource limit update failure handling](#container-resource-limit-update-failure-handling)
     - [Notes](#notes)
   - [Affected Components](#affected-components)
   - [Future Enhancements](#future-enhancements)
@@ -167,6 +168,12 @@ Kubelet calls UpdateContainerResources CRI API which currently takes
 but not for Windows. This parameter changes to *runtimeapi.ContainerResources*,
 that is runtime agnostic, and will contain platform-specific information.
 
+Additionally, GetContainerResources CRI API is introduced that allows Kubelet
+to query currently configured CPU and memory limits for a container.
+
+These CRI changes are a separate effort that does not affect the design
+proposed in this KEP.
+
 ### Kubelet and API Server Interaction
 
 When a new Pod is created, Scheduler is responsible for selecting a suitable
@@ -282,6 +289,16 @@ updates resource limit for the Pod and its Containers in the following manner:
 
 In all the above cases, Kubelet applies Container resource limit decreases
 before applying limit increases.
+
+#### Container resource limit update failure handling
+
+If multiple Containers in a Pod are being updated, and UpdateContainerResources
+CRI API fails for any of the containers, Kubelet will backoff and retry at a
+later time. Kubelet does not attempt to update limits for containers that are
+lined up for update after the failing container. This ensures that sum of the
+container limits does not exceed Pod-level cgroup limit at any point. Once all
+the container limits have been successfully updated, Kubelet updates the Pod's
+Status.ContainerStatuses[i].Resources to match the desired limit values.
 
 #### Notes
 

--- a/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
@@ -23,8 +23,8 @@ approvers:
   - "@mwielgus"
 editor: TBD
 creation-date: 2018-11-06
-last-updated: 2019-10-25
-status: implementable
+last-updated: 2018-11-06
+status: provisional
 see-also:
 replaces:
 superseded-by:
@@ -168,12 +168,6 @@ Kubelet calls UpdateContainerResources CRI API which currently takes
 but not for Windows. This parameter changes to *runtimeapi.ContainerResources*,
 that is runtime agnostic, and will contain platform-specific information.
 
-Additionally, GetContainerResources CRI API is introduced that allows Kubelet
-to query currently configured CPU and memory limits for a container.
-
-These CRI changes are a separate effort that does not affect the design
-proposed in this KEP.
-
 ### Kubelet and API Server Interaction
 
 When a new Pod is created, Scheduler is responsible for selecting a suitable
@@ -289,16 +283,6 @@ updates resource limit for the Pod and its Containers in the following manner:
 
 In all the above cases, Kubelet applies Container resource limit decreases
 before applying limit increases.
-
-#### Container resource limit update failure handling
-
-If multiple Containers in a Pod are being updated, and UpdateContainerResources
-CRI API fails for any of the containers, Kubelet will backoff and retry at a
-later time. Kubelet does not attempt to update limits for containers that are
-lined up for update after the failing container. This ensures that sum of the
-container limits does not exceed Pod-level cgroup limit at any point. Once all
-the container limits have been successfully updated, Kubelet updates the Pod's
-Status.ContainerStatuses[i].Resources to match the desired limit values.
 
 #### Notes
 

--- a/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
@@ -143,7 +143,8 @@ the allocated resources.
 #### Container Resize Policy
 
 To provide fine-grained user control, PodSpec.Containers is extended with
-ResizePolicy map (new object) for each resource type (CPU, memory):
+ResizePolicy - a list of named subobjects (new object) that supports 'cpu'
+and 'memory' as names. It supports the following policy values:
 * NoRestart - the default value; resize Container without restarting it,
 * RestartContainer - restart the Container in-place to apply new resource
   values. (e.g. Java process needs to change its Xmx flag)

--- a/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
@@ -135,10 +135,9 @@ Thanks to the above:
   v1.ResourceRequirements) shows the **actual** resources held by the Pod and
   its Containers.
 
-A new Pod subresource named 'resourceallocation' is introduced to allow
-fine-grained access control that enables Kubelet to set or update resources
-allocated to a Pod, and prevents the user or any other component from changing
-the allocated resources.
+A new admission controller named 'PodResourceAllocation' is introduced in order
+to limit access to ResourcesAllocated field such that only Kubelet can update
+this field.
 
 #### Container Resize Policy
 
@@ -194,11 +193,10 @@ resources allocated (Pod.Spec.Containers[i].ResourcesAllocated) for all Pods in
 the Node, except the Pod being resized. For the Pod being resized, it adds the
 new desired resources (i.e Spec.Containers[i].Resources.Requests) to the sum.
 * If new desired resources fit, Kubelet accepts the resize by updating
-  Pod.Spec.Containers[i].ResourcesAllocated via pods/resourceallocation
-  subresource, and then proceeds to invoke UpdateContainerResources CRI API
-  to update the Container resource limits. Once all Containers are successfully
-  updated, it updates Pod.Status.ContainerStatuses[i].Resources to reflect the
-  new resource values.
+  Pod.Spec.Containers[i].ResourcesAllocated, and then proceeds to invoke
+  UpdateContainerResources CRI API to update Container resource limits. Once
+  all Containers are successfully updated, it updates
+  Pod.Status.ContainerStatuses[i].Resources to reflect new resource values.
 * If new desired resources don't fit, Kubelet rejects the resize, and no
   further action is taken.
   - Kubelet retries the Pod resize at a later time.
@@ -243,10 +241,9 @@ Pod with ResizePolicy set to NoRestart for all its Containers.
    resources to determine if the new desired Resources fit the Node.
    * _Case 1_: Kubelet finds new desired Resources fit. It accepts the resize
      and sets Spec.Containers[i].ResourcesAllocated equal to the values of
-     Spec.Containers[i].Resources.Requests by invoking resourceallocation
-     subresource. It then applies the new cgroup limits to the Pod and its
-     Containers, and once successfully done, sets Pod's
-     Status.ContainerStatuses[i].Resources to reflect the desired resources.
+     Spec.Containers[i].Resources.Requests. It then applies the new cgroup
+     limits to the Pod and its Containers, and once successfully done, sets
+     Pod's Status.ContainerStatuses[i].Resources to reflect desired resources.
      - If at the same time, a new Pod was assigned to this Node against the
        capacity taken up by this resource resize, that new Pod is rejected by
        Kubelet during admission if Node has no more room.
@@ -328,7 +325,7 @@ Status.ContainerStatuses[i].Resources to match the desired limit values.
 
 Pod v1 core API:
 * extended model,
-* new subresource,
+* new admission controller,
 * added validation.
 
 Admission Controllers: LimitRanger, ResourceQuota need to support Pod Updates:

--- a/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
@@ -23,8 +23,8 @@ approvers:
   - "@mwielgus"
 editor: TBD
 creation-date: 2018-11-06
-last-updated: 2018-11-06
-status: provisional
+last-updated: 2019-10-25
+status: implementable
 see-also:
 replaces:
 superseded-by:
@@ -168,6 +168,12 @@ Kubelet calls UpdateContainerResources CRI API which currently takes
 but not for Windows. This parameter changes to *runtimeapi.ContainerResources*,
 that is runtime agnostic, and will contain platform-specific information.
 
+Additionally, GetContainerResources CRI API is introduced that allows Kubelet
+to query currently configured CPU and memory limits for a container.
+
+These CRI changes are a separate effort that does not affect the design
+proposed in this KEP.
+
 ### Kubelet and API Server Interaction
 
 When a new Pod is created, Scheduler is responsible for selecting a suitable
@@ -284,6 +290,16 @@ updates resource limit for the Pod and its Containers in the following manner:
 In all the above cases, Kubelet applies Container resource limit decreases
 before applying limit increases.
 
+#### Container resource limit update failure handling
+
+If multiple Containers in a Pod are being updated, and UpdateContainerResources
+CRI API fails for any of the containers, Kubelet will backoff and retry at a
+later time. Kubelet does not attempt to update limits for containers that are
+lined up for update after the failing container. This ensures that sum of the
+container limits does not exceed Pod-level cgroup limit at any point. Once all
+the container limits have been successfully updated, Kubelet updates the Pod's
+Status.ContainerStatuses[i].Resources to match the desired limit values.
+
 #### Notes
 
 * If CPU Manager policy for a Node is set to 'static', then only integral
@@ -374,3 +390,4 @@ TODO
 - 2019-01-18 - implementation proposal extended
 - 2019-03-07 - changes to flow control, updates per review feedback
 - 2019-08-29 - updated design proposal
+- 2019-10-25 - update key open items and move KEP to implementable

--- a/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
@@ -168,8 +168,9 @@ Kubelet calls UpdateContainerResources CRI API which currently takes
 but not for Windows. This parameter changes to *runtimeapi.ContainerResources*,
 that is runtime agnostic, and will contain platform-specific information.
 
-Additionally, GetContainerResources CRI API is introduced that allows Kubelet
-to query currently configured CPU and memory limits for a container.
+Additionally, ContainerStatus CRI API is extended to hold
+*runtimeapi.ContainerResources* so that it allows Kubelet to query Container's
+CPU and memory limit configurations from runtime.
 
 These CRI changes are a separate effort that does not affect the design
 proposed in this KEP.

--- a/keps/sig-node/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-node/20181106-in-place-update-of-pod-resources.md
@@ -491,17 +491,19 @@ TBD
 
 ### Alpha
 - In-Place Pod Resouces Update functionality is implemented,
+- LimitRanger and ResourceQuota handling are added,
+- Resize Policies functionality is implemented,
 - Unit tests and E2E tests covering basic functionality are added,
 - E2E tests covering multiple containers are added.
 
 ### Beta
 - VPA alpha integration of feature completed and any bugs addressed,
-- Resize Policies are added, LimitRanger and ResourceQuota handling added,
-- Unit tests and E2E tests covering the above are added,
+- E2E tests covering Resize Policy, LimitRanger, and ResourceQuota are added,
 - Negative tests are identified and added.
 
 ### Stable
 - VPA integration of feature moved to beta,
+- User feedback (ideally from atleast two distinct users) is green,
 - No major bugs reported for three months.
 
 ## Implementation History
@@ -513,3 +515,4 @@ TBD
 - 2019-10-25 - update key open items and move KEP to implementable
 - 2020-01-06 - API review suggested changes incorporated
 - 2020-01-13 - Test plan and graduation criteria added
+- 2020-01-21 - Graduation criteria updated per review feedback

--- a/keps/sig-node/20181106-in-place-update-of-pod-resources.md
+++ b/keps/sig-node/20181106-in-place-update-of-pod-resources.md
@@ -5,9 +5,9 @@ authors:
   - "@bskiba"
   - "@schylek"
   - "@vinaykul"
-owning-sig: sig-autoscaling
+owning-sig: sig-node
 participating-sigs:
-  - sig-node
+  - sig-autoscaling
   - sig-scheduling
 reviewers:
   - "@bsalamat"
@@ -23,9 +23,10 @@ approvers:
   - "@mwielgus"
 editor: TBD
 creation-date: 2018-11-06
-last-updated: 2019-10-25
+last-updated: 2020-01-14
 status: implementable
 see-also:
+  - "/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
+++ b/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
@@ -6,13 +6,16 @@ authors:
 owning-sig: sig-node
 participating-sigs:
 reviewers:
-  - TBD
+  - @Random-Liu
+  - @yujuhong
+  - @PatrickLang
 approvers:
-  - TBD
+  - @dchen1107
+  - @derekwaynecarr
 editor: TBD
 creation-date: 2019-10-25
 last-updated: 2019-10-25
-status: provisional
+status: implementable
 see-also:
   - "/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md"
 replaces:
@@ -33,9 +36,9 @@ superseded-by:
   - [Expected Behavior of CRI Runtime](#expected-behavior-of-cri-runtime)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
-  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
-  - [Version Skew Strategy](#version-skew-strategy)
-  - [Risks and Mitigations](#risks-and-mitigations)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [Stable](#stable)
 - [Implementation History](#implementation-history)
 <!-- /toc -->
 
@@ -214,26 +217,33 @@ TBD
 
 ### Test Plan
 
-Unit tests: TBD
-E2E tests: TBD
+* Unit tests are updated to reflect use of ContainerResources object in
+  UpdateContainerResources and ContainerStatus APIs.
+
+* E2E test is added to verify UpdateContainerResources API with docker runtime.
+
+* E2E test is added to verify ContainerStatus API using docker runtime.
+
+* E2E test is added to verify backward compatibility usign docker runtime.
 
 ### Graduation Criteria
 
-TBD
+#### Alpha
 
-### Upgrade / Downgrade Strategy
+* UpdateContainerResources and ContainerStatus API changes are done and tested
+  with dockershim and docker runtime, backward compatibility is maintained.
 
-Is this applicable? - TBD
+#### Beta
 
-### Version Skew Strategy
+* UpdateContainerResources and ContainerStatus API changes are completed and
+  tested for Windows runtime.
 
-Is this applicable? - TBD
+#### Stable
 
-### Risks and Mitigations
-
-TBD
+* No major bugs reported for three months.
 
 ## Implementation History
 
 - 2019-10-25 - Initial KEP draft created
+- 2020-01-14 - Test plan and graduation criteria added
 

--- a/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
+++ b/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
@@ -6,12 +6,12 @@ authors:
 owning-sig: sig-node
 participating-sigs:
 reviewers:
-  - @Random-Liu
-  - @yujuhong
-  - @PatrickLang
+  - "@Random-Liu"
+  - "@yujuhong"
+  - "@PatrickLang"
 approvers:
-  - @dchen1107
-  - @derekwaynecarr
+  - "@dchen1107"
+  - "@derekwaynecarr"
 editor: TBD
 creation-date: 2019-10-25
 last-updated: 2020-01-14

--- a/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
+++ b/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
@@ -1,0 +1,211 @@
+---
+title: Container Resources CRI API Changes for Pod Vertical Scaling
+authors:
+  - "@vinaykul"
+  - "@quinton-hoole"
+owning-sig: sig-node
+participating-sigs:
+reviewers:
+  - TBD
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2019-10-25
+last-updated: 2019-10-25
+status: provisional
+see-also:
+  - "/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md"
+replaces:
+superseded-by:
+---
+
+# Container Resources CRI API Changes for Pod Vertical Scaling
+
+## Table of Contents
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Implementation Details/Notes/Constraints [optional]](#implementation-detailsnotesconstraints-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Implementation History](#implementation-history)
+<!-- /toc -->
+
+## Summary
+
+This proposal aims to improve the Container Runtime Interface (CRI) APIs for
+managing CPU and memory resource configurations for Containers. It seeks to
+extend UpdateContainerResources CRI API such that it works for Windows, and
+other future runtimes besides Linux. It also seeks to add a new CRI API that
+allows Kubelet to query the current resources configuration for a Container.
+
+## Motivation
+
+In-Place Pod Vertical Scaling feature relies on Container Runtime Interface
+(CRI) to update the CPU and/or memory limits for Container(s) in a Pod.
+
+The current API set have a few issues that need to be addressed:
+1. UpdateContainerResources CRI API takes a parameter that describes container
+   resources to update for Linux Containers, and this may not work for Windows
+   Containers or other potential non-Linux runtimes in the future.
+1. There is no CRI mechanism that lets Kubelet query and discover the CPU and
+   memory limits configured on a running Container.
+1. The expected behavior from a runtime that handles UpdateContainerResources
+   CRI API is not very well defined.
+
+### Goals
+
+There are two primary goals of this proposal:
+  - Modify UpdateContainerResources to allow it to work for Windows Containers,
+    as well as Containers managed by other runtimes in the future,
+  - Define a new CRI API to query CPU and memory resource configurations that
+    are currently applied to a running Container.
+
+An additional goal of this proposal is to better define the expected behavior
+from a Container runtime when handling the above APIs.
+
+### Non-Goals
+
+Definition of expected behavior of a Container runtime when it handles CRI APIs
+related to a Container's resources APIs is intended to be a high-level guide.
+It is a non-goal of this proposal to define a detailed or specific way to
+implement these APIs. Implementation specifics are left to the runtime, within
+the bounds of expected behavior.
+
+## Proposal
+
+This is where we get down to the nitty gritty of what the proposal actually is.
+
+One key change is to make UpdateContainerResources API work for Windows, and
+any other runtimes that may need to pass resources information in the future.
+
+Another change in this proposal is to add a new GetContainerResources CRI API
+that Kubelet can use to query and discover the CPU and memory resources that
+are presently configured for a Container.
+
+* A new protobuf message object named *ContainerResources* that encapsulates
+LinuxContainerResources and WindowsContainerResources is introduced as below.
+  - This message can be easily extended for future runtimes by simply adding a
+    new runtime-specific resources struct to the ContainerResources message.
+```
+// ContainerResources holds resource configuration for a container.
+message ContainerResources {
+    // Resource configuration specific to Linux container.
+    LinuxContainerResources linux = 1;
+    // Resource configuration specific to Windows container.
+    WindowsContainerResources windows = 2;
+}
+```
+
+* UpdateContainerResourcesRequest message is extended to carry
+  ContainerResources field as below.
+  - This allows backward compatibility where runtimes that rely on
+    LinuxContainerResources continue to work.
+  - Kubelet fills both UpdateContainerResourcesRequest.Linux and
+    UpdateContainerResourcesRequest.Resources.Linux fields, allowing
+    newer runtimes to use UpdateContainerResourcesRequest.Resources.Linux
+    field.
+  - This enables deprecation of UpdateContainerResourcesRequest.Linux field.
+```
+message UpdateContainerResourcesRequest {
+    // ID of the container to update.
+    string container_id = 1;
+    // Resource configuration specific to Linux container.
+    LinuxContainerResources linux = 2;
+    // Resource configuration for the container.
+    ContainerResources resources = 3;
+}
+```
+
+* A new CRI API, GetContainerResources, is introduced, and RuntimeService is
+  modified as shown below.
+  - This API enables Kubelet to query and discover currently configured
+    resources for a Container.
+```
+message GetContainerResourcesRequest {
+    // ID of the container whose resource config is queried.
+    string container_id = 1;
+}
+
+message GetContainerResourcesResponse {
+    // Resource configuration of the container.
+    ContainerResources resources = 1;
+}
+
+// GetContainerResources returns resource configuration of the container.
+rpc GetContainerResources(GetContainerResourcesRequest) returns (GetContainerResourcesResponse) {}
+```
+
+* ContainerManager CRI API service interface is modified as follows:
+  - UpdateContainerResources takes ContainerResources parameter instead of
+    LinuxContainerResources.
+  - GetContainerResources is introduced that allows Kubelet to query current
+    resource configurations of a Container.
+  - Kubelet code is modified to implement and use these methods.
+```
+--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
++++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
+@@ -43,8 +43,10 @@ type ContainerManager interface {
+        ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
+        // ContainerStatus returns the status of the container.
+        ContainerStatus(containerID string) (*runtimeapi.ContainerStatus, error)
+-       // UpdateContainerResources updates the cgroup resources for the container.
+-       UpdateContainerResources(containerID string, resources *runtimeapi.LinuxContainerResources) error
++       // GetContainerResources returns resource configuration applied to the container.
++       GetContainerResources(containerID string) (*runtimeapi.ContainerResources, error)
++       // UpdateContainerResources updates resource configuration for the container.
++       UpdateContainerResources(containerID string, resources *runtimeapi.ContainerResources) error
+        // ExecSync executes a command in the container, and returns the stdout output.
+        // If command exits with a non-zero exit code, an error is returned.
+        ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error)
+```
+
+### Expected Behavior of UpdateContainerResources CRI API
+
+TBD
+
+### Expected Behavior of GetContainerResources CRI API
+
+TBD
+
+## Design Details
+
+TODO: Add a section/flow-diagram on how Kubelet will use these APIs
+
+### Implementation Details/Notes/Constraints [optional]
+
+TBD
+
+### Risks and Mitigations
+
+TBD
+
+### Test Plan
+
+Unit tests: TBD
+E2E tests: TBD
+
+### Graduation Criteria
+
+TBD
+
+### Upgrade / Downgrade Strategy
+
+Is this applicable? - TBD
+
+### Version Skew Strategy
+
+Is this applicable? - TBD
+
+## Implementation History
+
+- 2019-10-25 - Initial KEP draft created
+

--- a/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
+++ b/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
@@ -14,10 +14,10 @@ approvers:
   - @derekwaynecarr
 editor: TBD
 creation-date: 2019-10-25
-last-updated: 2019-10-25
+last-updated: 2020-01-14
 status: implementable
 see-also:
-  - "/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md"
+  - "/keps/sig-node/20181106-in-place-update-of-pod-resources.md"
 replaces:
 superseded-by:
 ---

--- a/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
+++ b/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md
@@ -100,12 +100,10 @@ LinuxContainerResources and WindowsContainerResources is introduced as below.
 ```
 // ContainerResources holds resource configuration for a container.
 message ContainerResources {
-    oneof r {
-        // Resource configuration specific to Linux container.
-        LinuxContainerResources linux = 1;
-        // Resource configuration specific to Windows container.
-        WindowsContainerResources windows = 2;
-    }
+    // Resource configuration specific to Linux container.
+    LinuxContainerResources linux = 1;
+    // Resource configuration specific to Windows container.
+    WindowsContainerResources windows = 2;
 }
 ```
 


### PR DESCRIPTION
One of the items/comments that is related to [In-Place Pod Vertical Scaling KEP](https://github.com/kubernetes/enhancements/pull/686#) is to extend/update the CRI API to better support different Container runtimes such as Windows etc for resource update. 

This mini KEP outlines the proposed changes to CRI API to accomplish that review item. This does not block implementation of Vertical Scaling KEP, but would be good to have in the time-frame of implementation of In-Place Pod Vertical Scaling feature.

CC: @PatrickLang @dashpole @derekwaynecarr @dchen1107 @yujuhong 