### PR TITLE
modify the error url of kustomization.yaml

### DIFF
--- a/keps/sig-cli/kustomize-secret-generator-plugins.md
+++ b/keps/sig-cli/kustomize-secret-generator-plugins.md
@@ -447,7 +447,7 @@ in CONTRIBUTING.md.
   * High level feature test
     (like those in [pkg/target](https://github.com/kubernetes-sigs/kustomize/tree/master/pkg/target))
   * Field documentarion in the 
-    [canonical example file](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/kustomization.yaml)
+    [canonical example file](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/helloWorld/kustomization.yaml)
   * Usage [examples](https://github.com/kubernetes-sigs/kustomize/tree/master/examples).
 
 


### PR DESCRIPTION
the error url is : https://github.com/kubernetes-sigs/kustomize/blob/master/docs/kustomization.yaml
the right url is :  https://github.com/kubernetes-sigs/kustomize/blob/master/examples/helloWorld/kustomization.yaml