### PR TITLE
CHPA: Until merged, the state should be implementable

### DIFF
--- a/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
+++ b/keps/sig-autoscaling/20190307-configurable-scale-velocity-for-hpa.md
@@ -14,7 +14,7 @@ approvers:
 editor: TBD
 creation-date: 2019-03-07
 last-updated: 2012-01-29
-status: implemented
+status: implementable
 superseded-by:
 ---
 


### PR DESCRIPTION
We set incorrect state of the KEP. This PR fixes that.