### PR TITLE
Explicit PRR Approver field in kep.yaml

### DIFF
--- a/keps/NNNN-kep-template/kep.yaml
+++ b/keps/NNNN-kep-template/kep.yaml
@@ -13,7 +13,10 @@ reviewers:
   - "@alice.doe"
 approvers:
   - TBD
-  - "@oscar.doe" # PRR Approver
+  - "@oscar.doe"
+prr-approvers:
+  - TBD
+  - "@bob.doe"
 see-also:
   - "/keps/sig-aaa/1234-we-heard-you-like-keps"
   - "/keps/sig-bbb/2345-everyone-gets-a-kep"

--- a/pkg/kepval/keps/proposals.go
+++ b/pkg/kepval/keps/proposals.go
@@ -55,6 +55,7 @@ type Proposal struct {
 	ParticipatingSIGs []string `json:"participatingSigs" yaml:"participating-sigs,flow,omitempty"`
 	Reviewers         []string `json:"reviewers" yaml:",flow"`
 	Approvers         []string `json:"approvers" yaml:",flow"`
+	PRRApprovers      []string `json:"prrApprovers" yaml:"prr-approvers,flow"`
 	Editor            string   `json:"editor" yaml:"editor,omitempty"`
 	CreationDate      string   `json:"creationDate" yaml:"creation-date"`
 	LastUpdated       string   `json:"lastUpdated" yaml:"last-updated"`

--- a/pkg/kepval/keps/proposals_test.go
+++ b/pkg/kepval/keps/proposals_test.go
@@ -49,6 +49,8 @@ reviewers:
 approvers:
   - "@deads2k"
   - "@lavalamp"
+prr-approvers:
+  - "@wojtek-t"
 creation-date: 2018-04-15
 last-updated: 2018-04-24
 status: provisional


### PR DESCRIPTION
This would make easier to build tooling to e.g. find keps without approver assigned.

/cc @justaugustus 