### PR TITLE
Change PRR rollback-supported to disable-supported

### DIFF
--- a/keps/NNNN-kep-template/README.md
+++ b/keps/NNNN-kep-template/README.md
@@ -390,7 +390,7 @@ _This section must be completed when targeting alpha to a release._
 
 * **Can the feature be disabled once it has been enabled (i.e. can we rollback
   the enablement)?**
-  Also set `rollback-supported` to `true` or `false` in `kep.yaml`.
+  Also set `disable-supported` to `true` or `false` in `kep.yaml`.
   Describe the consequences on existing workloads (e.g. if this is runtime
   feature, can it break the existing applications?).
 

--- a/keps/NNNN-kep-template/kep.yaml
+++ b/keps/NNNN-kep-template/kep.yaml
@@ -41,7 +41,7 @@ feature-gate:
   components:
     - kube-apiserver
     - kube-controller-manager
-rollback-supported: true
+disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:

--- a/keps/sig-storage/1412-immutable-secrets-and-configmaps/kep.yaml
+++ b/keps/sig-storage/1412-immutable-secrets-and-configmaps/kep.yaml
@@ -30,6 +30,6 @@ feature-gate:
   components:
     - kube-apiserver
     - kubelet
-rollback-supported: true
+disable-supported: true
 
 metrics:

--- a/keps/sig-storage/1432-volume-health-monitor/kep.yaml
+++ b/keps/sig-storage/1432-volume-health-monitor/kep.yaml
@@ -28,6 +28,6 @@ milestone:
   stable: "v1.21"
 
 feature-gate:
-rollback-supported: true
+disable-supported: true
 
 metrics:

--- a/pkg/kepval/keps/proposals.go
+++ b/pkg/kepval/keps/proposals.go
@@ -67,7 +67,7 @@ type Proposal struct {
 	Milestone       Milestone `json:"milestone" yaml:"milestone"`
 
 	FeatureGate       FeatureGate `json:"featureGate" yaml:"feature-gate"`
-	RollbackSupported bool        `json:"rollbackSupported" yaml:"rollback-supported"`
+	DisableSupported bool        `json:"disableSupported" yaml:"disable-supported"`
 	Metrics           []string    `json:"metrics" yaml:"metrics"`
 
 	Filename string `json:"-" yaml:"-"`

--- a/pkg/kepval/keps/proposals_test.go
+++ b/pkg/kepval/keps/proposals_test.go
@@ -64,7 +64,7 @@ feature-gate:
   components:
     - kube-apiserver
     - kube-controller-manager
-rollback-supported: true
+disable-supported: true
 metrics:
   - my_feature_metric
 ---`,


### PR DESCRIPTION
The name is intended to refer to rolling back the enablement of the
feature, but can cause confusion. It can be mixed up with what the
consequences of rolling back the version are, rather than just the
enablement.