### PR TITLE
kepctl: fix query when KEPs are nested in directories

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1060,6 +1060,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/kepctl/kepctl_test.go
+++ b/pkg/kepctl/kepctl_test.go
@@ -41,7 +41,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "invalid kep fails valdiate for owning-sig",
 			file: "testdata/invalid-kep.yaml",
-			err:  fmt.Errorf(`kep is invalid: error validating KEP metadata: "owning-sig" must be one of (committee-code-of-conduct,committee-product-security,committee-steering,sig-api-machinery,sig-apps,sig-architecture,sig-auth,sig-autoscaling,sig-cli,sig-cloud-provider,sig-cluster-lifecycle,sig-contributor-experience,sig-docs,sig-instrumentation,sig-multicluster,sig-network,sig-node,sig-release,sig-scalability,sig-scheduling,sig-service-catalog,sig-storage,sig-testing,sig-ui,sig-usability,sig-windows,ug-big-data,ug-vmware-users,wg-api-expression,wg-component-standard,wg-data-protection,wg-iot-edge,wg-k8s-infra,wg-lts,wg-machine-learning,wg-multitenancy,wg-naming,wg-policy,wg-security-audit) but it is a string: sig-awesome`),
+			err:  fmt.Errorf(`kep is invalid: error validating KEP metadata: "owning-sig" must be one of (committee-code-of-conduct,committee-product-security,committee-steering,sig-api-machinery,sig-apps,sig-architecture,sig-auth,sig-autoscaling,sig-cli,sig-cloud-provider,sig-cluster-lifecycle,sig-contributor-experience,sig-docs,sig-instrumentation,sig-multicluster,sig-network,sig-node,sig-release,sig-scalability,sig-scheduling,sig-security,sig-service-catalog,sig-storage,sig-testing,sig-ui,sig-usability,sig-windows,ug-big-data,ug-vmware-users,wg-api-expression,wg-component-standard,wg-data-protection,wg-iot-edge,wg-k8s-infra,wg-lts,wg-multitenancy,wg-naming,wg-policy,wg-security-audit) but it is a string: sig-awesome`),
 		},
 	}
 
@@ -70,7 +70,7 @@ func TestFindLocalKEPs(t *testing.T) {
 	}{
 		{
 			"sig-architecture",
-			[]string{"123-newstyle", "20200115-kubectl-diff"},
+			[]string{"123-newstyle", "20200115-kubectl-diff.md"},
 		},
 		{
 			"sig-sig",
@@ -78,21 +78,17 @@ func TestFindLocalKEPs(t *testing.T) {
 		},
 	}
 
+	c, _ := New("testdata")
 	for i, tc := range testcases {
-		k, err := findLocalKEPs("testdata", tc.sig)
-		if err != nil {
-			t.Errorf("Test case %d: expected no error but got %s", i, err)
-			continue
-		}
+		k := c.loadLocalKEPs("testdata", tc.sig)
 		if len(k) != len(tc.keps) {
-			t.Errorf("Test case %d: expected %s but got %s", i, tc.keps, k)
+			t.Errorf("Test case %d: expected %d but got %d", i, len(tc.keps), len(k))
 			continue
 		}
 		for j, kn := range k {
-			if kn != tc.keps[j] {
-				t.Errorf("Test case %d: expected %s but got %s", i, tc.keps[j], kn)
+			if kn.Name != tc.keps[j] {
+				t.Errorf("Test case %d: expected %s but got %s", i, tc.keps[j], kn.Name)
 			}
 		}
 	}
-	findLocalKEPs("testdata", "sig-architecture")
 }

--- a/pkg/kepctl/query.go
+++ b/pkg/kepctl/query.go
@@ -66,23 +66,11 @@ func (c *Client) Query(opts QueryOpts) error {
 	// load the KEPs for each listed SIG
 	for _, sig := range opts.SIG {
 		// KEPs in the local filesystem
-		names, err := findLocalKEPs(repoPath, sig)
-		if err != nil {
-			fmt.Fprintf(c.Err, "error searching for local KEPs from %s: %s\n", sig, err)
-		}
-
-		for _, k := range names {
-			kep, err := c.readKEP(repoPath, sig, k)
-			if err != nil {
-				fmt.Fprintf(c.Err, "error reading KEP %s: %s\n", k, err)
-			} else {
-				allKEPs = append(allKEPs, kep)
-			}
-		}
+		allKEPs = append(allKEPs, c.loadLocalKEPs(repoPath, sig)...)
 
 		// Open PRs; existing KEPs with open PRs will be shown twice
 		if opts.IncludePRs {
-			prKeps, err := c.findKEPPullRequests(sig)
+			prKeps, err := c.loadKEPPullRequests(sig)
 			if err != nil {
 				fmt.Fprintf(c.Err, "error searching for KEP PRs from %s: %s\n", sig, err)
 			}


### PR DESCRIPTION
Previously, it would give errors as it could not find the files. It assumed they were in the root of the SIG's KEP directory.