### PR TITLE
Use a regexp instead of strings for SIGs in query

### DIFF
--- a/pkg/kepval/keps/validations/yaml.go
+++ b/pkg/kepval/keps/validations/yaml.go
@@ -94,6 +94,10 @@ var (
 	prrApprovers []string
 )
 
+func Sigs() []string {
+	return listGroups
+}
+
 func init() {
 	resp, err := http.Get("https://raw.githubusercontent.com/kubernetes/community/master/sigs.yaml")
 	if err != nil {


### PR DESCRIPTION
This allows passing one or more regexp instead of strings to the `kepctl query` command. This makes discoverability way better. For example, with this and the PRR PR I have out, I could use `kepctl query --sig '.*' --prr '@johnbelamaric' --include-prs --status provisional` to get a list of all Provisional KEPs for which I am assigned as a PRR reviewer.

However, it means the CLI tool only will work if you are online, since the SIG list is loaded in the package `init` of the validations module. Maybe we should embed the list as of the build time?