### PR TITLE
cloud controller manager migration: default values and lease types update.

### DIFF
--- a/keps/sig-cloud-provider/991-cloud-controller-migration/README.md
+++ b/keps/sig-cloud-provider/991-cloud-controller-migration/README.md
@@ -289,6 +289,20 @@ unsetting the `--enable-migration-config` flag.
 * Increased apiserver load due to new leader election resource per migration configuration.
 * User error could result in cloud controllers not running in any component at all.
 
+### Test Plan
+
+- Unit Testing:
+  - test resource reading, parsing, validation
+  - test calculation of leader differences.
+  - test all helpers
+- Integration Testing
+  - test resource registration, parsing, and validation against the Schema APIs
+  - test interactions with the leader election APIs
+- E2E Testing
+  - In a single-node control plane with leader election setting, test control plane upgrade, assert controller managers
+    become health and ready after upgrade
+  - In a multi-node control plane setting, test control plane upgrade, assert availability throughout the upgrade
+
 ### Graduation Criteria
 
 ##### Alpha -> Beta Graduation

--- a/keps/sig-cloud-provider/991-cloud-controller-migration/kep.yaml
+++ b/keps/sig-cloud-provider/991-cloud-controller-migration/kep.yaml
@@ -12,7 +12,7 @@ approvers:
   - "@lavalamp"
 editor: TBD
 creation-date: 2019-04-22
-last-updated: 2019-04-22
+last-updated: 2021-02-08
 status: implementable
 see-also:
   - "/keps/sig-cloud-provider/20180530-cloud-controller-manager.md"


### PR DESCRIPTION
differentiate lock type between 'leases' and 'endpoints'