### PR TITLE
LTS: mark 1 year support KEP 1498 "implemented"

### DIFF
--- a/keps/sig-release/1498-kubernetes-yearly-support-period/README.md
+++ b/keps/sig-release/1498-kubernetes-yearly-support-period/README.md
@@ -230,6 +230,11 @@ Note: The above assumes no change in the number of releases made per year. If th
   and extend support additionally for 1.18, 1.17, and 1.16
 - [k-dev list discussion](https://groups.google.com/d/topic/kubernetes-dev/tOe2UFB_weQ/discussion)
   regarding move of this KEP to `implementable`
+- implemented state:
+  * 1.19 release and newer will have 1 year support as per this KEP
+  * barring any other changes outside this KEP's implemented state,
+    1.18 and prior will continue to have the 9 months or N-3 support
+    that was the norm when they were releases
 
 ## Drawbacks
 

--- a/keps/sig-release/1498-kubernetes-yearly-support-period/kep.yaml
+++ b/keps/sig-release/1498-kubernetes-yearly-support-period/kep.yaml
@@ -24,7 +24,7 @@ approvers:
   - "@pwittrock"
 creation-date: 2020-01-22
 latest-milestone: v1.19
-status: implementable
+status: implemented
 see-also:
 replaces:
 superseded-by:


### PR DESCRIPTION
This KEP has been implemented for 1.19 and newer.

Signed-off-by: Tim Pepper <tpepper@vmware.com>