### PR TITLE
Update exec credential provider KEP with feedback from cluster info PR

### DIFF
--- a/keps/sig-auth/541-external-credential-providers/README.md
+++ b/keps/sig-auth/541-external-credential-providers/README.md
@@ -271,6 +271,10 @@ type Cluster struct {
   // +listType=atomic
   // +optional
   CAData []byte `json:"caData,omitempty"`
+  // ProxyURL is the URL to the proxy to be used for all requests to this
+  // cluster.
+  // +optional
+  ProxyURL string `json:"proxy-url,omitempty"`
   // Config holds additional config data that is specific to the exec plugin
   // with regards to the cluster being authenticated to.
   // +optional

--- a/keps/sig-auth/541-external-credential-providers/README.md
+++ b/keps/sig-auth/541-external-credential-providers/README.md
@@ -156,7 +156,7 @@ clusters:
     server: "https://1.2.3.4:8080"
     certificate-authority: "/etc/kubernetes/ca.pem"
     extensions:
-    - name: exec  # reserved extension name for per cluster exec config
+    - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
       extension:
         some-config-per-cluster: config-data  # arbitrary config
 contexts:


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

* The goal of these updates is to reach consensus on how best to wire cluster info into exec credential providers so that we can wrap up and merge the implementation (https://github.com/kubernetes/kubernetes/pull/91192).
* These updates come from feedback on https://github.com/kubernetes/kubernetes/pull/91192.
  * https://github.com/kubernetes/kubernetes/pull/91192/files#r445956896 (`ProxyURL`)
  * https://github.com/kubernetes/kubernetes/pull/91192/files#r445957437 (`client.authentication.k8s.io/exec `)

@liggitt - would you be willing to submit your opinion about these updates? I reach out to you because you and @enj discussed a proper superset of these changes in https://github.com/kubernetes/kubernetes/pull/91192. I understand this is not the whole set of changes that you requested in that PR, but I tried to take the intersection of you and @enj's proposals and present them here as a starting place. My hope is that we can 1) tie off the cluster info design in this KEP, 2) update the implementation, 3) get the implementation approved, and 4) get the implementation merged.