### PR TITLE
keps/0001: Fix link to template

### DIFF
--- a/keps/0001-kubernetes-enhancement-proposal-process.md
+++ b/keps/0001-kubernetes-enhancement-proposal-process.md
@@ -144,9 +144,7 @@ These KEPs will be owned by SIG-architecture and should be seen as a way to comm
 
 ### KEP Template
 
-<b>
-The template for a KEP is precisely defined [here](/keps/NNNN-kep-template).
-</b>
+**The template for a KEP is precisely defined [here](/keps/NNNN-kep-template).**
 
 ### KEP Metadata
 


### PR DESCRIPTION
It appears that the []() syntax doesn't work inside the `<b>` tags. Use `href`
instead.