### PR TITLE
Updating topology KEPs to reflect updated 1.21 alpha target

### DIFF
--- a/keps/sig-network/2004-topology-aware-subsetting/README.md
+++ b/keps/sig-network/2004-topology-aware-subsetting/README.md
@@ -183,6 +183,11 @@ between expected endpoints and actual endpoints in the zone).
 - Autoscaling will not behave well if only a single zone is receiving large
   amounts of traffic. This could potentially be mitigated by separating
   deployments and HPAs per zone.
+- Services with ExternalTrafficPolicy=local will need special treatment here.
+  The `Auto` approach could result in a situation where an endpoint on a Node
+  is delivered to a separate underprovisioned zone. The simplest approach would
+  be to disable this subsetting functionality altogether. Alternatively, we
+  could subset strictly by zone without any kind of rebalancing mechanism.
 
 ## Design Details
 
@@ -535,8 +540,9 @@ EPEachZonePerSync = metrics.NewHistogramVec(
 ### Graduation Criteria
 - Alpha should provide basic functionality covered with tests described above.
 - This KEP will largely depend on the EndpointSlice Subsetting. Once the
-EndpointSlice Subsetting feature has been updated, our change can kick-in
-without any new fields being added.
+  EndpointSlice Subsetting feature has been updated, our change can kick-in
+  without any new fields being added.
+- Evaluate how this could apply to DNS.
 
 ### Version Skew Strategy
 Our KEP requires updates on both EndpointSlice Controller and kube-proxy. Thus

--- a/keps/sig-network/2004-topology-aware-subsetting/kep.yaml
+++ b/keps/sig-network/2004-topology-aware-subsetting/kep.yaml
@@ -26,12 +26,12 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.21"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.20"
-  beta: "v1.21"
+  alpha: "v1.21"
+  beta: "v1.22"
   stable: "v1.24"
 
 # The following PRR answers are required at alpha release

--- a/keps/sig-network/2030-endpointslice-subsetting/kep.yaml
+++ b/keps/sig-network/2030-endpointslice-subsetting/kep.yaml
@@ -24,13 +24,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.21"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.20"
-  beta: "v1.21"
-  stable: "v1.23"
+  alpha: "v1.21"
+  beta: "v1.22"
+  stable: "v1.24"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
This also adds some notes about node local traffic and DNS.

/assign @thockin 