### PR TITLE
Add Documentation PR section to the issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -9,5 +9,8 @@
   - Beta release target (x.y)
   - Stable release target (x.y)
 - Documentation PR: <!-- link to kubernetes/website PR -->
+  - Alpha:
+  - Beta:
+  - Stable:
 
 _Please keep this description up to date. This will help the Enhancement Team to track the evolution of the enhancement efficiently._

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -8,5 +8,6 @@
   - Alpha release target (x.y)
   - Beta release target (x.y)
   - Stable release target (x.y)
+- Documentation PR: <!-- link to kubernetes/website PR -->
 
 _Please keep this description up to date. This will help the Enhancement Team to track the evolution of the enhancement efficiently._


### PR DESCRIPTION
As we kick off the 1.20 release, there has been a discussion with the Enhancement team and Docs team on improving the current process of tracking all the necessary release requirements from Enhancement owners. 

Based on the discussion, @kikisdeliveryservice (Enhancement lead) and I (Docs lead) believe that adding a docs section in the issue template would help. This will make sure Enhancement owners are aware of docs requirements earlier in the process when an issue is created (An item from 1.17 retro) and help both the enhancement/docs team to not dig through all the comments to figure out where docs PR(s) were shared. 

/assign @mrbobbytables @jeremyrickard @justaugustus @johnbelamaric 
/hold 
for feedback

Example: https://github.com/kubernetes/enhancements/issues/757