### PR TITLE
Add README for cluster-api keps

### DIFF
--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -3,6 +3,7 @@ keps/sig-apps/README.md
 keps/sig-autoscaling/README.md
 keps/provider-aws/README.md
 keps/sig-cli/kep-faq.md
+keps/sig-cluster-lifecycle/clusterapi/README.md
 keps/sig-cluster-lifecycle/kubeadm/0023-documentation-for-images.md
 keps/sig-cluster-lifecycle/kubeadm/README.md
 keps/sig-network/README.md

--- a/keps/sig-cluster-lifecycle/clusterapi/README.md
+++ b/keps/sig-cluster-lifecycle/clusterapi/README.md
@@ -1,0 +1,6 @@
+# Cluster API CAEPs
+
+Cluster API follows its [own process](https://cluster-api.sigs.k8s.io/contributing#proposal-process-caep) for enhancement proposals.
+The current list of proposals can be found [here](https://sigs.k8s.io/cluster-api/docs/proposals).
+
+**Note:** CAEP process is fundamentally a derivative of the KEP.


### PR DESCRIPTION
The issue regarding this was originally raised at https://github.com/kubernetes-sigs/cluster-api/issues/3791 

Cluster-API enhancements proposals are updated independently in it's repository. The README gives link to those proposals.