### PR TITLE
Update dry-run KEP with kubectl plan

### DIFF
--- a/keps/sig-api-machinery/0015-dry-run.md
+++ b/keps/sig-api-machinery/0015-dry-run.md
@@ -32,6 +32,7 @@ for the request should be as close as possible to a non dry-run response.
 - [Admission controllers](#admission-controllers)
 - [Generated values](#generated-values)
 - [Storage](#storage)
+- [kubectl](#kubectl)
 <!-- /toc -->
 
 ## Specifying dry-run
@@ -150,3 +151,22 @@ A dry-run request should behave as close as possible to a regular
 request. Attempting to dry-run create an existing object will result in an
 `AlreadyExists` error to be returned. Similarly, if a dry-run update is
 performed on a non-existing object, a `NotFound` error will be returned.
+
+## kubectl
+
+For the `kubectl` client integration with server-side dry-run, we will pass
+the `dryRun` query parameter by reading the user's intent from a flag.
+
+For beta, we use `--server-dry-run` for `kubectl apply` to exercise
+server-side apply. This flag will be deprecated next release and removed in 2 releases.
+
+For GA, we'll use the existing `--dry-run` flag available on `kubectl apply`.
+
+Currently, the `--dry-run` flag is a boolean for subcommands including
+`kubectl apply` and `kubectl create`.
+
+We'll extend the flag to accept strings for new options `client` and `server`
+for selecting client-side and server-side behavior.  For backwards compatibility,
+we'll continue to default to `--dry-run=true` as
+the default, which is equivalent to `--dry-run=client`.
+

--- a/keps/sig-api-machinery/0015-dry-run.md
+++ b/keps/sig-api-machinery/0015-dry-run.md
@@ -158,7 +158,7 @@ For the `kubectl` client integration with server-side dry-run, we will pass
 the `dryRun` query parameter by reading the user's intent from a flag.
 
 For beta, we use `--server-dry-run` for `kubectl apply` to exercise
-server-side apply. This flag will be removed next release.
+server-side apply. This flag will be deprecated next release, then removed after 1 release.
 
 For GA, we'll use the existing `--dry-run` flag available on `kubectl apply`.
 

--- a/keps/sig-api-machinery/0015-dry-run.md
+++ b/keps/sig-api-machinery/0015-dry-run.md
@@ -207,5 +207,13 @@ func ParseDryRun(dryRunFlag string) (DryRunEnum, error) {
   }
   return DryRunNone, nil
 }
+
+func AddDryRunFlag(cmd *cobra.Command) {
+	cmd.Flags().String(
+      "dry-run",
+      "client",
+      `Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.`
+      )
+}
 ```
 

--- a/keps/sig-api-machinery/0015-dry-run.md
+++ b/keps/sig-api-machinery/0015-dry-run.md
@@ -158,17 +158,20 @@ For the `kubectl` client integration with server-side dry-run, we will pass
 the `dryRun` query parameter by reading the user's intent from a flag.
 
 For beta, we use `--server-dry-run` for `kubectl apply` to exercise
-server-side apply. This flag will be deprecated next release and removed in 2 releases.
+server-side apply. This flag will be deprecated next release, then removed in 2 releases.
 
-For GA, we'll use the existing `--dry-run` flag available on `kubectl apply`.
+For GA, we'll use the existing `--dry-run` flag available on `kubectl apply`.j
 
 Currently, the `--dry-run` flag is a boolean for subcommands including
 `kubectl apply` and `kubectl create`.
 
-We'll extend the flag to accept strings for new options `client` and `server`
-for selecting client-side and server-side behavior.  For backwards compatibility,
-we'll continue to default to `--dry-run=true` as
-the default, which is equivalent to `--dry-run=client`.
+We'll extend the flag to accept strings for new options
+for selecting client-side and server-side behavior: `client`, `server`, and
+`none`.
 
-The boolean values for `--dry-run` will be deprecated and removed in 2 releases.
+For backwards compatibility, we'll continue to default the value for `--dry-run`
+to `--dry-run=client`, which is equivalent to the existing behavior for
+`--dry-run=true`.
+
+The boolean values for `--dry-run` will be deprecated next release, then removed in 2 releases.
 

--- a/keps/sig-api-machinery/0015-dry-run.md
+++ b/keps/sig-api-machinery/0015-dry-run.md
@@ -170,3 +170,5 @@ for selecting client-side and server-side behavior.  For backwards compatibility
 we'll continue to default to `--dry-run=true` as
 the default, which is equivalent to `--dry-run=client`.
 
+The boolean values for `--dry-run` will be deprecated and removed in 2 releases.
+


### PR DESCRIPTION
For server-side dry-run GA, we want to support `--dry-run=server`.

This change updates the KEP to describe this plan, as discussed in https://github.com/kubernetes/kubernetes/issues/85652