### PR TITLE
Require documentation for EvenPodsSpread feature

### DIFF
--- a/keps/sig-scheduling/20190221-pod-topology-spread.md
+++ b/keps/sig-scheduling/20190221-pod-topology-spread.md
@@ -439,6 +439,10 @@ Beta:
   This is particularly for some extended usage such as Cluster Autoscaler.
 - [ ] Add necessary end-to-end tests.
 
+GA:
+
+- [ ] Ensure feature documentation is clear and complete.
+
 ## Alternatives
 
 - mixin new fields into `pod.spec.affinity` to act as a"sub feature" of Affinity


### PR DESCRIPTION
Tweak `sig-scheduling/20190221-pod-topology-spread.md`: before this feature goes GA, ensure that documentation for this feature is clear and complete.

Completeness might include:
- consider what diagrams might be appropriate and, at a minimum, log an issue against [k/website](https://github.com/kubernetes/website/) to track adding those diagrams.
- Add a task page that explains how to spread Pods for a workload across multiple failure zones.

There is existing documentation and that seems OK enough for the feature to move to Beta.

/sig scheduling