### PR TITLE
modify the error url of kustomize

### DIFF
--- a/keps/sig-cli/kustomize-secret-generator-plugins.md
+++ b/keps/sig-cli/kustomize-secret-generator-plugins.md
@@ -445,7 +445,7 @@ in CONTRIBUTING.md.
 * Testing and documentation.
 
   * High level feature test
-    (like those in [pkg/target](https://github.com/kubernetes-sigs/kustomize/tree/master/pkg/target))
+    (like those in [pkg/target](https://github.com/kubernetes-sigs/kustomize/tree/master/api/internal/target))
   * Field documentarion in the 
     [canonical example file](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/helloWorld/kustomization.yaml)
   * Usage [examples](https://github.com/kubernetes-sigs/kustomize/tree/master/examples).


### PR DESCRIPTION
the error url is: https://github.com/kubernetes-sigs/kustomize/tree/master/pkg/target
the right url is: https://github.com/kubernetes-sigs/kustomize/tree/master/api/internal/target