### PR TITLE
Update graduation criteria and dual stack prep

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -564,8 +564,9 @@ const (
 type ServiceImportSpec struct {
   // +listType=atomic
   Ports []ServicePort `json:"ports"`
+  // +kubebuilder:validation:MaxItems:=1
   // +optional
-  IP string `json:"ip,omitempty"`
+  IPs []string `json:"ips,omitempty"`
   // +optional
   Type ServiceImportType `json:"type"`
   // +optional
@@ -625,7 +626,8 @@ metadata:
   name: my-svc
   namespace: my-ns
 spec:
-  ip: 42.42.42.42
+  ips:
+  - 42.42.42.42
   type: "SuperclusterIP"
   ports:
   - name: http
@@ -872,11 +874,13 @@ when drafting this test plan.
 - A detailed DNS spec for multi-cluster services.
 - NetworkPolicy either solved or explicitly ruled out.
 - API group chosen and approved.
+- Implementation strategy defined and approved.
 - Kube-proxy can consume ServiceImport and EndpointSlice.
 - E2E tests exist for MCS services.
 - Beta -> GA Graduation criteria defined.
 - At least one MCS DNS implementation.
 - A formal plan for a standard Cluster ID.
+- Finalize a name for the "supercluster" concept.
 
 #### Beta -> GA Graduation
 


### PR DESCRIPTION
- Add implementation plan and naming to graduation criteria
- Change ServiceImport.Spec.IP to list (currently limited at 1) to
  align with dual stack plans.