### PR TITLE
add VictimsSelection plugin in scheduling framework

### DIFF
--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -279,7 +279,7 @@ The selection process are performed in cooperating with scheduler and preempt pl
 
 Thus, the plugin can provide two methods to customize behavior of victim pods selection.
 
-- `SelectVictimCandidatesOnNode`: The method receives a potential victim node and its potential victim pods.  And, the method returns victim candidate pods.  Please note the plugin is responsible that the returned victims can create enough room in the node for the preemptor pod.  That means, even if it can't create enough space for the preemptor pod, the scheduling cycle will not abort.  The plugin can use with the [`FrameworkHandle`](#frameworkhandle) for which it assures the selected victims can surely make enough space for the preemptor pod.
+- `SelectVictimCandidatesOnNode`: The method receives a potential victim node and its potential victim pods.  And, the method returns victim candidate pods.  Please note the plugin is responsible that the returned victims can create enough room in the node for the preemptor pod.  That means, even if it can't create enough space for the preemptor pod, the scheduling cycle will not abort. Scheduler also passes a predicate function which accept victim pods and returns they can make enough room for the preemptor pod or not.  You could use this predicate function iteratively to find minimal victim pods.
 
 - `PickOneNodeForPreemption`: The method receives a map from node to victim candidate pods (it might be filtered by extenders) and returns node which should be the victim consequently.
 
@@ -396,7 +396,7 @@ the `FrameworkHandle` provides APIs relevant to the lifetime of a plugin. This
 is how plugins can get a client (`kubernetes.Interface`) and
 `SharedInformerFactory`, or read data from the scheduler's cache of cluster
 state. The handle will also provide APIs to list and approve or reject
