### PR TITLE
Change beta target for skipping volume permission change KEP

### DIFF
--- a/keps/sig-storage/695-skip-permission-change/kep.yaml
+++ b/keps/sig-storage/695-skip-permission-change/kep.yaml
@@ -22,11 +22,10 @@ superseded-by:
 latest-milestone: "v1.19"
 milestone:
   alpha: "v1.18"
-  beta: "v1.19"
-  stable: "v1.20"
+  beta: "v1.20"
+  stable: "v1.21"
 feature-gates:
   - name: ConfigurableFSGroupPolicy
     components:
       - kube-apiserver
       - kubelet
-


### PR DESCRIPTION
Fixes beta target of the kep.

cc @kubernetes/sig-storage-pr-reviews 