### PR TITLE
Add YAML and JSON printers to kepctl query

### DIFF
--- a/cmd/kepctl/query.go
+++ b/cmd/kepctl/query.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/enhancements/pkg/kepctl"
@@ -43,6 +45,7 @@ func buildQueryCommand(k *kepctl.Client) *cobra.Command {
 	f.StringSliceVar(&opts.Stage, "stage", nil, "Stage")
 	f.StringSliceVar(&opts.PRRApprover, "prr", nil, "Prod Readiness Approver")
 	f.BoolVar(&opts.IncludePRs, "include-prs", false, "Include PRs in the results")
+	f.StringVar(&opts.Output, "output", kepctl.DefaultOutputOpt, fmt.Sprintf("Output format. Can be %v", kepctl.SupportedOutputOpts))
 
 	addRepoPathFlag(f, &opts.CommonArgs)
 

--- a/pkg/kepctl/kepctl.go
+++ b/pkg/kepctl/kepctl.go
@@ -19,6 +19,7 @@ package kepctl
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -480,4 +481,26 @@ func (c *Client) PrintTable(configs []PrintConfig, proposals []*keps.Proposal) {
 		table.Append(s)
 	}
 	table.Render()
+}
+
+// PrintYAML outputs keps array as YAML to c.Out
+func (c *Client) PrintYAML(proposals []*keps.Proposal) {
+	data, err := yaml.Marshal(proposals)
+	if err != nil {
+		fmt.Fprintf(c.Err, "error printing keps as YAML: %s", err)
+		return
+	}
+
+	fmt.Fprintln(c.Out, string(data))
+}
+
+// PrintJSON outputs keps array as YAML to c.Out
+func (c *Client) PrintJSON(proposals []*keps.Proposal) {
+	data, err := json.Marshal(proposals)
+	if err != nil {
+		fmt.Fprintf(c.Err, "error printing keps as JSON: %s", err)
+		return
+	}
+
+	fmt.Fprintln(c.Out, string(data))
 }

--- a/pkg/kepctl/query.go
+++ b/pkg/kepctl/query.go
@@ -26,6 +26,18 @@ import (
 	"k8s.io/enhancements/pkg/kepval/keps/validations"
 )
 
+var (
+	// SupportedOutputOpts stores all allowed query output formats
+	SupportedOutputOpts = []string{
+		"table",
+		"json",
+		"yaml",
+	}
+
+	// DefaultOutputOpt is the default output format for kepctl query
+	DefaultOutputOpt = "table"
+)
+
 type QueryOpts struct {
 	CommonArgs
 	SIG         []string
@@ -33,6 +45,7 @@ type QueryOpts struct {
 	Stage       []string
 	PRRApprover []string
 	IncludePRs  bool
+	Output      string
 }
 
 // Validate checks the args and cleans them up if needed
@@ -47,6 +60,12 @@ func (c *QueryOpts) Validate(args []string) error {
 		}
 		c.SIG = sigs
 	}
+
+	// check if the Output specified is one of "", "json" or "yaml"
+	if !sliceContains(SupportedOutputOpts, c.Output) {
+		return fmt.Errorf("unsupported output format: %s. Valid values: %v", c.Output, SupportedOutputOpts)
+	}
+
 	//TODO: check the valid values of stage, status, etc.
 	return nil
 }
@@ -109,6 +128,16 @@ func sliceToMap(s []string) map[string]bool {
 		m[v] = true
 	}
 	return m
+}
+
+func sliceContains(s []string, e string) bool {
+	for _, k := range s {
+		if k == e {
+			return true
+		}
+	}
+
+	return false
 }
 
 // returns all strings in vals that match at least one

--- a/pkg/kepctl/query.go
+++ b/pkg/kepctl/query.go
@@ -36,6 +36,11 @@ var (
 
 	// DefaultOutputOpt is the default output format for kepctl query
 	DefaultOutputOpt = "table"
+
+	StructuredOutputFormats = []string{
+		"json",
+		"yaml",
+	}
 )
 
 type QueryOpts struct {
@@ -73,7 +78,20 @@ func (c *QueryOpts) Validate(args []string) error {
 // Query searches the local repo and possibly GitHub for KEPs
 // that match the search criteria.
 func (c *Client) Query(opts QueryOpts) error {
-	fmt.Fprintf(c.Out, "Searching for KEPs...\n")
+	// if output format is json/yaml, suppress other outputs
+	// json/yaml are structured formats, logging events which
+	// do not conform to the spec will create formatting issues
+	var suppressOutputs bool
+	if sliceContains(StructuredOutputFormats, opts.Output) {
+		suppressOutputs = true
+	} else {
+		suppressOutputs = false
+	}
+
+	if !suppressOutputs {
+		fmt.Fprintf(c.Out, "Searching for KEPs...\n")
+	}
+
 	repoPath, err := c.findEnhancementsRepo(opts.CommonArgs)
 	if err != nil {
 		return errors.Wrap(err, "unable to search KEPs")

--- a/pkg/kepctl/query.go
+++ b/pkg/kepctl/query.go
@@ -118,7 +118,18 @@ func (c *Client) Query(opts QueryOpts) error {
 		keep = append(keep, k)
 	}
 
-	c.PrintTable(DefaultPrintConfigs("LastUpdated", "Stage", "Status", "SIG", "Authors", "Title", "Link"), keep)
+	switch opts.Output {
+	case "table":
+		c.PrintTable(DefaultPrintConfigs("LastUpdated", "Stage", "Status", "SIG", "Authors", "Title", "Link"), keep)
+	case "yaml":
+		c.PrintYAML(keep)
+	case "json":
+		c.PrintJSON(keep)
+	default:
+		// this check happens as a validation step in cobra as well
+		// added it for additional verbosity
+		return fmt.Errorf("unsupported output format: %s. Valid values: %s", opts.Output, SupportedOutputOpts)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Added an `--output` flag to `kepctl query` which accepts yaml, json or nothing
which is the default behavior and prints as a table to the standard output.

Related to #2095 

### Future Improvements

- Add a flag for specifying the columns that we want in the output
- Add the `link` attribute to the YAML and JSON as well.

/hold

(for reviews)