### PR TITLE
podresources: move the completion to 1.21

### DIFF
--- a/keps/sig-node/2043-pod-resource-concrete-assigments/README.md
+++ b/keps/sig-node/2043-pod-resource-concrete-assigments/README.md
@@ -349,6 +349,7 @@ Feature only collects data when requests comes in, data is then garbage collecte
 - 2020-07-06: Add Topology and cpus into PodResources interface
 - 2020-09-02: Add the GetAllocatableResources endpoint
 - 2020-10-01: KEP extended with Watch API
+- 2020-11-02: Agreement in sig-node to implement Watch API in the 1.21 cycle
 
 ## Alternatives
 

--- a/keps/sig-node/2043-pod-resource-concrete-assigments/kep.yaml
+++ b/keps/sig-node/2043-pod-resource-concrete-assigments/kep.yaml
@@ -27,13 +27,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.21"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.13"
   beta: "v1.15"
-  stable: "v1.20"
+  stable: "v1.21"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
For capacity reasons, the implementation of the Watch extension proposed
in this KEP has to be postponed to 1.21. We are still actively pursuing
all the other simpler changes to be part of 1.20.

This PR fixes the KEP to reflect that the implementation will be
completed in 1.21 and not in 1.20.

Signed-off-by: Francesco Romani <fromani@redhat.com>