### PR TITLE
Update TopologyManager KEP with new milestone information

### DIFF
--- a/keps/sig-node/0035-20190130-topology-manager.md
+++ b/keps/sig-node/0035-20190130-topology-manager.md
@@ -55,8 +55,9 @@ _Reviewers:_
     - [Feature Gate and Kubelet Flags](#feature-gate-and-kubelet-flags)
     - [Changes to Existing Components](#changes-to-existing-components)
 - [Graduation Criteria](#graduation-criteria)
-  - [Phase 1: Alpha (v1.16) [COMPLETED]](#phase-1-alpha-v116-completed)
-  - [Phase 2: Beta (target v1.17)](#phase-2-beta-target-v117)
+  - [Alpha (v1.16) [COMPLETED]](#alpha-v116-completed)
+  - [Alpha (v1.17) [COMPLETED]](#alpha-v117-completed)
+  - [Beta (target v1.18)](#beta-target-v118)
   - [GA (stable)](#ga-stable)
 - [Challenges](#challenges)
 - [Limitations](#limitations)
@@ -388,7 +389,7 @@ _Figure: Topology Manager fetches affinity from hint providers._
 
 # Graduation Criteria
 
-## Phase 1: Alpha (v1.16) [COMPLETED]
+## Alpha (v1.16) [COMPLETED]
 
 * Feature gate is disabled by default.
 * Alpha-level documentation.
@@ -397,18 +398,21 @@ _Figure: Topology Manager fetches affinity from hint providers._
 * Device plugin interface includes NUMA Node ID.
 * Device Manager allocation policy takes topology hints into account.
 
-## Phase 2: Beta (target v1.17)
+## Alpha (v1.17) [COMPLETED]
+
+* Allow pods in all QoS classes to request aligned resources.
+
+## Beta (target v1.18)
 
 * Enable the feature gate by default.
 * Provide beta-level documentation.
 * Add node E2E tests.
-* Allow pods in all QoS classes to request aligned resources.
 * Guarantee aligned resources for multiple containers in a pod.
 * Refactor to easily support different merge strategies for different policies.
-* Add support for device-specific topology constraints beyond NUMA.
 
 ## GA (stable)
 
+* Add support for device-specific topology constraints beyond NUMA.
 * Support hugepages alignment.
 * User feedback.
 * *TBD*


### PR DESCRIPTION
This PR updates the TopologyManager KEP with its proper milestone information for Kubernetes v1.17 and v1.18.