### PR TITLE
Mark SCTP as implemented

### DIFF
--- a/keps/sig-network/614-SCTP-support/README.md
+++ b/keps/sig-network/614-SCTP-support/README.md
@@ -724,3 +724,4 @@ _This section must be completed when targeting beta graduation to a release._
 - 2018-09-27 Kubernetes 1.12.0 released with Alpha SCTP support
 - 2019-10-02 Test Plan and Graduation Criteria added
 - 2020-08-26 Kubernetes 1.19.0 released with Beta SCTP support
+- 2020-10-21 All code and docs merged for GA in 1.20. Marked as implemented.

--- a/keps/sig-network/614-SCTP-support/kep.yaml
+++ b/keps/sig-network/614-SCTP-support/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 614
 authors:
   - "@janosi"
 owning-sig: sig-network
-status: implementable
+status: implemented
 creation-date: 2018-06-14
 reviewers:
   - "@danwinship"


### PR DESCRIPTION
Code (https://github.com/kubernetes/kubernetes/pull/95566) and docs (https://github.com/kubernetes/website/pull/24593) are now updated. SCTP is GA in 1.20.
