### PR TITLE
Adding check for readiness approval in FQDN Hostname KEP 

### DIFF
--- a/keps/sig-node/1797-configure-fqdn-as-hostname-for-pods/README.md
+++ b/keps/sig-node/1797-configure-fqdn-as-hostname-for-pods/README.md
@@ -135,7 +135,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [X] (R) Graduation criteria is in place
 - [X] (R) Production readiness review completed
-- [ ] Production readiness review approved
+- [X] Production readiness review approved
 - [X] "Implementation History" section is up-to-date for milestone
 - [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [X] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes


### PR DESCRIPTION
Forgot to add the check to Production Readiness approval in my previous PR https://github.com/kubernetes/enhancements/pull/1962. 