### PR TITLE
Warn against using addons.sig.k8s.io group

### DIFF
--- a/keps/sig-cluster-lifecycle/addons/0035-20190128-addons-via-operators.md
+++ b/keps/sig-cluster-lifecycle/addons/0035-20190128-addons-via-operators.md
@@ -145,7 +145,9 @@ We expect the following functionality to be common to all operators for addons:
 
 
 An example can make this easier to understand, here is what a CRD instance for
-kube-proxy might look like:
+kube-proxy might look like (NOTE: your apiVersion will depend on the group
+you intend to use for your CRDs, and should *not* be in the addons.sig.k8s.io
+group):
 
 ```yaml
 apiVersion: addons.sigs.k8s.io/v1alpha1


### PR DESCRIPTION
I've seen a few internal projects use addons.sig.k8s.io as a result of the "may look like this" comment, and would like to avoid further confusion here.