### PR TITLE
Fix status for `kubectl diff` kep

### DIFF
--- a/keps/sig-cli/20200115-kubectl-diff.md
+++ b/keps/sig-cli/20200115-kubectl-diff.md
@@ -13,7 +13,7 @@ approvers:
 editor: TBD
 creation-date: 2020-01-15
 last-updated: 2020-01-27
-status: implemented
+status: implementable
 see-also:
   - "/keps/sig-api-machinery/0015-dry-run.md"
   - "/keps/sig-api-machinery/0006-apply.md"


### PR DESCRIPTION
This addresses a nit regarding our KEP metadata because `implemented` is reserved for stable GA graduation. See https://github.com/kubernetes/enhancements/issues/491#issuecomment-579666531.

cc @palnabarun 
