### PR TITLE
Clarify requirements for permitted x509 extensions

### DIFF
--- a/keps/sig-auth/20190607-certificates-api.md
+++ b/keps/sig-auth/20190607-certificates-api.md
@@ -190,7 +190,7 @@ Kubernetes provides the following well-known signers.  Today, failures for all o
     1. Trust distribution: signed certificates must be honored by the kube-apiserver as valid to terminate connections to a kubelet.
        The CA bundle is not distributed by any other means.
     2. Permitted subjects - organizations are exactly `[]string{"system:nodes"}`, common name starts with `"system:node:"`
-    3. Permitted x509 extensions - DNS and IP SANs are allowed
+    3. Permitted x509 extensions - only DNS and IP SANs are allowed, at least one DNS or IP SAN must be present
     4. Permitted key usages - exactly `[]string{"key encipherment", "digital signature", "server auth"}`
     5. Expiration/cert lifetime - minimum of CSR signer or request.
     6. CA bit allowed/disallowed - not allowed.


### PR DESCRIPTION
Whilst implementing the recent changes in #1400 in kubernetes/kubernetes, we discovered an ambiguity in the wording for the requirements around x509 extensions for `kubelet-serving` specified CertificateSigningRequests.

This patch amends the KEP according to the actual requirements/expectations, based on how the kubelet actually behaves: https://github.com/kubernetes/kubernetes/blob/d90dd93855ab6c3ccda73dfbd3d19c81f56abca5/pkg/kubelet/certificate/kubelet.go#L89-L103

/cc @liggitt
/assign @enj
