### PR TITLE
KEP-1553: Include PRs as in scope in design details

### DIFF
--- a/keps/sig-contributor-experience/1553-issue-triage/README.md
+++ b/keps/sig-contributor-experience/1553-issue-triage/README.md
@@ -166,7 +166,8 @@ Here we propose [introducing two new labels](https://github.com/kubernetes/test-
 - `needs-triage`
 - `triage/accepted`
 
-The `needs-triage` label would be automatically applied to incoming issues.
+The `needs-triage` label would be automatically applied to incoming issues and
+PRs.
 
 Current contributors would then need to inspect issues with the `needs-triage`
 label and attempt to triage them.


### PR DESCRIPTION
The rest of the KEP was updated to include PRs as in scope for the issue-triage label, but it was neglected in the specific design details.

/cc @nikhita @cblecker 