### PR TITLE
Update release-notes KEP to reflect the current state

### DIFF
--- a/keps/sig-release/1733-release-notes/kep.yaml
+++ b/keps/sig-release/1733-release-notes/kep.yaml
@@ -12,7 +12,7 @@ approvers:
   - "@calebamiles"
   - "@tpepper"
   - "@justaugustus"
-editor: TBD
+editor: "@saschagrunert"
 creation-date: 2019-03-31
 last-updated: 2019-03-31
-status: provisional
+status: implementable


### PR DESCRIPTION
This update for the release notes KEP should layout the current state of
the implementation.

Refers to https://github.com/kubernetes/enhancements/issues/1733

/cc @puerco @justaugustus @jeefy 