### PR TITLE
Mark accelerator-usage-metrics as implementable

### DIFF
--- a/keps/sig-node/1867-disable-accelerator-usage-metrics/README.md
+++ b/keps/sig-node/1867-disable-accelerator-usage-metrics/README.md
@@ -82,7 +82,7 @@ Add a feature flag and pass the disable option to cadvisor.
 
 ### Test Plan
 
-* E2E tests that checks when the feature flag is enabled if the metrics are present or not.
+* E2E test that checks when the feature flag is enabled if the metrics are present or not.
 
 ### Graduation Criteria
 

--- a/keps/sig-node/1867-disable-accelerator-usage-metrics/kep.yaml
+++ b/keps/sig-node/1867-disable-accelerator-usage-metrics/kep.yaml
@@ -4,12 +4,16 @@ authors:
   - "@RenaudWasTaken"
 owning-sig: sig-node
 participating-sigs: []
-status: provisional
+status: implementable
 creation-date: 2020-06-18
 reviewers:
-  - TBD
+  - "dashpole"
+  - "derekwaynecarr"
+  - "dawnchen"
 approvers:
-  - TBD
+  - "dashpole"
+  - "derekwaynecarr"
+  - "dawnchen"
 prr-approvers:
   - "deads2k"
   - "johnbelamaric"


### PR DESCRIPTION
- Marks KEP as implementable
- Updates the reviewers and approvers fields with sig-node reviewers and approvers
- Fix typo in the test plan (since we only have a single test)

Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>