### PR TITLE
Update SELinux relabeling enhancement to follow fsGroupChangePolicy

### DIFF
--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -65,6 +65,13 @@
 This KEP tries to speed up the way that volumes (incl. persistent volumes) are made available to Pods on systems with SELinux in enforcing mode.
 Current way includes recursive relabeling of all files on a volume before a container can be started. This is slow for large volumes.
 
+** Status: withdrawn **
+This KEP proposes to mount filesystems with the right SELinux context using `mount -o context=system_u:system_r:container_t:s0:c309,c383` mount option directly, without recursively changing labels on the volume.
+This works well for in-tree volume plugins, that mount volumes on the host, but it's problematic in CSI driver containers.
+`/bin/mount`, running in a privileged container, needs host's `/sys/fs/selinux` and `/etc/selinux/config`, otherwise it [silently discards any SELinux related mount options](https://github.com/karelzak/util-linux/blob/master/libmount/src/context_mount.c#L292).
+Since there are so many CSI drivers around, we can't force them easily to propagate these files from the host into the driver containers.
+In addition, there may be another Linux security modules and CSI drivers should not care if they are enabled and what files they need propagated in the driver containers.
+
 ## Motivation
 
 ### SELinux intro

--- a/keps/sig-storage/1710-selinux-relabeling/kep.yaml
+++ b/keps/sig-storage/1710-selinux-relabeling/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-storage
 participating-sigs:
   - sig-node
-status: implementable
+status: withdrawn
 creation-date: 2020-02-18
 reviewers:
   - "@msau42"

--- a/keps/sig-storage/695-skip-permission-change/kep.yaml
+++ b/keps/sig-storage/695-skip-permission-change/kep.yaml
@@ -21,10 +21,10 @@ superseded-by:
 latest-milestone: "v1.19"
 milestone:
   alpha: "v1.18"
-  beta: "v1.19"
-  stable: "v1.20"
+  beta: "v1.20"
+  stable: "v1.21"
 feature-gates:
-  - name: ConfigurableFSGroupPolicy
+  - name: ConfigurableVolumeChangePolicy
     components:
       - kube-apiserver
       - kubelet


### PR DESCRIPTION
I tried to implemet SELinuxRelabelPolicy as outlined [here](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling) and I hit one issue that would require all CSI driver vendors to update their CSI drivers:

In order to use `-o context=system_u:system_r:container_t:s0:c309,c383` mount option, the CSI driver must have `/sys/fs/selinux` and `/etc/selinux/config` mounted from the host. Otherwise, `/bin/mount` [silently discards all SELinux mount options](https://github.com/karelzak/util-linux/blob/master/libmount/src/context_mount.c#L292).

Since there are so many CSI drivers out there and very small fraction of them tests with SELinux, I've chosen to abandon mounting volumes and relabel volumes in kubelet, when the SELinux context is known.

This PR updates the existing FSGroupChangePolicy KEP:

* It renames `FSGroupChangePolicy` field to `VolumeChangePolicy` and re-uses it for SELinux relabeling too.
* It renames `ConfigurableFSGroupPolicy` alpha feature gate to `ConfigurableVolumeChangePolicy`.

There are some gotchas that may be hard to explain in the API:

* With `VolumeChangePolicy: Always`, it's the container runtime who relabels the volume. As consequence, it relabels only SubPaths that are actually mounted into the container. `VolumeChangePolicy: OnRootMismatch` relabels the whole volume (if needed). This is different to how `fsGroup` ownership change works - it always changes the whole volume, regardless of SubPaths.

* `VolumeChangePolicy: OnRootMismatch` works only when kubelet knows the SELinux label to apply, i.e. at least MCS level is set in `Pod.Spec.SecurityContext.SELinuxOptions`. When it's empty, kubelet silently falls back to policy `Always` - it lets the container runtime to pick a random unique MCS level and relabel the volume. Since the level is random, we can say that `OnRootMismatch` never matches.

cc @tallclair @smarterclayton @gnufied @msau42 @saad-ali 