### PR TITLE
KEP-277: Switch Ephemeral Containers KEP to directory-based format

### DIFF
--- a/keps/sig-node/20190717-seccomp-ga.md
+++ b/keps/sig-node/20190717-seccomp-ga.md
@@ -356,7 +356,7 @@ Therefore, seccomp annotation updates will be ignored. This maintains backwards 
 (no tightening validation), and makes a small stabilizing change to behavior (new Kubelets will
 ignore the update).
 
-When an [Ephemeral Container](20190212-ephemeral-containers.md) is added, it will follow the same
+When an [Ephemeral Container](277-ephemeral-containers) is added, it will follow the same
 rules for using or overriding the pod's seccomp profile. Ephemeral container's will never sync with
 a seccomp annotation.
 

--- a/keps/sig-node/20191205-container-streaming-requests.md
+++ b/keps/sig-node/20191205-container-streaming-requests.md
@@ -139,7 +139,7 @@ graduated or removed.
 Design a high-bandwidth low-latency production ready streaming channel to containers. Such a system
 should go through an ingress point other than the apiserver, and could be implemented (or at least
 prototyped) out of tree by leveraging the new [ephemeral containers
-feature](20190212-ephemeral-containers.md).
+feature](277-ephemeral-containers).
 
 ## Proposal
 

--- a/keps/sig-node/277-ephemeral-containers/kep.yaml
+++ b/keps/sig-node/277-ephemeral-containers/kep.yaml
@@ -1,0 +1,46 @@
+title: Ephemeral Containers
+kep-number: 277
+authors:
+  - "@verb"
+owning-sig: sig-node
+participating-sigs:
+  - sig-auth
+  - sig-node
+status: implementable
+creation-date: 2019-02-12
+reviewers:
+  - "@yujuhong"
+approvers:
+  - "@dchen1107"
+  - "@liggitt"
+prr-approvers:
+  - "@johnbelamaric"
+see-also:
+  - "/keps/sig-cli/1441-kubectl-debug"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.20"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v1.16"
+  beta: "v1.21"
+  stable: "v1.23"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: EphemeralContainers
+    components:
+      - kube-apiserver
+      - kubelet
+disable-supported: true
+
+# The following PRR answers are required at beta release
+metrics:
+  - my_feature_metric


### PR DESCRIPTION
This migrates the Ephemeral Containers KEP to the new directory-based format. No changes have been introduced, except:

1. I added a new summary of the proposal in the **Proposal** section, as required by the new template
2. I moved the API details from **Proposal** to **Design Details**
3. I added conformance test graduation criteria, as required by the new template.
4. I have not filled in new sections of the template, most notably the **PRR** sections.

I'd like to merge this as a separate PR to make it easier to review future PRs, which will actually propose new behavior or content changes.