### PR TITLE
Transfer Enhancements subproject ownership to SIG Arch

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - pm-maintainers
-  - sig-pm-leads
+  - enhancements-approvers
+  - sig-architecture-leads
 reviewers:
-  - features-maintainers
-  - kep-process-approvers
-  - kep-process-reviewers
-  - sig-release-leads
+  - enhancements-reviewers
 labels:
-  - sig/pm
+  - sig/architecture

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -164,36 +164,13 @@ aliases:
     - spiffxp
     - timothysc
 ## BEGIN CUSTOM CONTENT
-  pm-maintainers:
-    - calebamiles # SIG PM Chair
-    - idvoretskyi # SIG PM Chair
-    - jdumars # SIG PM Chair
-    - justaugustus # SIG PM Chair
-  features-maintainers:
-    - justaugustus # 1.12 Features Lead
-    - claurence # 1.14 Enhancements Lead
-    - kacole2 # 1.15 / 1.13 Enhancements Lead
-  kep-process-approvers:
+  enhancements-approvers:
     - calebamiles
     - idvoretskyi
     - jdumars
     - justaugustus
-  kep-process-reviewers:
+  enhancements-reviewers:
     - lachie83
-  kep-reviewers:
-    - bgrant0607
-    - derekwaynecarr
-    - dims
-    - jbeda
-    - jdumars
-    - mattfarina
-  kep-approvers:
-    - bgrant0607
-    - derekwaynecarr
-    - dims
-    - jbeda
-    - jdumars
-    - mattfarina
   provider-aws:
     - d-nishi
     - justinsb

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -165,12 +165,15 @@ aliases:
     - timothysc
 ## BEGIN CUSTOM CONTENT
   enhancements-approvers:
-    - calebamiles
-    - idvoretskyi
-    - jdumars
+    - jeremyrickard
+    - johnbelamaric
     - justaugustus
+    - mrbobbytables
   enhancements-reviewers:
-    - lachie83
+    - jeremyrickard
+    - johnbelamaric
+    - justaugustus
+    - mrbobbytables
   provider-aws:
     - d-nishi
     - justinsb

--- a/keps/OWNERS
+++ b/keps/OWNERS
@@ -1,12 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - kep-approvers
-  - kep-process-approvers
+  - enhancements-approvers
 reviewers:
-  - kep-reviewers
-  - kep-process-reviewers
+  - enhancements-reviewers
 labels:
   - kind/kep
-options:
-  no_parent_owners: true


### PR DESCRIPTION
- Transfer Enhancements subproject ownership to SIG Arch
- Update Enhancements subproject owners
  - @jeremyrickard 
  - @johnbelamaric 
  - @justaugustus 
  - @mrbobbytables

~Email to follow shortly...~
Email retiring SIG PM and announcing transfer of Enhancements subproject to SIG Arch: https://groups.google.com/d/topic/kubernetes-dev/RU8iINF758Y/discussion

/assign @dims @johnbelamaric @derekwaynecarr 
/hold
/milestone v1.19
/priority important-soon
/sig architecture pm