### PR TITLE
modify the error url of cloud-controller-manager.md

### DIFF
--- a/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
+++ b/keps/sig-cloud-provider/providers/0020-cloud-provider-alibaba-cloud.md
@@ -75,7 +75,7 @@ E.g.
 
 [Alibaba Cloud Controller Manager](https://github.com/AliyunContainerService/alicloud-controller-manager) is a working implementation of the [Kubernetes Cloud Controller Manager](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/).
 
-The repo requirements is mainly a copy from [cloudprovider KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md#repository-requirements). Open the link for more detail.
+The repo requirements is mainly a copy from [cloudprovider KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md#repository-requirements). Open the link for more detail.
 
 ### User Experience Reports
 As a CNCF Platinum member, Alibaba Cloud is dedicated in providing users with highly secure , stable and efficient cloud service.


### PR DESCRIPTION
/kind bug
/sig docs

the error url is: https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md

the right url is: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md