### PR TITLE
Modify KEPify JSON output

### DIFF
--- a/cmd/kepify/main.go
+++ b/cmd/kepify/main.go
@@ -17,10 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,40 +135,15 @@ func printJSONOutput(filePath string, proposals keps.Proposals) error {
 	total := len(proposals)
 	fmt.Printf("Total KEPs: %d\n", total)
 
-	fmt.Fprintln(file, "{")
-	for i, kep := range proposals {
-		fmt.Fprintf(file, "\t\"%s\": {\n", hash(kep.OwningSIG+":"+kep.Title))
-		fmt.Fprintf(file, "\t\t\"%s\": \"%s\",\n", "title", kep.Title)
-		fmt.Fprintf(file, "\t\t\"%s\": \"%s\",\n", "owning-sig", kep.OwningSIG)
-		fmt.Fprintf(file, "\t\t\"%s\": %s,\n", "participating-sigs", marshal(kep.ParticipatingSIGs))
-		fmt.Fprintf(file, "\t\t\"%s\": %s,\n", "reviewers", marshal(kep.Reviewers))
-		fmt.Fprintf(file, "\t\t\"%s\": %s,\n", "authors", marshal(kep.Authors))
-		fmt.Fprintf(file, "\t\t\"%s\": \"%s\",\n", "editor", kep.Editor)
-		fmt.Fprintf(file, "\t\t\"%s\": \"%s\",\n", "creation-date", kep.CreationDate)
-		fmt.Fprintf(file, "\t\t\"%s\": \"%s\",\n", "last-updated", kep.LastUpdated)
-		fmt.Fprintf(file, "\t\t\"%s\": \"%s\",\n", "status", kep.Status)
-		fmt.Fprintf(file, "\t\t\"%s\": %s,\n", "see-also", marshal(kep.SeeAlso))
-		fmt.Fprintf(file, "\t\t\"%s\": %s,\n", "replaces", marshal(kep.Replaces))
-		fmt.Fprintf(file, "\t\t\"%s\": %s,\n", "superseded-by", marshal(kep.SupersededBy))
-		contents, _ := json.Marshal(kep.Contents)
-		fmt.Fprintf(file, "\t\t\"%s\": %s\n", "markdown", contents)
-		if i < total-1 {
-			fmt.Fprintln(file, "\t},")
-		} else {
-			fmt.Fprintln(file, "\t}")
-		}
+	data, err := json.Marshal(proposals)
+	if err != nil {
+		return err
 	}
-	fmt.Fprintln(file, "}")
+	if err := ioutil.WriteFile(filePath, data, 0755); err != nil {
+		return err
+	}
+
 	return nil
-}
-
-func marshal(array []string) string {
-	contents, _ := json.Marshal(array)
-	return string(contents)
-}
-
-func hash(s string) string {
-	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
 }
 
 /// ignore certain files in the keps/ subdirectory

--- a/pkg/kepval/keps/proposals.go
+++ b/pkg/kepval/keps/proposals.go
@@ -19,6 +19,8 @@ package keps
 import (
 	"bufio"
 	"bytes"
+	"crypto/md5"
+	"fmt"
 	"io"
 	"strings"
 
@@ -34,23 +36,24 @@ func (p *Proposals) AddProposal(proposal *Proposal) {
 }
 
 type Proposal struct {
-	Title             string   `yaml:"title"`
-	Authors           []string `yaml:,flow`
-	OwningSIG         string   `yaml:"owning-sig"`
-	ParticipatingSIGs []string `yaml:"participating-sigs",flow,omitempty`
-	Reviewers         []string `yaml:,flow`
-	Approvers         []string `yaml:,flow`
-	Editor            string   `yaml:"editor,omitempty"`
-	CreationDate      string   `yaml:"creation-date"`
-	LastUpdated       string   `yaml:"last-updated"`
-	Status            string   `yaml:"status"`
-	SeeAlso           []string `yaml:"see-also,omitempty"`
-	Replaces          []string `yaml:"replaces,omitempty"`
-	SupersededBy      []string `yaml:"superseded-by,omitempty"`
+	ID                string   `json:"id"`
+	Title             string   `json:"title" yaml:"title"`
+	Authors           []string `json:"authors" yaml:",flow"`
+	OwningSIG         string   `json:"owningSig" yaml:"owning-sig"`
+	ParticipatingSIGs []string `json:"participatingSigs" yaml:"participating-sigs,flow,omitempty"`
+	Reviewers         []string `json:"reviewers" yaml:",flow"`
+	Approvers         []string `json:"approvers" yaml:",flow"`
+	Editor            string   `json:"editor" yaml:"editor,omitempty"`
+	CreationDate      string   `json:"creationDate" yaml:"creation-date"`
+	LastUpdated       string   `json:"lastUpdated" yaml:"last-updated"`
+	Status            string   `json:"status" yaml:"status"`
+	SeeAlso           []string `json:"seeAlso" yaml:"see-also,omitempty"`
+	Replaces          []string `json:"replaces" yaml:"replaces,omitempty"`
+	SupersededBy      []string `json:"supersededBy" yaml:"superseded-by,omitempty"`
 
-	Filename string `yaml:"-"`
-	Error    error  `yaml:"-"`
-	Contents string `yaml:"-"`
+	Filename string `json:"-" yaml:"-"`
+	Error    error  `json:"-" yaml:"-"`
+	Contents string `json:"markdown" yaml:"-"`
 }
 
 type Parser struct{}
@@ -92,5 +95,10 @@ func (p *Parser) Parse(in io.Reader) *Proposal {
 	}
 
 	proposal.Error = yaml.UnmarshalStrict(metadata, proposal)
+	proposal.ID = hash(proposal.OwningSIG + ":" + proposal.Title)
 	return proposal
+}
+
+func hash(s string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
 }


### PR DESCRIPTION
This makes the JSON output of the kepify tool a bit easier parsable, since we now marshal into an array of objects. Beside this, we add the KEP ID (hashed value) as `ID` field to each proposal as well.

We have to avoid dashes in the JSON keys to be able to directly map the keys into Typescript structures.

Follow up of: https://github.com/kubernetes/enhancements/pull/1467
Initiated by: https://github.com/kubernetes-sigs/release-notes/pull/140

The new layout:
```json
[
  {
    "id": "5322b8bc501906188172ab1818558107",
    "title": "aws-k8s-tester",
    "authors": ["@gyuho"],
    "owningSig": "sig-cloud-provider",
    "participatingSigs": null,
    "reviewers": ["@d-nishi", "@shyamjvs"],
    "approvers": ["@d-nishi", "@shyamjvs"],
    "editor": "TBD",
    "creationDate": "2018-11-26",
    "lastUpdated": "2018-11-29",
    "status": "provisional",
    "seeAlso": null,
    "replaces": null,
    "supersededBy": null,
    "markdown": "\n# aws-k8s-tester - kubetest plugin for AWS and EKS\n\n## Table of Contents\n\n\u003c!-- toc --\u003e\n- [Summary](#summary)\n- [Motivation](#motivation)\n  - [Goals](#goals)\n  - [Non-Goals](#non-goals)\n- [Proposal](#proposal)\n  - [User Stories](#user-stories)\n    - [Kubernetes E2E test workflow: upstream, Prod EKS builds](#kubernetes-e2e-test-workflow-upstream-prod-eks-builds)\n    - [Sub-project E2E test workflow: upstream, ALB Ingress Controller](#sub-project-e2e-test-workflow-upstream-alb-ingress-controller)\n  - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)\n  - [Risks and Mitigations](#risks-and-mitigations)\n- [Graduation Criteria](#graduation-criteria)\n- [Implementation History](#implementation-history)\n\u003c!-- /toc --\u003e\n\n## Summary\n\nAll e2e tests maintained by AWS uses `aws-k8s-tester` as a plugin to kubetest. `aws-k8s-tester` runs various Kubernetes testing operations (e.g. create a temporary EKS cluster) mainly to implement [`kubernetes/test-infra/kubetest.deployer`](https://github.com/kubernetes/test-infra/blob/40b4010f8e38582a5786adedd4e04cf4e1fc5a36/kubetest/main.go#L222-L229) interface.\n\n## Motivation\n\nMany AWS tests are run by community projects such as [kops](https://github.com/kubernetes/kops), which does not test EKS. Does EKS Service check out-of-range NodePort? Does EKS Service prevent NodePort collisions? Can EKS support 5,000 nodes? There were thousands more to cover. Incomplete test coverage feeds production issues: one component failure may evolve into cluster-wide outage, Kubernetes CSI driver might be incompatible with Amazon EBS, customers may experience scalability problems from untested features, etc. Complete test coverage will unearth such issues beforehand, which leads to better customer experience. This work alone will make a huge impact on improving EKS reliability and its release cadence.\n\n### Goals\n\nThe following key features are in scope:\n\n* EKS cluster creation/teardown\n* Test open-source Kubernetes distribution (e.g. wrap kubeadm to run Kubernetes e2e tests)\n* Create AWS resources to test AWS sub-projects (e.g. create EC2 instances to test CSI driver)\n\nThese are the key design principles that guides EKS testing development:\n\n- *Platform Uniformity*: EKS provides a native Kubernetes experience. To keep two platforms in sync, EKS must be tested with upstream Kubernetes. Whenever a new feature is added to Kubernetes, customer should assume it will be tested against EKS. For example, encryption provider feature was added to Kubernetes 1.10 as an alpha feature, but customers have to wait until it becomes a stable feature. Rigorous test coverage will enable more new features to customers at earliest.\n- *Maximize Productivity*: Test automation is essential to EKS development productivity at scale. EKS team should do the minimum amount of work possible to upgrade Kubernetes (including etcd). To this end, pre-prod and prod EKS builds will be continuously tested for every PR created in upstream Kubernetes. For example, etcd client upgrade in API server must be tested against EKS control plane components. If the upgrade test fails EKS, we should block the change.\n- *Transparency for Community*: We want to contribute EKS tests to upstream and make test results visible to the whole communities. Users should be able to see how EKS performs with 5,000 worker nodes and compare it with other providers, just by looking at upstream performance dashboard.\n\n### Non-Goals\n\n* The project does not replace kops or kubeadm.\n* This project is only meant for testing.\n\n## Proposal\n\n### User Stories\n\n#### Kubernetes E2E test workflow: upstream, Prod EKS builds\n\nEKS uses `aws-k8s-tester` as a plugin to kubetest. `aws-k8s-tester` is a broker that creates and deletes AWS resources on behalf of kubetest, connects to pre-prod EKS clusters, reports test results back to dashboards, etc. Every upstream change will be tested against EKS cluster.\n\nFigure 1 shows how AWS would run Kubernetes e2e tests inside EKS (e.g. ci-kubernetes-e2e-aws-eks).\n\n![20181126-aws-k8s-tester-figure-01](20181126-aws-k8s-tester-figure-01.png)\n\n#### Sub-project E2E test workflow: upstream, ALB Ingress Controller\n\nLet's take ALB Ingress Controller for example. Since Kubernetes cluster is a prerequisite to ALB Ingress Controller, `aws-k8s-tester` first creates EKS cluster. Then ALB Ingress Controller plug-in deploys and creates Ingress objects, with sample web server and client. awstester is configured through YAML rather than POSIX flags. This makes it easier to implement sub-project add-ons (e.g. add “alb-ingress-controller” field to set up ingress add-on). Cluster status, ingress controller states, and testing results are persisted to disk for status report and debugging purposes.\n\nFigure 2 shows how `aws-k8s-tester` plugin creates and tests ALB Ingress Controller.\n\n![20181126-aws-k8s-tester-figure-02](20181126-aws-k8s-tester-figure-02.png)\n\n### Implementation Details/Notes/Constraints\n\nWe implement kubetest plugin, out-of-tree and provided as a single binary file. Separate code base speeds up development and makes dependency management easier. For example, kops in kubetest uses AWS SDK [v1.12.53](https://github.com/aws/aws-sdk-go/releases/tag/v1.12.53), which was released at December 2017. Upgrading SDK to latest would break existing kops. Packaging everything in a separate binary gives us freedom to choose whatever SDK version we need.\n\n### Risks and Mitigations\n\n* *“aws-k8s-tester” creates a key-pair using EC2 API. Is the private key safely managed?* Each test run creates a temporary key pair and stores the private key on disk. The private key is used to SSH access into Kubernetes worker nodes and read service logs from the EC2 instance. “aws-k8s-tester” safely [deletes the private key on disk](https://github.com/aws/aws-k8s-tester/blob/cde0484f0ae167d8831442a48b4b5e447481af45/internal/ec2/key_pair.go#L65) and [destroys all associated AWS resources](https://github.com/aws/aws-k8s-tester/blob/cde0484f0ae167d8831442a48b4b5e447481af45/internal/ec2/key_pair.go#L71-L73), whether the test completes or get interrupted. For instance, when it deletes the key pair object from EC2, the public key is also deleted, which means the local private key has no use for any threat.\n* *Does “aws-k8s-tester” store any sensitive information?* “aws-k8s-tester” maintains a test cluster state in [`ClusterState`](https://godoc.org/github.com/aws/awstester/eksconfig#ClusterState), which is periodically synced to local disk and S3. It does not contain any sensitive data such as private key blobs.\n* *Upstream Kubernetes test-infra team mounts our AWS test credential to their Prow cluster. Can anyone access the credential?* Upstream Prow cluster schedules all open-source Kubernetes test runs. In order to test EKS from upstream Kubernetes, AWS credential must be accessible from each test job. Currently, it is mounted as a Secret object (https://kubernetes.io/docs/concepts/configuration/secret/) in upstream Prow cluster. Which means our AWS credential is still stored as base64-encoded plaintext in etcd. Then, there are two ways to access this data. One is to read from Prow testing pod (see [test-infra/PR#9940](https://github.com/kubernetes/test-infra/pull/9940/files)). In theory, any test job has access to “eks-aws-credentials” secret object, thus can maliciously mount it to steal the credential. In practice, every single job needs an approval before it runs any tests. So, if anybody tries to exploit the credential, the change should be rejected beforehand. Two, read the non-encrypted credential data from etcd. This is unlikely as well. We can safely assume that Google GKE deploys etcd in a trusted environment, where the access is restricted to Google test-infra team. See https://kubernetes.io/docs/concepts/configuration/secret/#risks for more.\n\n## Graduation Criteria\n\n`aws-k8s-tester` will be considered successful when it is used by the majority of AWS Kubernetes e2e tests.\n\n## Implementation History\n\n* Initial integration with upstream has been tracked \n* Initial proposal to SIG 2018-11-26\n* Initial KEP draft 2018-11-26\n"
  }
]
```

Compared to the old
```json
{
	"5322b8bc501906188172ab1818558107": {
		"title": "aws-k8s-tester",
		"owning-sig": "sig-cloud-provider",
		"participating-sigs": null,
		"reviewers": ["@d-nishi","@shyamjvs"],
		"authors": ["@gyuho"],
		"editor": "TBD",
		"creation-date": "2018-11-26",
		"last-updated": "2018-11-29",
		"status": "provisional",
		"see-also": null,
		"replaces": null,
		"superseded-by": null,
		"markdown": "\n# aws-k8s-tester - kubetest plugin for AWS and EKS\n\n## Table of Contents\n\n\u003c!-- toc --\u003e\n- [Summary](#summary)\n- [Motivation](#motivation)\n  - [Goals](#goals)\n  - [Non-Goals](#non-goals)\n- [Proposal](#proposal)\n  - [User Stories](#user-stories)\n    - [Kubernetes E2E test workflow: upstream, Prod EKS builds](#kubernetes-e2e-test-workflow-upstream-prod-eks-builds)\n    - [Sub-project E2E test workflow: upstream, ALB Ingress Controller](#sub-project-e2e-test-workflow-upstream-alb-ingress-controller)\n  - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)\n  - [Risks and Mitigations](#risks-and-mitigations)\n- [Graduation Criteria](#graduation-criteria)\n- [Implementation History](#implementation-history)\n\u003c!-- /toc --\u003e\n\n## Summary\n\nAll e2e tests maintained by AWS uses `aws-k8s-tester` as a plugin to kubetest. `aws-k8s-tester` runs various Kubernetes testing operations (e.g. create a temporary EKS cluster) mainly to implement [`kubernetes/test-infra/kubetest.deployer`](https://github.com/kubernetes/test-infra/blob/40b4010f8e38582a5786adedd4e04cf4e1fc5a36/kubetest/main.go#L222-L229) interface.\n\n## Motivation\n\nMany AWS tests are run by community projects such as [kops](https://github.com/kubernetes/kops), which does not test EKS. Does EKS Service check out-of-range NodePort? Does EKS Service prevent NodePort collisions? Can EKS support 5,000 nodes? There were thousands more to cover. Incomplete test coverage feeds production issues: one component failure may evolve into cluster-wide outage, Kubernetes CSI driver might be incompatible with Amazon EBS, customers may experience scalability problems from untested features, etc. Complete test coverage will unearth such issues beforehand, which leads to better customer experience. This work alone will make a huge impact on improving EKS reliability and its release cadence.\n\n### Goals\n\nThe following key features are in scope:\n\n* EKS cluster creation/teardown\n* Test open-source Kubernetes distribution (e.g. wrap kubeadm to run Kubernetes e2e tests)\n* Create AWS resources to test AWS sub-projects (e.g. create EC2 instances to test CSI driver)\n\nThese are the key design principles that guides EKS testing development:\n\n- *Platform Uniformity*: EKS provides a native Kubernetes experience. To keep two platforms in sync, EKS must be tested with upstream Kubernetes. Whenever a new feature is added to Kubernetes, customer should assume it will be tested against EKS. For example, encryption provider feature was added to Kubernetes 1.10 as an alpha feature, but customers have to wait until it becomes a stable feature. Rigorous test coverage will enable more new features to customers at earliest.\n- *Maximize Productivity*: Test automation is essential to EKS development productivity at scale. EKS team should do the minimum amount of work possible to upgrade Kubernetes (including etcd). To this end, pre-prod and prod EKS builds will be continuously tested for every PR created in upstream Kubernetes. For example, etcd client upgrade in API server must be tested against EKS control plane components. If the upgrade test fails EKS, we should block the change.\n- *Transparency for Community*: We want to contribute EKS tests to upstream and make test results visible to the whole communities. Users should be able to see how EKS performs with 5,000 worker nodes and compare it with other providers, just by looking at upstream performance dashboard.\n\n### Non-Goals\n\n* The project does not replace kops or kubeadm.\n* This project is only meant for testing.\n\n## Proposal\n\n### User Stories\n\n#### Kubernetes E2E test workflow: upstream, Prod EKS builds\n\nEKS uses `aws-k8s-tester` as a plugin to kubetest. `aws-k8s-tester` is a broker that creates and deletes AWS resources on behalf of kubetest, connects to pre-prod EKS clusters, reports test results back to dashboards, etc. Every upstream change will be tested against EKS cluster.\n\nFigure 1 shows how AWS would run Kubernetes e2e tests inside EKS (e.g. ci-kubernetes-e2e-aws-eks).\n\n![20181126-aws-k8s-tester-figure-01](20181126-aws-k8s-tester-figure-01.png)\n\n#### Sub-project E2E test workflow: upstream, ALB Ingress Controller\n\nLet's take ALB Ingress Controller for example. Since Kubernetes cluster is a prerequisite to ALB Ingress Controller, `aws-k8s-tester` first creates EKS cluster. Then ALB Ingress Controller plug-in deploys and creates Ingress objects, with sample web server and client. awstester is configured through YAML rather than POSIX flags. This makes it easier to implement sub-project add-ons (e.g. add “alb-ingress-controller” field to set up ingress add-on). Cluster status, ingress controller states, and testing results are persisted to disk for status report and debugging purposes.\n\nFigure 2 shows how `aws-k8s-tester` plugin creates and tests ALB Ingress Controller.\n\n![20181126-aws-k8s-tester-figure-02](20181126-aws-k8s-tester-figure-02.png)\n\n### Implementation Details/Notes/Constraints\n\nWe implement kubetest plugin, out-of-tree and provided as a single binary file. Separate code base speeds up development and makes dependency management easier. For example, kops in kubetest uses AWS SDK [v1.12.53](https://github.com/aws/aws-sdk-go/releases/tag/v1.12.53), which was released at December 2017. Upgrading SDK to latest would break existing kops. Packaging everything in a separate binary gives us freedom to choose whatever SDK version we need.\n\n### Risks and Mitigations\n\n* *“aws-k8s-tester” creates a key-pair using EC2 API. Is the private key safely managed?* Each test run creates a temporary key pair and stores the private key on disk. The private key is used to SSH access into Kubernetes worker nodes and read service logs from the EC2 instance. “aws-k8s-tester” safely [deletes the private key on disk](https://github.com/aws/aws-k8s-tester/blob/cde0484f0ae167d8831442a48b4b5e447481af45/internal/ec2/key_pair.go#L65) and [destroys all associated AWS resources](https://github.com/aws/aws-k8s-tester/blob/cde0484f0ae167d8831442a48b4b5e447481af45/internal/ec2/key_pair.go#L71-L73), whether the test completes or get interrupted. For instance, when it deletes the key pair object from EC2, the public key is also deleted, which means the local private key has no use for any threat.\n* *Does “aws-k8s-tester” store any sensitive information?* “aws-k8s-tester” maintains a test cluster state in [`ClusterState`](https://godoc.org/github.com/aws/awstester/eksconfig#ClusterState), which is periodically synced to local disk and S3. It does not contain any sensitive data such as private key blobs.\n* *Upstream Kubernetes test-infra team mounts our AWS test credential to their Prow cluster. Can anyone access the credential?* Upstream Prow cluster schedules all open-source Kubernetes test runs. In order to test EKS from upstream Kubernetes, AWS credential must be accessible from each test job. Currently, it is mounted as a Secret object (https://kubernetes.io/docs/concepts/configuration/secret/) in upstream Prow cluster. Which means our AWS credential is still stored as base64-encoded plaintext in etcd. Then, there are two ways to access this data. One is to read from Prow testing pod (see [test-infra/PR#9940](https://github.com/kubernetes/test-infra/pull/9940/files)). In theory, any test job has access to “eks-aws-credentials” secret object, thus can maliciously mount it to steal the credential. In practice, every single job needs an approval before it runs any tests. So, if anybody tries to exploit the credential, the change should be rejected beforehand. Two, read the non-encrypted credential data from etcd. This is unlikely as well. We can safely assume that Google GKE deploys etcd in a trusted environment, where the access is restricted to Google test-infra team. See https://kubernetes.io/docs/concepts/configuration/secret/#risks for more.\n\n## Graduation Criteria\n\n`aws-k8s-tester` will be considered successful when it is used by the majority of AWS Kubernetes e2e tests.\n\n## Implementation History\n\n* Initial integration with upstream has been tracked \n* Initial proposal to SIG 2018-11-26\n* Initial KEP draft 2018-11-26\n"
	}
}
```