### PR TITLE
Mark anago krel migration KEP as implemented

### DIFF
--- a/keps/sig-release/0000-anago-to-krel-migration/kep.yaml
+++ b/keps/sig-release/0000-anago-to-krel-migration/kep.yaml
@@ -7,4 +7,5 @@ reviewers:
 approvers:
   - "@justaugustus"
 creation-date: 2020-09-22
-status: implementable
+latest-milestone: v1.20
+status: implemented


### PR DESCRIPTION
With the merge of the anago removal PR we can now consider that KEP as
done.

cc @kubernetes/release-engineering @kubernetes/sig-release-leads 

/hold
Requires https://github.com/kubernetes/release/pull/1765
