### PR TITLE
MCS: Add Headless support and graduation criteria

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -528,12 +528,8 @@ const (
 
 // ServiceImportSpec describes an imported service and the information necessary to consume it.
 type ServiceImportSpec struct {
-  // +patchStrategy=merge
-  // +patchMergeKey=port
-  // +listType=map
-  // +listMapKey=port
-  // +listMapKey=protocol
-  Ports []ServicePort `json:"ports"`
+  // +listType=atomic
+  Ports []corev1.ServicePort `json:"ports"`
   // +optional
   IP string `json:"ip,omitempty"`
   // +optional

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
@@ -11,6 +11,7 @@ reviewers:
   - TBD
   - "@johnbelamaric"
   - "@janetkuo"
+  - "@danwinship"
 approvers:
   - "@pmorie"
   - "@thockin"

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
@@ -5,10 +5,9 @@ authors:
 owning-sig: sig-multicluster
 participating-sigs:
   - sig-network
-status: provisional
+status: implementable
 creation-date: 2020-03-30
 reviewers:
-  - TBD
   - "@johnbelamaric"
   - "@janetkuo"
   - "@danwinship"

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
@@ -12,6 +12,8 @@ reviewers:
   - "@johnbelamaric"
   - "@janetkuo"
   - "@danwinship"
+  - "@deads2k"
+  - "@liggitt"
 approvers:
   - "@pmorie"
   - "@thockin"

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
@@ -9,6 +9,8 @@ status: provisional
 creation-date: 2020-03-30
 reviewers:
   - TBD
+  - "@johnbelamaric"
+  - "@janetkuo"
 approvers:
   - "@pmorie"
   - "@thockin"


### PR DESCRIPTION
- Adds initial pass at multi-cluster Headless support based on previous weekly meeting & PR discussions.
- Reorganizes behavioral spec based on discussion from previous PR.
- Adds test plan, upgrade story, graduation criteria.
- Moves derived cluster state on `ServiceImport` to `Status`.
- Removes service topology and dual-stack related fields as both are still in flux.