### PR TITLE
correct error links in sig-cloud-provider

### DIFF
--- a/keps/sig-cloud-provider/20190125-out-of-tree-aws.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-aws.md
@@ -53,7 +53,7 @@ that has feature parity to the kube-controller-manager.
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md). 
+Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md). 
 This KEP is specifically tracking progress for the AWS cloud provider.
 
 ### Goals
@@ -63,7 +63,7 @@ This KEP is specifically tracking progress for the AWS cloud provider.
 
 ### Non-Goals
 
-* Removing in-tree AWS cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2019-01-25-removing-in-tree-providers.md).
+* Removing in-tree AWS cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md).
 
 ## Proposal
 

--- a/keps/sig-cloud-provider/20190125-out-of-tree-gce.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-gce.md
@@ -53,7 +53,7 @@ that has feature parity to the kube-controller-manager.
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md). 
+Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md). 
 This KEP is specifically tracking progress for the GCE cloud provider.
 
 ### Goals
@@ -63,7 +63,7 @@ This KEP is specifically tracking progress for the GCE cloud provider.
 
 ### Non-Goals
 
-* Removing in-tree GCE cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2019-01-25-removing-in-tree-providers.md).
+* Removing in-tree GCE cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md).
 
 ## Proposal
 

--- a/keps/sig-cloud-provider/20190125-out-of-tree-ibm.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-ibm.md
@@ -53,7 +53,7 @@ that has feature parity to the kube-controller-manager.
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md). 
+Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md). 
 This KEP is specifically tracking progress for the IBM cloud provider.
 
 ### Goals
@@ -63,7 +63,7 @@ This KEP is specifically tracking progress for the IBM cloud provider.
 
 ### Non-Goals
 
-* Removing in-tree IBM cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2019-01-25-removing-in-tree-providers.md).
+* Removing in-tree IBM cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md).
 
 ## Proposal
 

--- a/keps/sig-cloud-provider/20190125-out-of-tree-openstack.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-openstack.md
@@ -57,7 +57,7 @@ that has feature parity to the kube-controller-manager.
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md). 
+Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md). 
 This KEP is specifically tracking progress for the OpenStack cloud provider.
 
 ### Goals
@@ -67,7 +67,7 @@ This KEP is specifically tracking progress for the OpenStack cloud provider.
 
 ### Non-Goals
 
-* Removing in-tree OpenStack cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2019-01-25-removing-in-tree-providers.md).
+* Removing in-tree OpenStack cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md).
 
 ## Proposal
 The OpenStack Cloud Provider is implemented, tested and documented, It is being released with matching kubernetes version from [release v1.11](https://github.com/kubernetes/cloud-provider-openstack/releases). cloud-provider-openstack release 1.14, 1.15, 1.16 has been running in production.

--- a/keps/sig-cloud-provider/20190125-out-of-tree-vsphere.md
+++ b/keps/sig-cloud-provider/20190125-out-of-tree-vsphere.md
@@ -62,7 +62,7 @@ that has feature parity to the kube-controller-manager.  This KEP captures mostl
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md). 
+Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md). 
 This KEP is specifically tracking progress for the vSphere cloud provider.
 
 ### Goals
@@ -72,7 +72,7 @@ This KEP is specifically tracking progress for the vSphere cloud provider.
 
 ### Non-Goals
 
-* Removing in-tree vSphere cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2019-01-25-removing-in-tree-providers.md).
+* Removing in-tree vSphere cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md).
 
 ## Proposal
 

--- a/keps/sig-cloud-provider/azure/20190125-out-of-tree-azure.md
+++ b/keps/sig-cloud-provider/azure/20190125-out-of-tree-azure.md
@@ -67,7 +67,7 @@ that has feature parity to the kube-controller-manager.
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md).
+Motivation for supporting out-of-tree providers can be found in [KEP-0002](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md).
 This KEP is specifically tracking progress for the Azure cloud provider.
 
 ### Goals
@@ -77,7 +77,7 @@ This KEP is specifically tracking progress for the Azure cloud provider.
 
 ### Non-Goals
 
-- Removing in-tree Azure cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2019-01-25-removing-in-tree-providers.md).
+- Removing in-tree Azure cloud provider code, this effort falls under the [KEP for removing in-tree providers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190125-removing-in-tree-providers.md).
 
 ## Proposal
 


### PR DESCRIPTION
correct error links in sig-cloud-provider:
- cloud-controller-manager
- removing-in-tree-providers