### PR TITLE
Update installHint doc upon feedback in user-facing docs

### DIFF
--- a/keps/sig-auth/541-external-credential-providers/README.md
+++ b/keps/sig-auth/541-external-credential-providers/README.md
@@ -138,18 +138,18 @@ users:
       - name: "FOO"
         value: "bar"
 
-      # Hint to help the user install the executable. Optional.
+      # Text shown to the user when the executable doesn't seem to be present. Optional.
       installHint: |
-      example-client-go-exec-plugin is required to authenticate
-      to the current cluster.  It can be installed:
+        example-client-go-exec-plugin is required to authenticate
+        to the current cluster.  It can be installed:
 
-      On macOS: brew install example-client-go-exec-plugin
+        On macOS: brew install example-client-go-exec-plugin
 
-      On Ubuntu: apt-get install example-client-go-exec-plugin
+        On Ubuntu: apt-get install example-client-go-exec-plugin
 
-      On Fedora: dnf install example-client-go-exec-plugin
+        On Fedora: dnf install example-client-go-exec-plugin
 
-      ...
+        ...
 clusters:
 - name: my-cluster
   cluster:


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

This change comes from the website docs PR: https://github.com/kubernetes/website/pull/22441.

The belief here is that the proposed `installHint` doc makes it easier for website docs readers to understand what the `installHint` field does. It also nicely parallels the `InstallHint` Go field doc.

It also also introduces valid YAML to the `kubeconfig` example.

CC @enj 