### PR TITLE
template: recommend line breaks

### DIFF
--- a/keps/NNNN-kep-template/README.md
+++ b/keps/NNNN-kep-template/README.md
@@ -156,6 +156,13 @@ should help to ensure that the tone and content of the `Summary` section is
 useful for a wide audience.
 
 A good summary is probably at least a paragraph in length.
+
+Both in this section and below, follow the guidelines of the [documentation
+style guide]. In particular, wrap lines to a reasonable length, to make it
+easier for reviewers to cite specific portions, and to minimize diff churn on
+updates.
+
+[documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
 -->
 
 ## Motivation


### PR DESCRIPTION
When people write KEPs with no line breaks, it's harder to review them because you can only add comments at the paragraph level rather than (approximately) the sentence level. So explicitly recommend line breaks.

(Not sure this is the best place to do that...)