### PR TITLE
Add discussion link to issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,7 @@
 # Enhancement Description
 - One-line enhancement description (can be used as a release note):
 - Kubernetes Enhancement Proposal: <!-- link to kubernetes/enhancements file; if none yet, link to PR -->
+- Discussion Link: <!-- link to SIG mailing list thread, meeting, or recording where the Enhancement was discussed before KEP creation -->
 - Primary contact (assignee):
 - Responsible SIGs:
 - Enhancement target (which target equals to which milestone):

--- a/keps/README.md
+++ b/keps/README.md
@@ -8,6 +8,7 @@ This process is still in a _beta_ state and is mandatory for all enhancements be
 ## Quick start for the KEP process
 
 1. Socialize an idea with a sponsoring SIG.
+   You can send your idea to their mailing list, or add it to the agenda for one of their upcoming meetings.
    Make sure that others think the work is worth taking up and will help review the KEP and any code changes required.
 2. Follow the process outlined in the [KEP template](NNNN-kep-template/README.md)
 


### PR DESCRIPTION
Before KEPs are created, they are intended to be discussed and socialized with the owning SIG. This field adds a discoverability point between the tracking issue and the original conversation around the KEP.

/hold
/cc @LappleApple @kikisdeliveryservice 
/assign @johnbelamaric 