### PR TITLE
chore: set file mode bits of normal files to 0o644

### DIFF
--- a/pkg/kepctl/create.go
+++ b/pkg/kepctl/create.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -152,7 +151,7 @@ func (c *Client) createKEP(kep *keps.Proposal, opts CreateOpts) error {
 	}
 
 	newPath := filepath.Join(path, "keps", opts.SIG, opts.Name, "README.md")
-	ioutil.WriteFile(newPath, b, os.ModePerm)
+	ioutil.WriteFile(newPath, b, 0644)
 
 	return nil
 }

--- a/pkg/kepctl/create_test.go
+++ b/pkg/kepctl/create_test.go
@@ -25,8 +25,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/enhancements/pkg/kepval/keps"
 	"sigs.k8s.io/yaml"
+
+	"k8s.io/enhancements/pkg/kepval/keps"
 )
 
 func TestWriteKep(t *testing.T) {
@@ -105,6 +106,7 @@ func TestWriteKep(t *testing.T) {
 				fileStat, err := os.Stat(p)
 				assert.NoError(t, err)
 				assert.NotNil(t, fileStat)
+				assert.Equal(t, os.FileMode(0644), fileStat.Mode().Perm())
 			}
 		})
 	}

--- a/pkg/kepctl/kepctl.go
+++ b/pkg/kepctl/kepctl.go
@@ -403,7 +403,7 @@ func (c *Client) writeKEP(kep *keps.Proposal, opts CommonArgs) error {
 	)
 	newPath := filepath.Join(path, "keps", opts.SIG, opts.Name, "kep.yaml")
 	fmt.Fprintf(c.Out, "writing KEP to %s\n", newPath)
-	return ioutil.WriteFile(newPath, b, os.ModePerm)
+	return ioutil.WriteFile(newPath, b, 0644)
 }
 
 type PrintConfig interface {


### PR DESCRIPTION
Currently `kepctl` would set the executable bit of plain text files, which is not necessary:
```
$ ls -l keps/sig-api-machinery/000-strip-managed-fields
total 28
-rwxr-xr-x 1 knight staff 24319 Dec  6 15:40 README.md
-rwxr-xr-x 1 knight staff   741 Dec  6 15:40 kep.yaml
```

This PR changes the file mode bits of these plain text files to 0o644(`-rw-r--r--`).

/cc @jeremyrickard