### PR TITLE
Make Fair Queuing for Server Requests achieve max-min fairness

### DIFF
--- a/keps/sig-api-machinery/20190228-priority-and-fairness.md
+++ b/keps/sig-api-machinery/20190228-priority-and-fairness.md
@@ -784,7 +784,7 @@ predicting the course of `mu(i,t)` from now until E arrives.  However,
 because all the non-empty queues have the same value for `mu(i,t)`
 (i.e., `mu_fair(t)`), we can safely make whatever assumption we want
 without distorting the dispatching choice --- all non-empty queues are
-affected equally.
+affected equally, so even wildly wrong guesses don't change the ordering.
 
 The correspondence with the original telling of the fair queuing story
 goes as follows.  Equate


### PR DESCRIPTION
The existing design for Fair Queuing for Server Requests is broken.  It aims for equal division of capacity among non-empty queues rather than the max-min fair result.  This PR revises the design, to achieve max-min fairness.