### PR TITLE
Abandon Conformance Behaviors KEP

### DIFF
--- a/keps/sig-architecture/960-conformance-behaviors/README.md
+++ b/keps/sig-architecture/960-conformance-behaviors/README.md
@@ -86,6 +86,17 @@ Check these off as they are completed for the Release Team to track. These check
 
 ## Summary
 
+
+**NOTE**
+
+This KEP is now withdrawn. After initial attempts at implementation it
+became clear that the effort to rework existing tests to follow this methodology
+was more extensive than expected. Additionally, the problems this KEP intended
+to solve (particularly separate reviewer pools) have not proven to be the
+bottleneck in test creation and promotion.
+
+**END NOTE**
+
 This proposal modifies the conformance testing framework to be driven by a list
 of agreed upon behaviors. These behaviors are identified by processing of the
 API schemas, documentation, expert knowledge, and code examination. They are

--- a/keps/sig-architecture/960-conformance-behaviors/kep.yaml
+++ b/keps/sig-architecture/960-conformance-behaviors/kep.yaml
@@ -18,5 +18,5 @@ approvers:
   - "@smarterclayton"
 editor: TBD
 creation-date: 2019-04-12
-last-updated: 2020-04-17
-status: implementable
+last-updated: 2020-07-28
+status: withdrawn


### PR DESCRIPTION
As discussed in the [June 30 Conformance Meeting](https://docs.google.com/document/d/1W31nXh9RYAb_VaYkwuPLd1hFxuRX3iU0DmaQ4lkCsX8/edit#heading=h.hyqvyh9r34), abandoning this KEP.

Future PRs will remove the dead code.