### PR TITLE
Mark 1.18 storage GA features as implemented

### DIFF
--- a/keps/sig-storage/20181111-extend-datasource-field.md
+++ b/keps/sig-storage/20181111-extend-datasource-field.md
@@ -12,8 +12,8 @@ approvers:
   - "@thockin"
 editor: "@j-griffith"
 creation-date: 2018-11-11
-last-updated: 2020-01-27
-status: implementable
+last-updated: 2020-03-09
+status: implemented
 see-also:
 replaces:
 superseded-by:
@@ -156,6 +156,7 @@ Given that the only implementation changes in Kuberenetes is to enable the featu
 
 1.15 - Alpha status
 1.16 - Beta status
+1.18 - GA
 
 ## Drawbacks [optional]
 

--- a/keps/sig-storage/20190129-csi-pod-info-on-mount.md
+++ b/keps/sig-storage/20190129-csi-pod-info-on-mount.md
@@ -12,8 +12,8 @@ approvers:
   - "@saad-ali"
 editor: TBD
 creation-date: 2019-01-29
-last-updated: 2019-01-29
-status: implementable
+last-updated: 2020-03-09
+status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-pod-information.md"
 replaces:

--- a/keps/sig-storage/20190129-csi-skip-attach.md
+++ b/keps/sig-storage/20190129-csi-skip-attach.md
@@ -12,8 +12,8 @@ approvers:
   - "@saad-ali"
 editor: TBD
 creation-date: 2019-01-29
-last-updated: 2019-01-29
-status: implementable
+last-updated: 2020-03-09
+status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface-skip-attach.md"
 replaces:

--- a/keps/sig-storage/20190130-csi-raw-block-support.md
+++ b/keps/sig-storage/20190130-csi-raw-block-support.md
@@ -12,8 +12,8 @@ approvers:
   - "@saad-ali"
 editor: TBD
 creation-date: 2019-01-30
-last-updated: 2019-10-15
-status: implementable
+last-updated: 2020-03-09
+status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md"
   - "https://github.com/kubernetes/enhancements/pull/1288"
@@ -41,7 +41,7 @@ see-also:
   - [K8s 1.13: Alpha](#k8s-113-alpha)
   - [K8s 1.14: Beta](#k8s-114-beta)
   - [K8s 1.17: Beta](#k8s-117-beta)
-  - [K8s 1.18: Targeting GA](#k8s-118-targeting-ga)
+  - [K8s 1.18: GA](#k8s-118-ga)
 <!-- /toc -->
 
 ## Summary
@@ -164,6 +164,6 @@ and we can test with them
 * Fixed volume reconstruction after kubelet restart.
 * Stress tests as noted above.
 
-### K8s 1.18: Targeting GA
+### K8s 1.18: GA
 * Added block tests to csi-sanity.
 * Disruptive testing with block devices in /dev reordered after reboot.

--- a/keps/sig-storage/20191008-raw-block-support.md
+++ b/keps/sig-storage/20191008-raw-block-support.md
@@ -12,8 +12,8 @@ approvers:
   - "@saad-ali"
 editor: TBD
 creation-date: 2019-10-08
-last-updated: 2019-15-10
-status: implementable
+last-updated: 2020-03-09
+status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md"
 ---
@@ -39,7 +39,7 @@ see-also:
   - [K8s 1.9: Alpha](#k8s-19-alpha)
   - [K8s 1.13: Beta](#k8s-113-beta)
   - [K8s 1.17: Beta](#k8s-117-beta)
-  - [K8s 1.18: Targeting GA](#k8s-118-targeting-ga)
+  - [K8s 1.18: GA](#k8s-118-ga)
 <!-- /toc -->
 
 ## Summary
@@ -163,5 +163,5 @@ Already happened.
 * Fixed block volume reconstruction.
 * Stress tests as noted above.
 
-### K8s 1.18: Targeting GA
+### K8s 1.18: GA
 * Disruptive testing with block devices in /dev reordered after reboot.


### PR DESCRIPTION
Marking couple of KEPs that reached GA in this release:

* Extend usage of Volume DataSource to allow PVCs for Cloning: reached GA in https://github.com/kubernetes/enhancements/issues/989
* Pass Pod information in CSI calls: https://github.com/kubernetes/enhancements/issues/603
* Skip attach for non-attachable CSI volumes: https://github.com/kubernetes/enhancements/issues/770
* CSI raw block: https://github.com/kubernetes/enhancements/issues/565
* Raw block: https://github.com/kubernetes/enhancements/issues/351

/assign @msau42