### PR TITLE
Update service finalizer KEP to implemented

### DIFF
--- a/keps/sig-network/20190423-service-lb-finalizer.md
+++ b/keps/sig-network/20190423-service-lb-finalizer.md
@@ -16,8 +16,8 @@ approvers:
   - "@thockin"
 editor: TBD
 creation-date: 2019-04-23
-last-updated: 2019-04-29
-status: implementable
+last-updated: 2020-01-06
+status: implemented
 see-also:
 replaces:
 superseded-by:


### PR DESCRIPTION
Ref https://github.com/kubernetes/enhancements/issues/980#issuecomment-570606885, service finalizer has graduated to stable in 1.17.

/cc @jeremyrickard 