### PR TITLE
fix(typo): replace reportingComponent with reportingController

### DIFF
--- a/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md
+++ b/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md
@@ -333,7 +333,7 @@ We need to make sure that kubernetes client used by EventRecorder uses properly 
 ### Other Related Changes
 
 To allow easier querying we need to make following fields selectable for Events:
-- event.reportingComponent
+- event.reportingController
 - event.reportingInstance
 - event.action
 - event.reason


### PR DESCRIPTION
the [383-new-event-api-ga-gradution](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md) introduce an [API Change](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md#api-changes) in Event Object. 

And the [related-changes](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md#other-related-changes) section defines a **event.reportingComponent** field name witch is defined as **reporingController** in Event struct.

Maybe this is a typo?

