### PR TITLE
OWNERS_ALIASES: add fabriziopandini and neolit123 to SCL leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -29,8 +29,9 @@ aliases:
     - andrewsykim
     - cheftako
   sig-cluster-lifecycle-leads:
+    - fabriziopandini
     - justinsb
-    - luxas
+    - neolit123
     - timothysc
   sig-contributor-experience-leads:
     - Phillels


### PR DESCRIPTION
/assign @timothysc
/sig cluster-lifecycle

xref: https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle#leadership

Remove luxas to sync with k/community as requested by justaugustus.
