### PR TITLE
Mark node labeling KEP as implemented

### DIFF
--- a/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md
+++ b/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md
@@ -14,8 +14,8 @@ approvers:
   - "@thockin"
   - "@smarterclayton"
 creation-date: 2017-08-14
-last-updated: 2018-10-31
-status: implementable
+last-updated: 2020-05-01
+status: implemented
 ---
 
 # Bounding Self-Labeling Kubelets


### PR DESCRIPTION
Last item in the timeline is complete in 1.19 in https://github.com/kubernetes/kubernetes/pull/90307

/sig auth
/cc @mikedanese 