### PR TITLE
Graduate DisableAcceleratorUsageMetrics to beta

### DIFF
--- a/keps/sig-node/1867-disable-accelerator-usage-metrics/README.md
+++ b/keps/sig-node/1867-disable-accelerator-usage-metrics/README.md
@@ -31,15 +31,15 @@
 ## Release Signoff Checklist
 
 - [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements](https://github.com/kubernetes/enhancements/issues/1867)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [X] (R) KEP approvers have approved the KEP status as `implementable`
 - [X] (R) Design details are appropriately documented
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [X] (R) Graduation criteria is in place
 - [X] (R) Production readiness review completed
 - [ ] Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [X] "Implementation History" section is up-to-date for milestone
+- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [X] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 [kubernetes.io]: https://kubernetes.io/
 [kubernetes/enhancements]: https://git.k8s.io/enhancements
@@ -170,6 +170,9 @@ Add a feature flag and pass the disable option to cadvisor.
 ## Implementation History
 
 - 2020-06-18: Initial version of the KEP
+- 2020-07-21: [Implementation of the docs merged](https://github.com/kubernetes/website/pull/22628)
+- 2020-07-22: [Implementation of the feature merged](https://github.com/kubernetes/kubernetes/pull/91930)
+- 2020-09-30: Graduate feature to beta
 
 ## Drawbacks
 

--- a/keps/sig-node/1867-disable-accelerator-usage-metrics/kep.yaml
+++ b/keps/sig-node/1867-disable-accelerator-usage-metrics/kep.yaml
@@ -23,17 +23,17 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.19"
+latest-milestone: "v1.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.19"
-  beta: "v1.21"
+  beta: "v1.20"
   stable: "v1.22"
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
Hello there!

This PR updates the DisableAcceleratorUsageMetrics KEP with the following changes:
- Graduates the KEP to beta
- Updates the KEP history
- Updates the KEP checklist

Signed-off-by: Renaud Gaubert <rgaubert@nvidia.com>
/sig node
/cc @derekwaynecarr @dchen1107 @dashpole 
