### PR TITLE
exec credential provider: updates after sig-release feedback

### DIFF
--- a/keps/sig-auth/541-external-credential-providers/README.md
+++ b/keps/sig-auth/541-external-credential-providers/README.md
@@ -26,6 +26,10 @@
 - [Alternatives](#alternatives)
   - [RPC vs exec](#rpc-vs-exec)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature enablement and rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
 - [Implementation History](#implementation-history)
 <!-- /toc -->
 

--- a/keps/sig-auth/541-external-credential-providers/README.md
+++ b/keps/sig-auth/541-external-credential-providers/README.md
@@ -559,7 +559,8 @@ Feature is already in Beta.
 - Docs are up-to-date with latest version of APIs
 - Docs describe set of best practices (i.e. do not mutate `kubeconfig`)
 
-Question: does this need conformance tests?  What would such a test look like?
+Note: this feature set does not need conformance tests because it is inherently
+opt-in on the client-side and it relies on an extra binary to be present.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-auth/541-external-credential-providers/README.md
+++ b/keps/sig-auth/541-external-credential-providers/README.md
@@ -629,10 +629,9 @@ The downsides of this approach compared to exec model are:
     settings again, just as it would if it was enabled for the first time.
 
 * **Are there any tests for feature enablement/disablement?**
-  - Sorta.
   - There are unit tests in `k8s.io/client-go/plugin/pkg/auth/exec` that
     verify what happens when various parts of this feature set are enabled (e.g.,
-    `providerClusterInfo`)
+    `provideClusterInfo`)
   - There are unit tests in `k8s.io/client-go/tools/clientcmd/...` that validate
     `kubeconfig`'s are handled correctly when they do not contain exec plugin
     configuration.
@@ -656,19 +655,22 @@ The downsides of this approach compared to exec model are:
     is very unlikely that a client would see an impact on existing behavior.
   - If a client did indeed enable the corresponding settings in its `kubeconfig` after
     rolling out this feature and it continually got 401's (or 403's, even) back from the
-    API, then it may be worth rolling the authentication configuration back to the
+    API, then it may be worth reverting the authentication configuration back to the
     previous state to see if the failure persists.
   - If the client is failing because it cannot use the exec plugin to get a credential,
     then there may be messages in the logs that look like this:
       `Unable to connect to the server: getting credentials: exec`
 
 * **Were upgrade and rollback tested? Was upgrade->downgrade->upgrade path tested?**
-  - No.
+  - N/A.
 
 * **Is the rollout accompanied by any deprecations and/or removals of features,
   APIs, fields of API types, flags, etc.?**
-  - This feature set contains the usual alpha, beta, and GA stages, and will follow the
-    same canonical deprecation pattern for its alpha and beta API versions.
+  - Deprecation of `gcp` and `azure` authentication options. These authentication options
+    can be used going forward via this exec plugin feature set.
+  - Otherwise, this feature set contains the usual alpha, beta, and GA
+    stages, and will follow the same canonical deprecation pattern for
+    its API versions.
 
 ### Monitoring requirements
 

--- a/keps/sig-auth/541-external-credential-providers/kep.yaml
+++ b/keps/sig-auth/541-external-credential-providers/kep.yaml
@@ -15,8 +15,10 @@ reviewers:
 approvers:
   - "@liggitt"
   - "@mikedanese"
+prr-approvers:
+  - "@deads2k"
 stage: beta
-latest-milestone: "v1.19"
+latest-milestone: "v1.20"
 milestone:
   alpha: "v1.10"
   beta: "v1.11"

--- a/keps/sig-auth/541-external-credential-providers/kep.yaml
+++ b/keps/sig-auth/541-external-credential-providers/kep.yaml
@@ -15,3 +15,9 @@ reviewers:
 approvers:
   - "@liggitt"
   - "@mikedanese"
+stage: beta
+latest-milestone: "v1.19"
+milestone:
+  alpha: "v1.10"
+  beta: "v1.11"
+  stable: "v1.21"


### PR DESCRIPTION
Signed-off-by: Andrew Keesler <akeesler@vmware.com>

- Per sig-release, this PR is out of date with the required KEP format.
- This PR should bring this KEP up to date with the required KEP format.
  - PRR: https://github.com/kubernetes/enhancements/blob/master/pkg/kepctl/testdata/templates/README.md#production-readiness-review-questionnaire
  - `kep.yaml` format: https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/kep.yaml
-  Previous PR in this saga: https://github.com/kubernetes/enhancements/pull/2023.