### PR TITLE
Add section on supporting intermediate certificates

### DIFF
--- a/keps/sig-auth/20190607-certificates-api.md
+++ b/keps/sig-auth/20190607-certificates-api.md
@@ -28,6 +28,7 @@ status: implementable
   - [Sequence of an Issuance](#sequence-of-an-issuance)
   - [Signers](#signers)
     - [Limiting approval and signer powers for certain signers.](#limiting-approval-and-signer-powers-for-certain-signers)
+    - [Supporting intermediate certificates.](#supporting-intermediate-certificates)
   - [CertificateSigningRequest API Definition](#certificatesigningrequest-api-definition)
   - [Manual CSR Approval With Kubectl](#manual-csr-approval-with-kubectl)
   - [Automatic CSR Approval Implementations](#automatic-csr-approval-implementations)
@@ -235,6 +236,10 @@ Cluster admins can either:
 2. grant signer-specific approval permissions using the bootstrap roles starting in 1.18
 3. disable the approval-authorizing admission plugin in 1.18 (if they don't care about partitioning approver rights)
  
+#### Supporting intermediate certificates.
+It's important that the Certificates API fully supports using an intermediate certificate as the signer, including the case where the signer is itself signed by an intermediate. As a result, the user must be able to specify that the signing certificates are provided to the client, in which case their PEM values would be appended to the Certificate in the CertificateSigningRequestStatus. Conforming clients will parse the full chain of certificates provided by the apiserver and present them all for new TLS handshakes.
+
+Firstly, we will add a new bool flag to the controller, `cluster-signing-include-signers`, which requires that the signing certificate is always appended in this way. Currently the controller only allows a single signing cert in `cluster-signing-cert-file`, so this approach would only work in the case where the signing certificate is a child of the root CA, in which case it is the only certificate that needs to be provided to the client. To support further nested signing certificates, we additionally need to relax the contraint of the cert file parameter to accept multiple signers in a chain. The additional certificates would only be used if the include signers option is set; they are not needed in signing.
 
 ### CertificateSigningRequest API Definition
 

--- a/keps/sig-auth/20190607-certificates-api.md
+++ b/keps/sig-auth/20190607-certificates-api.md
@@ -237,9 +237,19 @@ Cluster admins can either:
 3. disable the approval-authorizing admission plugin in 1.18 (if they don't care about partitioning approver rights)
  
 #### Supporting intermediate certificates.
-It's important that the Certificates API fully supports using an intermediate certificate as the signer, including the case where the signer is itself signed by an intermediate. As a result, the user must be able to specify that the signing certificates are provided to the client, in which case their PEM values would be appended to the Certificate in the CertificateSigningRequestStatus. Conforming clients will parse the full chain of certificates provided by the apiserver and present them all for new TLS handshakes.
+It's important that the Certificates API fully supports using an intermediate certificate as the signer, 
+including the case where the signer is itself signed by an intermediate. As a result, the user must be able 
+to specify that the signing certificates are provided to the client, in which case their PEM values would 
+be appended to the Certificate in the CertificateSigningRequestStatus. Conforming clients will parse the 
+full chain of certificates provided by the apiserver and present them all for new TLS handshakes.
 
-Firstly, we will add a new bool flag to the controller, `cluster-signing-include-signers`, which requires that the signing certificate is always appended in this way. Currently the controller only allows a single signing cert in `cluster-signing-cert-file`, so this approach would only work in the case where the signing certificate is a child of the root CA, in which case it is the only certificate that needs to be provided to the client. To support further nested signing certificates, we additionally need to relax the contraint of the cert file parameter to accept multiple signers in a chain. The additional certificates would only be used if the include signers option is set; they are not needed in signing.
+Firstly, we will add a new bool flag to the controller, `cluster-signing-include-signers`, which requires 
+that the signing certificate is always appended in this way. Currently the controller only allows a 
+single signing cert in `cluster-signing-cert-file`, so this approach would only work in the case where 
+the signing certificate is a child of the root CA, in which case it is the only certificate that needs 
+to be provided to the client. To support further nested signing certificates, we additionally need to 
+relax the contraint of the cert file parameter to accept multiple signers in a chain. The additional 
+certificates would only be used if the include signers option is set; they are not needed in signing.
 
 ### CertificateSigningRequest API Definition
 


### PR DESCRIPTION
I've written my proposal for how we could support intermediate certificates, which is already partially implemented in https://github.com/kubernetes/kubernetes/pull/88741.

There's already been a lot of different ideas about the right design here, so this is just intended to spur discussion, I'm happy to write up whatever conclusion we come to.

**Here's the bit thats causing confusion:**
We have a signing certificate, currently inputed as a file, with another file for a key. We want users to be able to indicate, optionally, that the signing certificate should be presented back to the client. However, for this to be useful in cases with a long chain up to the root, we need to also allow the user to provide additional intermediate certificates (closer to the root than the signer), that can be used to build a chain to the root. There are a few options, and we'd love input from people who have worked with a similar system.
1. Instead of having a single signing certificate in an input file, we could allow a certificate chain, where only one certificate is the signer that should be combined with the key. We would need to infer what certificate is the signer - by convention, it could be the last cert in the file (is this a convention in any other signing systems? In Go cert chain parsing, the order usually doesn't matter), or we could walk the chain to find the 'deepest' cert (sounds tricky, but Go stdlib does this sort of thing to build TLS cert chains), or we could check the public key of each against the private key (but that might find multiple). Then, the user can provide a bool to suggest whether to append the full chain as given, including the signer.
2. We could maintain a single signing cert in that file, but add another optional file, which should contain a list of additional certs to append to the signed output, giving the user a lot of control. However, in all sign-with-an-intermediate cases, this file will need to contain the same cert as the main cert file, which is a bit of a weird user experience and leads to edge cases around file rotation that would be nice to avoid - we'd need to check on rotation that the chain file and the signing cert file still form a coherent chain, and in doing so we'd constrain the user to what we believe is a coherent chain. In the case where the signer is the child of a root, the files will be identical, which again is a bit odd.
3. We could maintain a single signing cert in the file, and append it if a boolean is set (or default to appending it if the signer isnt a root). Additionally, for cases where your signer is not a child of the root, we can have another file that contains certs that are further up the chain than the signer only. This avoids some of the user experience concern, although its still a bit weird to have two files comprising your chain. Some rotation concerns persist - unlike a key and a cert, its not 'obvious' that we have a mismatch between the chain certs and the signing cert, so we'd need some kind of chain verification logic.