### PR TITLE
OWNERS: Add Lauri Apple as an Enhancements subproject owner

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -172,11 +172,13 @@ aliases:
     - jeremyrickard
     - johnbelamaric
     - justaugustus
+    - LappleApple
     - mrbobbytables
   enhancements-reviewers:
     - jeremyrickard
     - johnbelamaric
     - justaugustus
+    - LappleApple
     - mrbobbytables
   prod-readiness-approvers:
     - johnbelamaric

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -73,10 +73,8 @@ aliases:
     - Huang-Wei
     - ahg-g
   sig-security-leads:
-    - aasmall
-    - cji
-    - jaybeale
-    - joelsmith
+    - iancoldwater
+    - tabbysable
   sig-service-catalog-leads:
     - jberkhahn
     - mszostok
@@ -134,11 +132,10 @@ aliases:
   wg-policy-leads:
     - ericavonb
     - hannibalhuang
-  wg-security-audit-leads:
-    - aasmall
-    - cji
-    - jaybeale
-    - joelsmith
+  wg-reliability-leads:
+    - deads2k
+    - stevekuznetsov
+    - wojtek-t
   ug-big-data-leads:
     - erikerlandson
     - foxish

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,7 +10,8 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-calebamiles
-idvoretskyi
-jdumars
+jeremyrickard
+johnbelamaric
 justaugustus
+LappleApple
+mrbobbytables


### PR DESCRIPTION
- OWNERS: Add Lauri Apple as an Enhancements subproject owner
- OWNERS: Sync OWNERS_ALIASES w/ k/community
- OWNERS: Update SECURITY_CONTACTS

This has been approved by all @kubernetes/sig-architecture-leads and @kubernetes/enhancements subproject owners.
ref: https://groups.google.com/g/kubernetes-sig-architecture/c/_LcElBQ0uc8, https://kubernetes.slack.com/archives/C5P3FE08M/p1601585313029600, https://github.com/kubernetes/org/pull/2241
cc: @LappleApple 