### PR TITLE
Document Ingress for GA

### DIFF
--- a/keps/sig-network/20190125-ingress-api-group.md
+++ b/keps/sig-network/20190125-ingress-api-group.md
@@ -629,6 +629,7 @@ backend:
 
 - [ ] 1.17: API finalized and implemented on the branch.
 - [ ] 1.XX: Ingress spec and conformance tests finalized and running against branch.
+- [ ] 1.XX: Review & update Ingress [documentation](https://k8s.io/docs/concepts/services-networking/ingress/)
 - [ ] 1.XX: API changes merged into the main API, with tests from v1beta1 pointing to GA.
 
 ## Implementation History


### PR DESCRIPTION
Before / as Ingress goes GA, provide clear-enough and current-enough documentation. Update _Graduate Ingress to GA_ to note this as a requirement for graduation.

/sig docs
/sig network