### PR TITLE
Add pod-level process stats to the summary API for out-of-pid eviction

### DIFF
--- a/keps/sig-node/20190129-pid-limiting.md
+++ b/keps/sig-node/20190129-pid-limiting.md
@@ -159,6 +159,28 @@ GA
 
 Adding support for pid limiting at the Node Allocatable level 
 
+Eviction will rank based on priority, followed by the number of processes used.
+To integrate this into the eviction manager's control loops, we will add pod-level
+ProcessStats:
+
+```golang
+// ProcessStats are stats pertaining to processes.
+type ProcessStats struct {
+  // Number of processes
+  // +optional
+  ProcessCount *uint64 `json:"process_count,omitempty"`
+}
+
+// PodStats holds pod-level unprocessed sample stats.
+type PodStats struct {  type PodStats struct {
+  ...
+  // ProcessStats pertaining to processes.
+  // +optional
+  ProcessStats *ProcessStats `json:"process_stats,omitempty"`
+}
+```
+
+
 The following criteria applies to `SupportNodePidsLimit`:
 
 Alpha


### PR DESCRIPTION
Currently, the kubelet ranks pods for out-of-pid eviction only by PodPriority. When there are many pods of the same priority, it ranks them randomly, which is not ideal. In the case of a fork bomb, the kubelet prevents the node from running out of pids, but may evict many innocent pods before choosing the fork bomb.

See https://github.com/kubernetes/kubernetes/issues/89284 for details on the implementation.

/sig node
/assign @derekwaynecarr 