### PR TITLE
Remove root OWNERS applied sig-arch label

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,5 +5,3 @@ approvers:
   - sig-architecture-leads
 reviewers:
   - enhancements-reviewers
-labels:
-  - sig/architecture


### PR DESCRIPTION
The label being applied to every PR has made it difficult to triage what items actually belong to sig-arch.

/assign @jeremyrickard @johnbelamaric @justaugustus 