### PR TITLE
Add note regarding KEP number to faq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhancement Tracking and Backlog
 
-Enhancement tracking repo for Kubernetes releases. Owned by [PM SIG](https://github.com/kubernetes/community/blob/master/sig-pm/README.md).
+Enhancement tracking repo for Kubernetes releases. Owned by [SIG Architecture](https://git.k8s.io/community/sig-architecture#enhancements).
 
 This repo contains issues and [KEPs](https://git.k8s.io/enhancements/keps). These issues are umbrellas for new enhancements to be added to Kubernetes. An enhancement usually takes multiple releases to complete. And an enhancement can be tracked as backlog items before work begins. An enhancement may be filed once there is consensus in at least one [Kubernetes SIG](https://git.k8s.io/community/sig-list.md).
 
@@ -25,7 +25,7 @@ It is unlikely an enhancement if it is:
 - adding error messages or events
 
 If you are not sure, ask someone in the SIG where you initially circulated the idea. If they aren't sure jump into
-[#sig-pm](https://kubernetes.slack.com/messages/sig-pm/) on Slack or ping someone listed in [OWNERS](https://github.com/kubernetes/enhancements/blob/master/OWNERS).
+[#enhancements](https://kubernetes.slack.com/messages/enhancements/) on Slack or ping someone listed in [OWNERS](https://github.com/kubernetes/enhancements/blob/master/OWNERS).
 
 ## When to Create a New Enhancement Issue
 

--- a/keps/README.md
+++ b/keps/README.md
@@ -60,6 +60,12 @@ Things we'd like to see happen to consider KEPs well on their way:
 
 Even so, the process can evolve. As we find new techniques we can improve our processes.
 
+### What is the number at the beginning of the KEP name?
+
+KEPs are now prefixed with their associated tracking issue number. This gives
+both the KEP a unique identifier and provides an easy breadcrumb for people to
+find the issue where the current state of the KEP is being updated.
+
 ### My FAQ isn't answered here!
 
 The KEP process is still evolving!


### PR DESCRIPTION
Adds a brief description of the kep number to the faq.

Also updates a few references to sig-pm in the root README.

/assign @justaugustus @johnbelamaric @jeremyrickard 
Fixes: https://github.com/kubernetes/enhancements/issues/1721