### PR TITLE
podresources: add Watch endpoint

### DIFF
--- a/keps/sig-node/compute-device-assignment.md
+++ b/keps/sig-node/compute-device-assignment.md
@@ -86,9 +86,9 @@ message ListPodResourcesResponse {
 message WatchPodResourcesRequest {}
 
 enum WatchPodAction {
-    UPDATED = 0;
-    DELETED = 1;
-    ADDED = 2;
+    ADDED = 0;
+    MODIFIED = 1;
+    DELETED = 2;
 }
 
 // WatchPodResourcesResponse is the response returned by Watch function
@@ -184,7 +184,7 @@ Beta:
 
 ## Implementation History
 
-- 2020-08-XX: KEP extended with ListAndWatch function
+- 2020-08-XX: KEP extended with Watch function
 - 2018-09-11: Final version of KEP (proposing pod-resources endpoint) published and presented to sig-node.  [Slides](https://docs.google.com/presentation/u/1/d/1xz-iHs8Ec6PqtZGzsmG1e68aLGCX576j_WRptd2114g/edit?usp=sharing)
 - 2018-10-30: Demo with example gpu monitoring daemonset
 - 2018-11-10: KEP lgtm'd and approved

--- a/keps/sig-node/compute-device-assignment.md
+++ b/keps/sig-node/compute-device-assignment.md
@@ -102,6 +102,7 @@ message PodResources {
     string name = 1;
     string namespace = 2;
     repeated ContainerResources containers = 3;
+    int64 resource_version = 4;
 }
 
 // ContainerResources contains information about the resources assigned to a container
@@ -117,10 +118,24 @@ message ContainerDevices {
 }
 ```
 
+### Consuming the Watch endpoint in client applications
+
+Using the `Watch` endpoint, client applications can be notified of the pod resource allocation changes as soon as possible.
+However, the state of a pod will not be sent up until the first resource allocation change, which is the pod deletion in the worst case.
+Client applications who need to have the complete resource allocation picture thus need to consume both `List` and `Watch` endpoints.
+The `resourceVersion` found in the responses of both APIs allows client applications to identify the most recent information.
+To keep the implementation simple as possible, the kubelet does *not* store any historical list of changes.
+
+In order to make sure not to miss any updates, client application can:
+1. call the `Watch` endpoint to get a stream of changes.
+2. call the `List` endpoint to get the state of all the pods in the node.
+3. reconcile updates using the `resourceVersion`.
+
 ### Potential Future Improvements
 
 * Add identifiers for other resources used by pods to the `PodResources` message.
   * For example, persistent volume location on disk
+* Implement historical list of changes, allowing client applications to call `List` and `Watch` endpoints in a more natural order.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
Extend the protocol with a simple implementation of ListAndWatch
to enable monitoring agents to be notified of resource allocation
changes.

Signed-off-by: Francesco Romani <fromani@redhat.com>