### PR TITLE
Update issue template to divide into alpha/beta/stable

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -5,12 +5,23 @@
 - Primary contact (assignee):
 - Responsible SIGs:
 - Enhancement target (which target equals to which milestone):
-  - Alpha release target (x.y)
-  - Beta release target (x.y)
-  - Stable release target (x.y)
-- Documentation PR: <!-- link to kubernetes/website PR -->
-  - Alpha:
-  - Beta:
-  - Stable:
+  - Alpha release target (x.y):
+  - Beta release target (x.y):
+  - Stable release target (x.y):
+- [ ] Alpha
+  - [ ] KEP (`k/enhancements`) update PR(s):
+  - [ ] Code (`k/k`) update PR(s):
+  - [ ] Docs (`k/website`) update PR(s):
+
+<!-- Uncomment these as you prepare the enhancement for the next stage
+- [ ] Beta
+  - [ ] KEP (`k/enhancements`) update PR(s):
+  - [ ] Code (`k/k`) update PR(s):
+  - [ ] Docs (`k/website`) update(s):
+- [ ] Stable
+  - [ ] KEP (`k/enhancements`) update PR(s):
+  - [ ] Code (`k/k`) update PR(s):
+  - [ ] Docs (`k/website`) update(s):
+-->
 
 _Please keep this description up to date. This will help the Enhancement Team to track the evolution of the enhancement efficiently._


### PR DESCRIPTION
Modify the issue template to divide up into `alpha`, `beta`, and `stable` to track resource changes based on the release. (This is a follow up on https://github.com/kubernetes/enhancements/pull/2016 based on https://github.com/kubernetes/enhancements/pull/2016#issuecomment-713118605)

/hold
for feedback from the Enhancement team

cc @justaugustus @mrbobbytables @kikisdeliveryservice 
