### PR TITLE
Hardened Exec Requests: Fill in PRR, add Kubelet feature gate, mark implementable

### DIFF
--- a/keps/sig-node/1898-hardened-exec/README.md
+++ b/keps/sig-node/1898-hardened-exec/README.md
@@ -22,6 +22,7 @@
   - [API](#api)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
+    - [Alpha Criteria](#alpha-criteria)
     - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
     - [Beta -&gt; GA Graduation](#beta---ga-graduation)
   - [Version Skew Strategy](#version-skew-strategy)
@@ -290,6 +291,20 @@ expecting success or failure depending on the status of the `HardenedExecRequest
 The tests should be implemented under `test/e2e/common` for inclusion in the `e2e_node` test suites.
 
 ### Graduation Criteria
+
+#### Alpha Criteria
+
+- Update `PodExecOptions` with pod reference
+- Update Kubelet API (guarded by `DeprecatedKubeletStreamingAPI`)
+  - Remove the kubelet's `/run` and UID-specific endpoints
+  - Require POST request for kubelet streaming endpoints
+  - Require options in request body
+- Update kube-apiserver:
+  - Always use POST for streaming requests to Kubelet
+  - Send options in request body (but also query params)
+  - Require POST with request body for non-websocket `exec` requests, guarded by **alpha** `HardenedExecRequests`
+- Update go-client to send exec POST requests with options in the body (and also in query params)
+- Expand E2E test coverage - https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1898-hardened-exec#test-plan
 
 #### Alpha -> Beta Graduation
 

--- a/keps/sig-node/1898-hardened-exec/kep.yaml
+++ b/keps/sig-node/1898-hardened-exec/kep.yaml
@@ -6,12 +6,15 @@ owning-sig: sig-node
 participating-sigs:
   - sig-api-machinery
   - sig-auth
-status: provisional
+status: implementable
 creation-date: 2020-07-08
 reviewers:
-  - TBD
+  - derekwaynecarr
+  - liggitt
+  - sftim
 approvers:
-  - TBD
+  - derekwaynecarr
+  - liggitt
 prr-approvers:
   - deads2k
 see-also:
@@ -36,10 +39,10 @@ milestone:
 feature-gates:
   - name: HardenedExecRequests
     components:
-      - kubelet
       - kube-apiserver
-      - client-go
-      - kubectl
+  - name: DeprecatedKubeletStreamingAPI
+    components:
+      - kubelet
 disable-supported: true
 
 # The following PRR answers are required at beta release


### PR DESCRIPTION
I decided to add an additional feature gate, `DeprecatedKubeletStreamingAPI`, and move the backwards-incompatible Kubelet changes behind this feature gate. This feature gate will not follow the normal gradual rollout, since these APIs are not intended to be user-facing, but will provide an escape hatch for someone depending on them today.

I also filled out the PRR, and marked the KEP as implementable.

Forr PRR approval:
/assign @deads2k 

For implemantable:
/assign @derekwaynecarr 

/milestone v1.20

For https://github.com/kubernetes/enhancements/issues/1898