### PR TITLE
kepval: surface the reason for errors during KEP validation

### DIFF
--- a/cmd/kepval/main.go
+++ b/cmd/kepval/main.go
@@ -18,21 +18,22 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"k8s.io/enhancements/pkg/kepval/keps"
 )
 
 func main() {
-	os.Exit(run())
+	os.Exit(run(os.Stderr))
 }
 
-func run() int {
+func run(w io.Writer) int {
 	parser := &keps.Parser{}
 	for _, filename := range os.Args[1:] {
 		file, err := os.Open(filename)
 		if err != nil {
-			fmt.Printf("could not open file %s: %v\n", filename, err)
+			fmt.Fprintf(w, "could not open file %s: %v\n", filename, err)
 			return 1
 		}
 		defer file.Close()
@@ -42,10 +43,10 @@ func run() int {
 			continue
 		}
 
-		fmt.Printf("%v has an error: %q\n", filename, kep.Error.Error())
+		fmt.Fprintf(w, "%v has an error: %q\n", filename, kep.Error.Error())
 		return 1
 	}
 
-	fmt.Printf("No validation errors: %v\n", os.Args[1:])
+	fmt.Fprintf(w, "No validation errors: %v\n", os.Args[1:])
 	return 0
 }

--- a/cmd/kepval/main_test.go
+++ b/cmd/kepval/main_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,8 +75,9 @@ func TestValidation(t *testing.T) {
 	for _, file := range files {
 		t.Run(file, func(t *testing.T) {
 			os.Args[1] = file
-			if exit := run(); exit != 0 {
-				t.Fatalf("exit code was %d and not 0. Please see output.", exit)
+			var b bytes.Buffer
+			if exit := run(&b); exit != 0 {
+				t.Fatalf("exit code was %d and not 0. Output:\n%s", exit, b.String())
 			}
 		})
 	}


### PR DESCRIPTION
Make run() accept an io.Writer. When invoking the application
from the command line pass os.Stderr to it.
For unit tests pass a bytes.Buffer pointer.

Before:
exit code was 1 and not 0. Please see output.

After:
exit code was 1 and not 0. Output:
some-kep-path/kep.yaml has an error: "yaml: unmarshal errors:\n
line 26: field "foo" not found in type keps.Proposal"