-[waiting pods](#permit) and check [the preemptor pod fits to the node](#victimsselection).
+[waiting pods](#permit).
 
 **WARNING**: `FrameworkHandle` provides access to both the kubernetes API server
 and the scheduler's internal cache. The two are **not guaranteed to be in sync**

--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -3,6 +3,7 @@ title: Scheduling Framework
 authors:
   - "@bsalamat"
   - "@misterikkit"
+  - "@everpeace"
 owning-sig: sig-scheduling
 participating-sigs:
 reviewers:
@@ -36,6 +37,9 @@ superseded-by:
     - [Post-filter](#post-filter)
     - [Scoring](#scoring)
     - [Reserve](#reserve)
+    - [Pre-Preempt](#pre-preempt)
+    - [Preempt](#preempt)
+    - [Post-Preempt](#post-preempt)
     - [Permit](#permit)
     - [Pre-bind](#pre-bind)
     - [Bind](#bind)
@@ -264,6 +268,31 @@ state, it will either trigger [Un-reserve](#un-reserve) plugins (on failure) or
 
 *Note: This concept used to be referred to as "assume".*
 
+### Pre-Preempt
+
+This is an informational extension point. Plugins will be called with a pod which was unscheduled and eligible to preemption. A plugin may use this data to update internal state or to generate logs/metrics.
+
+### Preempt
+
+The plugin provides an extension point for selecting the victim pods for preemption.  Only one preempt plugin may be enabled at a time.  
+
+The selection process are performed in cooperating with scheduler and preempt plugin as follows.
+
+1. Scheduler firstly filters _potential victim nodes_ that satisfies the following two conditions.  It contains _potential victim pods_ that are allowed to be preempted by the preemptor pod according to their `spec.preemptionPolicy`.  The other is the preemptor pod can be schedulable when all the potential victim pods are assumed to be preempted.
+1. For each potential victim node, scheduler filters several pods as _victim candidate pods_ from potential victim pods with the plugin's help (see `SelectVictimCandidatesOnNode`).
+1. Scheduler calls scheduler extenders, if configured, to filter victim candidate pods.
+1. Scheduler picks one node from the potential victim nodes for preemption with the plugin's help (see `PickOneNodeForPreemption`).
+
+Thus, the plugin can provide two methods to customize behavior of victim pods selection.
+
+- `SelectVictimCandidatesOnNode`: The method receives a potential victim node and its potential victim pods.  And, the method returns victim candidate pods.  Please note the plugin is responsible that the returned victims can create enough room in the node for the preemptor pod.  That means, even if it can't create enough space for the preemptor pod, the scheduling cycle will not abort.  The plugin can use with the [`FrameworkHandle`](#frameworkhandle) for which it assures the selected victims can surely make enough space for the preemptor pod.
+
+- `PickOneNodeForPreemption`: The method receives a map from node to victim candidate pods (it might be filtered by extenders) and returns node which should be the victim consequently.
+
+### Post-Preempt
+
+This is an informational extension point. Plugins will be called with the node and victim pods which will be preempted. A plugin may use this data to update internal state or to generate logs/metrics.
+
 ### Permit
 
 These plugins are used to prevent or delay the binding of a Pod. A permit plugin
@@ -377,7 +406,7 @@ the `FrameworkHandle` provides APIs relevant to the lifetime of a plugin. This
 is how plugins can get a client (`kubernetes.Interface`) and
 `SharedInformerFactory`, or read data from the scheduler's cache of cluster
 state. The handle will also provide APIs to list and approve or reject
-[waiting pods](#permit).
+[waiting pods](#permit) and check [the preemptor pod fits to the node](#preempt).
 
 **WARNING**: `FrameworkHandle` provides access to both the kubernetes API server
 and the scheduler's internal cache. The two are **not guaranteed to be in sync**

--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -272,7 +272,7 @@ The plugin provides an extension point for selecting the victim pods for preempt
 
 The selection process are performed in cooperating with scheduler and preempt plugin as follows.
 
-1. Scheduler firstly filters _potential victim nodes_ that satisfies the following two conditions.  It contains _potential victim pods_ that are allowed to be preempted by the preemptor pod according to their `spec.preemptionPolicy`.  The other is the preemptor pod can be schedulable when all the potential victim pods are assumed to be preempted.
+1. Scheduler firstly filters _potential victim nodes_ that satisfies the following two conditions.  It contains _potential victim pods_ that are allowed to be preempted by the preemptor pod's `spec.preemptionPolicy`. For example, if the preemptor pods' `spec.preemptionPolicy` is `Never`,  no victims are selected for any nodes.  The other is the preemptor pod can be schedulable when all the potential victim pods are assumed to be preempted.
 1. For each potential victim node, scheduler filters several pods as _victim candidate pods_ from potential victim pods with the plugin's help (see `SelectVictimCandidatesOnNode`).
 1. Scheduler calls scheduler extenders, if configured, to filter victim candidate pods.
 1. Scheduler picks one node from the potential victim nodes for preemption with the plugin's help (see `PickOneNodeForPreemption`).

--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -37,9 +37,7 @@ superseded-by:
     - [Post-filter](#post-filter)
     - [Scoring](#scoring)
     - [Reserve](#reserve)
-    - [Pre-Preempt](#pre-preempt)
     - [Preempt](#preempt)
-    - [Post-Preempt](#post-preempt)
     - [Permit](#permit)
     - [Pre-bind](#pre-bind)
     - [Bind](#bind)
@@ -268,10 +266,6 @@ state, it will either trigger [Un-reserve](#un-reserve) plugins (on failure) or
 
 *Note: This concept used to be referred to as "assume".*
 
-### Pre-Preempt
-
-This is an informational extension point. Plugins will be called with a pod which was unscheduled and eligible to preemption. A plugin may use this data to update internal state or to generate logs/metrics.
-
 ### Preempt
 
 The plugin provides an extension point for selecting the victim pods for preemption.  Only one preempt plugin may be enabled at a time.  
@@ -288,10 +282,6 @@ Thus, the plugin can provide two methods to customize behavior of victim pods se
 - `SelectVictimCandidatesOnNode`: The method receives a potential victim node and its potential victim pods.  And, the method returns victim candidate pods.  Please note the plugin is responsible that the returned victims can create enough room in the node for the preemptor pod.  That means, even if it can't create enough space for the preemptor pod, the scheduling cycle will not abort.  The plugin can use with the [`FrameworkHandle`](#frameworkhandle) for which it assures the selected victims can surely make enough space for the preemptor pod.
 
 - `PickOneNodeForPreemption`: The method receives a map from node to victim candidate pods (it might be filtered by extenders) and returns node which should be the victim consequently.
-
-### Post-Preempt
-
-This is an informational extension point. Plugins will be called with the node and victim pods which will be preempted. A plugin may use this data to update internal state or to generate logs/metrics.
 
 ### Permit
 

--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -37,7 +37,7 @@ superseded-by:
     - [Post-filter](#post-filter)
     - [Scoring](#scoring)
     - [Reserve](#reserve)
-    - [Preempt](#preempt)
+    - [VictimsSelection](#victimsselection)
     - [Permit](#permit)
     - [Pre-bind](#pre-bind)
     - [Bind](#bind)
@@ -266,7 +266,7 @@ state, it will either trigger [Un-reserve](#un-reserve) plugins (on failure) or
 
 *Note: This concept used to be referred to as "assume".*
 
-### Preempt
+### VictimsSelection
 
 The plugin provides an extension point for selecting the victim pods for preemption.  Only one preempt plugin may be enabled at a time.  
 
@@ -396,7 +396,7 @@ the `FrameworkHandle` provides APIs relevant to the lifetime of a plugin. This
 is how plugins can get a client (`kubernetes.Interface`) and
 `SharedInformerFactory`, or read data from the scheduler's cache of cluster
 state. The handle will also provide APIs to list and approve or reject
-[waiting pods](#permit) and check [the preemptor pod fits to the node](#preempt).
+[waiting pods](#permit) and check [the preemptor pod fits to the node](#victimsselection).
 
 **WARNING**: `FrameworkHandle` provides access to both the kubernetes API server
 and the scheduler's internal cache. The two are **not guaranteed to be in sync**


### PR DESCRIPTION
This PR addresses: https://github.com/kubernetes/kubernetes/issues/85871

I added `VictimsSelection` extension point to expose more flexible control of the preemption logic to end-users.

# Topics on design consideration

## Point 1: scheduling framework can break the spec?

I don't think so.  kube-scheduler does have public api for preemption ([`PriorityClass` and their semantics(e.g. `PreemptionPolicy`, and affinity takes into consideration in preemption, etc.)](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)).  I think we can't break the spec even if we can give more control for customizing preemption behavior.  Thus, I designed the flexibility of `VictimsSelection` extension point within the spec.

## Point 2: how to handle scheduler extender in this extension point ??

We currently provide [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) to a mechanism to extend kube-scheduler behavior and it includes an extension point to filter kube-scheduler selected victims.  I think we should keep backward compatibility.  So, I designed the extension point so that it can interact with extenders.

# TODO:
- [ ] update diagrams in KEP
  - I would like to discuss the sentences of the KEP first.  Once we agreed with the sentences, I would like to update diagram in the KEP.  

---

/sig scheduling

