### PR TITLE
Clarifying default Ingress PathType and corresponding validation.

### DIFF
--- a/keps/sig-network/20190125-ingress-api-group.md
+++ b/keps/sig-network/20190125-ingress-api-group.md
@@ -31,6 +31,7 @@ superseded-by:
     - [Potential features for post V1](#potential-features-for-post-v1)
   - [Path as a prefix](#path-as-a-prefix)
     - [Paths proposal](#paths-proposal)
+      - [Defaults](#defaults)
       - [Path matching semantics](#path-matching-semantics)
       - [<code>Exact</code> match](#-match)
       - [<code>Prefix</code> match](#-match-1)
@@ -233,9 +234,14 @@ Note: default value are permitted between API versions
 
 [api-conv-versions]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#defaulting
 
+##### Defaults
+
+The `PathType` field will default to a value of `ImplementationSpecific` to
+provide backwards compatibility. 
+
 ##### Path matching semantics
 
-For non-`ImplementationSpecific` paths:
+For `Prefix` and `Exact` paths:
 
 1. Let `[p_1, p_2, ..., p_n]` be the list of Paths for a specific host.
 1. Every Path `p_i` must be syntactically valid:
@@ -252,7 +258,7 @@ For non-`ImplementationSpecific` paths:
       preference depends on the implementation.
 1. If there is no matching path, then the `defaultBackend` for the host will be
    used.
-1. If there is not match for the host, then the overall `defaultBackend` for
+1. If there is not a match for the host, then the overall `defaultBackend` for
    the Ingress will be selected.
 
 ##### `Exact` match
@@ -339,7 +345,7 @@ The `IngressRule.Host` specification would be changed to:
 > http host header is to equal to the suffix (removing the first
 > label) of the wildcard rule.
 >
-> - The wildcard character `'*'` must appear by itself as a the first
+> - The wildcard character `'*'` must appear by itself as the first
 >   DNS label and matches only a single label.
 > - You cannot have a wildcard label by itself (e.g. `Host == "*"`).
 


### PR DESCRIPTION
This PR has a lot of discussion, the final proposal ended up being very simple:

* Default to ImplementationSpecific PathType for Ingress to ensure backwards compatibility

---
_For posterity, here's what the original proposal was:_

To ensure backwards compatibility, we need to ensure that existing Ingresses continue to be valid. Both `Exact` and `Prefix` path types include more validation than currently included by ingresses, specifically that they must not contain consecutive `'/'` characters. Additionally, Ingress path validation currently includes a requirement that all paths are valid regexes, something not required by either `Exact` or `Prefix` path types. The new `ImplementationSpecific` path type comes with no API validation as defined by this KEP. 

As I see it, there are several options:
1. Maintain the current path validation when Ingress Path is not specified (currently the default behavior in this KEP).
2. Make `ImplementationSpecific` the default path type, effectively removing the current path validation.
3. Create a new `RegularExpression` path type, make that default, and use the same validation that is currently enforced (leading `/` + valid regex).
4. Remove the proposed validation that paths must not contain consecutive `'/'` characters and make `Prefix` the default path type, effectively removing the requirements that paths be a valid regex from the current Ingress path validation.

For the sake of a starting point, I've proposed option 1, but I'm open to any of the above proposals and/or anything else that makes sense. 

/sig network
/cc @bowei @cmluciano @thockin 