### PR TITLE
Plan to fix admission chain for subresources

### DIFF
--- a/keps/sig-api-machinery/0006-apply.md
+++ b/keps/sig-api-machinery/0006-apply.md
@@ -314,7 +314,7 @@ set the field manager for the parent.
 
 For example, a validating webhook on Deployments to enforce a replica policy
 can be bypassed by any /scale subresource request because
-the webhook admission chain is not called on the subresource. We cannot track
+the webhook admission chain is called only for the subresource. We cannot track
 that the user who made the request to the /scale resource owns the replicas
 field.
 

--- a/keps/sig-api-machinery/0006-apply.md
+++ b/keps/sig-api-machinery/0006-apply.md
@@ -322,7 +322,7 @@ field.
 
 The webhooks will be called for the subresource and parent using the same
 admission context, such that the original user is represented in the admission
-attributes. Webhooks will opt-in to this behavior on subresources in the
+attributes. Webhooks will opt-in to the new behavior (of being called for subresources, too) in the
 registration.
 
 The webhooks will be called in the following order, considering a request to

--- a/keps/sig-api-machinery/0006-apply.md
+++ b/keps/sig-api-machinery/0006-apply.md
@@ -139,6 +139,8 @@ A brief list of the changes:
 * Existing Go IDL files will be fixed (e.g., by [fixing the directives](https://github.com/kubernetes/kubernetes/pull/70100/files))
 * Dry-run will be implemented on control plane verbs (POST, PUT, PATCH).
   * Admission webhooks will have their API appended accordingly.
+* The admission chain for subresources will be fixed for accurate mutation,
+  validation, and field ownership tracking
 * An upgrade path will be implemented so that version skew between kubectl and
   the control plane will not have disastrous results.
 
@@ -298,6 +300,77 @@ The conversion between the two and creating the diff was complex and would have 
 ##### Implementation History
 
 - 12/2019 [#86083](https://github.com/kubernetes/kubernetes/pull/86083) implementing a poc for the described approach
+
+#### Fix Admission Chain for Subresources
+
+##### Current Behavior
+
+Currently, the admission chain on a subresource is not propagated for the parent
+resource.
+
+When a user makes a request to a subresource, then admission webhooks and
+validation are skipped on the parent, and we don't have the user information to
+set the field manager for the parent.
+
+For example, a validating webhook on Deployments to enforce a replica policy
+can be bypassed by any /scale subresource request because
+the webhook admission chain is not called on the subresource. We cannot track
+that the user who made the request to the /scale resource owns the replicas
+field.
+
+##### Proposed Change
+
+The webhooks will be called for the subresource and parent using the same
+admission context, such that the original user is represented in the admission
+attributes. Webhooks will opt-in to this behavior on subresources in the
+registration.
+
+The webhooks will be called in the following order, considering a request to
+`/foo/scale` as an example:
+1. mutating webhooks will be called on the included subresource (/foo/scale)
+2. mutating webhooks will be called on the parent (/foo)
+3. optionally, mutating webhooks will be called a second time in the same order
+   (1), then (2) (/foo/scale, then /foo)
+4. validating webhooks will be called in parallel for the subresource and parent
+   (/foo/scale and /foo simultaneously)
+
+Note that when applying mutating webhooks on the included subresources (1),
+then any modification attempts to implicitly modify fields of the parent that
+are not explicitly fields of the subresource will be discarded before writing to
+storage.
+
+After webhooks and validation pass, then we'll use the user in the
+admission context to properly track the field manager for server-side apply when
+writing the parent to storage.
+
+We'll add the new field `includeSubresources` to the admission webhook
+configurations to indicate that when a user makes a request to a webhook,
+then the webhook will be called on the subresource and its parent.
+This field will accept a list of subresource names, with support for wildcard matches.
+
+For example, `includeSubresources: ["*"]` would call a webhook on any
+subresource and its parent when a user makes a request to any subresource.
+
+An example below is included for a validating webhook configuration
+as policy on replicas for Deployments.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: "deployment-replicas-policy.example.com"
+webhooks:
+- name: "deployment-replicas-policy.example.com"
+  includeSubresources:
+  - /scale
+  # Note that the subresource /status is not included
+  rules:
+  - operations: ["CREATE", "UPDATE"]
+    apiGroups: ["apps"]
+    apiVersions: ["v1", "v1beta1"]
+    resources: ["deployments"]
+    scope: "Namespaced"
+```
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
This KEP update outlines the API change to webhook configuration to fix the admission chain for subresources so that the mutation, validation, and field ownership is propagated from the subresource to the parent resource.

This addresses https://github.com/kubernetes/kubernetes/issues/84530 and https://github.com/kubernetes/kubernetes/issues/82046.

cc @jennybuckley @apelisse @kwiesmueller @mariantalla @liggitt @deads2k @lavalamp 

/wg apply
/sig api-machinery