### PR TITLE
Graceful Termination for External Traffic Policy Local

### DIFF
--- a/keps/sig-network/1669-graceful-termination-local-external-traffic-policy/README.md
+++ b/keps/sig-network/1669-graceful-termination-local-external-traffic-policy/README.md
@@ -1,0 +1,154 @@
+# KEP-1669: Graceful Termination for Local External Traffic Policy
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Additions to EndpointSlice](#additions-to-endpointslice)
+  - [kube-proxy](#kube-proxy)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [E2E Tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+- [X] Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] KEP approvers have approved the KEP status as `implementable`
+- [ ] Design details are appropriately documented
+- [ ] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [ ] Graduation criteria is in place
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+Services with externalTrafficPolicy=Local lack the ability to gracefully handle traffic from a loadbalancer when it goes from N to 0 endpoints.
+Since terminating pods are never considered "ready" in Endpoints/EndpointSlice, a node with only terminating endpoints would drop traffic even though
+it may still be part of a loadbalancer's node pool. Even with loadbalancer health checks, there is usually a delay between when the health check
+fails and when a node is completely decommissioned. This KEP proposes changes to gracefully handle traffic to a node that has only terminating endpoints
+for a Service with externalTrafficPolicy=Local.
+
+## Motivation
+
+### Goals
+
+* enable zero downtime rolling updates for Services with ExternalTrafficPolicy=Local via nodeports/loadbalancerIPs/externalIPs.
+
+### Non-Goals
+
+* changing the behavior of terminating pods/endpoints outside the scope of Services with ExternalTrafficPolicy=Local via a nodeport/loadbalancerIPs/externalIPs.
+
+## Proposal
+
+This KEP proposes that if all endpoints for a given Service (with externalTrafficPolicy=Local) within the bounds of a node are terminating (i.e pod.DeletionTimestamp != nil),
+then all external traffic on this node should be sent to **ready** and **not ready** terminating endpoints, preferring the former if there are any. This ensures that traffic
+is not dropped between the time a node fails its health check (has 0 endpoints) and when a node is decommissioned from the loadbalancer's node pool.
+
+The proposed changes in this KEP depend on KEP-1672 and the EndpointSlice API.
+
+### User Stories (optional)
+
+#### Story 1
+
+As a user I would like to do a rolling update of a Deployment fronted by a Service Type=LoadBalancer with ExternalTrafficPolicy=Local.
+If a node that has only 1 pod of said deployment goes into the `Terminating` state, all traffic to that node is dropped until either a new pod
+comes up or my cloud provider removes the node from the loadbalancer's node pool. Ideally the terminating pod should gracefully handle traffic to this node
+until either one of the conditions are satisfied.
+
+### Risks and Mitigations
+
+There are scalability implications to tracking termination state in EndpointSlice. For now we are assuming that the performance trade-offs are worthwhile but
+future testing may change this decision. See KEP 1672 for more details.
+
+## Design Details
+
+### Additions to EndpointSlice
+
+This work depends on the `Terminating` condition existing on the EndpointSlice API (see KEP 1672) in order to check the termination state of an endpoint.
+
+### kube-proxy
+
+Updates to kube-proxy when watching EndpointSlice:
+* update kube-proxy endpoints info to track terminating endpoints based on endpoint.condition.terminating in EndpointSlice.
+* update kube-proxy endpoints info to track endpoint readiness based on endpoint.condition.ready in EndpointSlice
+* if externalTrafficPolicy=Local, record all local endpoints that are ready && terminating and endpoints that are !ready && terminating. When there are no local ready endpoints, fall back in the preferred order:
+  * local ready & terminating endpoints
+  * local not ready & terminating endpoints
+  * blackhole traffic
+* for all other traffic (i.e. externalTrafficPolicy=Cluster), preserve existing behavior where traffic is only sent to ready && !terminating endpoints.
+
+In addition, kube-proxy's node port health check should fail if there are only `Terminating` endpoints, regardless of their readiness in order to:
+* remove the node from a loadbalancer's node pool as quickly as possible
+* gracefully handle any new connections that arrive before the loadbalancer is able to remove the node
+* allow existing connections to gracefully terminate
+
+### Test Plan
+
+#### Unit Tests
+
+kube-proxy unit tests:
+
+* Unit tests will validate the correct behavior when there are only local terminating endpoints.
+* Unit tests will validate the new change in behavior only applies for Services with ExternalTrafficPolicy=Local via nodeports/loadbalancerIPs/externalIPs.
+* Existing unit tests will validate that terminating endpoints are only used when there are no ready endpoints AND externalTrafficPolicy=Local, otherwise ready && !terminating endpoints are used.
+* Unit tests will validate health check node port succeeds only when there are ready && !terminating endpoints.
+
+#### E2E Tests
+
+E2E tests will be added to validate that no traffic is dropped during a rolling update for a Service with ExternalTrafficPolicy=Local.
+This test may be marked "Flaky" as the behavior is largely also dependant on the cloud provider's loadbalancer.
+
+All existing E2E tests for Services should continue to pass.
+
+### Graduation Criteria
+
+The graduation criteria of this KEP will largely depend on the graduation status of the EndpointSlice API. Once the `terminating` field is added to EndpointSlice API,
+this change in behavior will kick-in as soon as kube-proxy consumes EndpointSlice.
+
+### Upgrade / Downgrade Strategy
+
+Behavioral changes to terminating endpoints will apply once kube-proxy is upgraded to v1.19 and the `EndpointSlice`/`EndpointSliceProxying` feature gates are enabled.
+On downgrade, the worse case scenario is that kube-proxy falls back to the existing behavior. See [Version Skew Strategy](#version-skew-strategy) below.
+
+### Version Skew Strategy
+
+The worse case version skew scenario is that kube-proxy falls back to the existing behavior today where traffic does not fall back to terminating endpoints.
+This would either happen if a version of the control plane was not aware of the additions to EndpointSlice or if the version of kube-proxy did not know to consume the additions to EndpointSlice.
+
+There's not much risk involved as the worse case scenario is falling back to existing behavior.
+
+## Implementation History
+
+- [x] 2020-04-23: KEP accepted as implementable for v1.19
+
+## Drawbacks
+
+* scalability: this KEP (and KEP 1672) would add more writes per endpoint to EndpointSlice as each terminating endpoint adds at least 1 and at
+most 2 additional writes - 1 write for marking an endpoint as "terminating" and another if an endpoint changes it's readiness during termination.
+* complexity: an additional corner case is added to kube-proxy adding to it's complexity.
+
+## Alternatives
+
+Some users work around this issue today by adding a preStop hook that sleeps for some duration. Though this may work in some scenarios, better handling from kube-proxy
+would alleviate the need for this work around altogether.
+

--- a/keps/sig-network/1669-graceful-termination-local-external-traffic-policy/kep.yaml
+++ b/keps/sig-network/1669-graceful-termination-local-external-traffic-policy/kep.yaml
@@ -1,0 +1,19 @@
+---
+title: Graceful Termination for Local External Traffic Policy
+authors:
+  - "@andrewsykim"
+owning-sig: sig-network
+participating-sigs:
+  - sig-scalability
+reviewers:
+  - "@thockin"
+  - "@wojtek-t"
+  - "@smarterclayton"
+approvers:
+  - "@thockin"
+creation-date: 2020-04-07
+last-updated: 2020-04-07
+status: implementable
+see-also:
+  - "/keps/sig-network/1672-tracking-terminating-endpoints/README.md"
+  - https://github.com/kubernetes/kubernetes/issues/85643

--- a/keps/sig-network/1672-tracking-terminating-endpoints/README.md
+++ b/keps/sig-network/1672-tracking-terminating-endpoints/README.md
@@ -1,0 +1,152 @@
+# KEP-1672: Tracking Terminating Endpoints in the EndpointSlice API
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+  - [Notes/Constraints/Caveats (optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+- [X] Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] KEP approvers have approved the KEP status as `implementable`
+- [ ] Design details are appropriately documented
+- [ ] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [ ] Graduation criteria is in place
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+Today, terminating endpoints are considered "not ready" regardless of their actual readiness.
+Before any work is done in improving how terminating endpoints are handled, there must be a way
+to track whether an endpoint is terminating without having to watch the associated pods. This
+KEP proposes a means to track the terminating state of an endpoint via the EndpointSlice API.
+This would enable consumers of the API to make smarter decisions when it comes to handling
+terminating endpoints (see KEP-1669 as an example).
+
+## Motivation
+
+### Goals
+
+* Provide a mechanism to track whether an endpoint is terminating by only watching the EndpointSlice API.
+
+### Non-Goals
+
+* Consumption of the new API field is out of scope for this KEP but future KEPs will leverage
+the work done here to improve graceful terminination of pods in certain scenarios (see issue [85643](https://github.com/kubernetes/kubernetes/issues/85643))
+
+## Proposal
+
+This KEP proposes to keep "terminating" pods in the set of endpoints in EndpointSlice with
+additions to the API to indicate whether a given endpoint is terminating or not. If consumers
+of the API (e.g. kube-proxy) are required to treat terminating endpoints differently, they
+may do so by checking this condition.
+
+The criteria for a ready endpoint (pod phase + readiness probe) will not change based on the
+terminating state of pods, but consumers of the API may choose to prefer endpoints that are both ready and not terminating.
+
+### User Stories (optional)
+
+#### Story 1
+
+A consumer of the EndpointSlice API (e.g. kube-proxy) may want to know which endpoints are
+terminating without having to watch Pods directly for scalability reasons.
+
+One example would be the IPVS proxier which should set the weight of an endpoint to 0
+during termination and finally remove the real server when the endpoint is removed.
+Without knowing when a pod is done terminating, the IPVS proxy makes a best-effort guess
+at when the pod is terminated by looking at the connection tracking table.
+
+### Notes/Constraints/Caveats (optional)
+
+### Risks and Mitigations
+
+Tracking the terminating state of endpoints poses some scalability concerns as each
+terminating endpoint adds additional writes to the API. Today, a terminating pod
+results in 1 write in Endpoints (removing the endpoint). With the proposed changes,
+each terminating endpoint could result in at least 2 writes (ready -> terminating -> removed)
+and possibly more depending on how many times readiness changes during termination.
+
+## Design Details
+
+To track whether an endpoint is terminating, a `terminating` field would be added as part of
+the `EndpointCondition` type in the EndpointSlice API.
+
+```go
+// EndpointConditions represents the current condition of an endpoint.
+type EndpointConditions struct {
+    // ready indicates that this endpoint is prepared to receive traffic,
+    // according to whatever system is managing the endpoint. A nil value
+    // indicates an unknown state. In most cases consumers should interpret this
+    // unknown state as ready.
+    // +optional
+    Ready *bool `json:"ready,omitempty" protobuf:"bytes,1,name=ready"`
+
+    // terminating indicates if this endpoint is terminating. Consumers should assume a
+    // nil value indicates the endpoint  is not terminating.
+    // +optional
+    Terminating *bool `json:"terminating,omitempty" protobuf:"bytes,2,name=terminating"`
+}
+```
+
+NOTE: A nil value for `Terminating` indicates that the endpoint is not terminating.
+
+Updates to endpointslice controller:
+* include pods with a deletion timestamp in endpointslice
+* any pod with a deletion timestamp will have condition.terminating = true
+* allow endpoint ready condition to change during termination
+
+### Test Plan
+
+endpointslice controller unit tests:
+* Unit tests will validate pods with a deletion timestamp are included with condition.teriminating = true
+* Unit tests will validate that the ready condition can change for terminating endpoints
+
+There will be no e2e tests since consumption of this new API is out-of-scope for this KEP.
+Any future KEP that consumes this API should have e2e tests to ensure behavior for terminating
+endpoints is correct.
+
+### Graduation Criteria
+
+Since this is an addition to the EndpointSlice API, graduation will follow the graduation
+timeline for the [EndpointSlice API work](/keps/sig-network/20190603-endpointslices/README.md).
+
+### Upgrade / Downgrade Strategy
+
+Since this is an addition to the EndpointSlice API, the upgrade/downgrade strategy will follow that
+of the [EndpointSlice API work](/keps/sig-network/20190603-endpointslices/README.md).
+
+### Version Skew Strategy
+
+Since this is an addition to the EndpointSlice API, the version skew strategy will follow that
+of the [EndpointSlice API work](/keps/sig-network/20190603-endpointslices/README.md).
+
+## Implementation History
+
+- [x] 2020-04-23: KEP accepted as implementable for v1.19
+
+## Drawbacks
+
+There are some scalability draw backs as tracking terminating endpoints requires at least 1 additional write per endpoint.
+

--- a/keps/sig-network/1672-tracking-terminating-endpoints/kep.yaml
+++ b/keps/sig-network/1672-tracking-terminating-endpoints/kep.yaml
@@ -1,0 +1,20 @@
+title: Tracking Terminating Endpoints in EndpointSlice
+kep-number: 1672
+authors:
+  - "@andrewsykim"
+owning-sig: sig-network
+participating-sigs:
+  - sig-scalability
+status: implementable
+creation-date: 2020-04-07
+reviewers:
+  - "@thockin"
+  - "@robscott"
+  - "@freehan"
+  - "@smarterclayton"
+  - "@wojtek-t"
+approvers:
+  - "@thockin"
+see-also:
+  - /kep/sig-network/20190603-EndpointSlice-API.md
+replaces: []


### PR DESCRIPTION
This PR adds two related, but separate KEPS:

### Tracking Terminating Endpoints in EndpointSlice API (KEP-1672)

Adds a field `terminating` to the `endpointCondition` field in the EndpointSlice API. This allows consumers of the API to know when a pod is terminating in case extra steps are required during a pod's graceful termination period.  One use-case (in addition to the one below) is to simplify the graceful termination logic in the IPVS proxier, more details in the PR.

### Graceful Termination for External Traffic Policy Local (KEP-1669)

Uses the proposed changes to EndpointSlice API above to enable zero downtime deployments for Services with Type=LoadBalancer/NodePort and ExternalTrafficPolicy=Local. This is mainly accomplished by redirecting traffic to ready terminating endpoints if all endpoints on a given node are terminating.

Continuing discussion from https://github.com/kubernetes/kubernetes/issues/85643#issuecomment-601415454

note: first commit just fixes some trailing white spaces.