### PR TITLE
trivial: fix broken link markdown

### DIFF
--- a/keps/sig-apps/0753-sidecarcontainers.md
+++ b/keps/sig-apps/0753-sidecarcontainers.md
@@ -105,7 +105,7 @@ shutdown have met several times and are in sync regarding these features
 interoperability.
 
 The details about this dependency is explained in the [graduation criteria
-section][#graduation-criteria].
+section](#graduation-criteria).
 
 ## Motivation
 


### PR DESCRIPTION
In-page link was [text][url] instead of [text](url).

Signed-off-by: Tim Pepper <tpepper@vmware.com>