### PR TITLE
Update PRR KEP and KEP template for implementation

### DIFF
--- a/keps/NNNN-kep-template/README.md
+++ b/keps/NNNN-kep-template/README.md
@@ -130,7 +130,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [ ] (R) Graduation criteria is in place
 - [ ] (R) Production readiness review completed
-- [ ] Production readiness review approved
+- [ ] (R) Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
@@ -360,7 +360,7 @@ Production readiness reviews are intended to ensure that features merging into
 Kubernetes are observable, scalable and supportable; can be safely operated in
 production environments, and can be disabled or rolled back in the event they
 cause increased failures in production. See more in the PRR KEP at
-https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness/README.md.
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
 
 The production readiness review questionnaire must be completed and approved
 for the KEP to move to `implementable` status and be included in the release.

--- a/keps/sig-architecture/1194-prod-readiness/README.md
+++ b/keps/sig-architecture/1194-prod-readiness/README.md
@@ -149,14 +149,16 @@ Status update on Phase 1:
 The questionnaire was put into place in Phase 1, so what remains for Phase 2 is
 to document the review process and implement the tooling supporting it.
 
-The process will be enforced in the enhancements repository. When an enhancement
-is targeted at a release, a production readiness review will be necessary.
-Initially, the Enhancements Team will label the enhancement issue with a
-`prr-required` label; eventually tooling may do this automatically. The
-associated KEP must then be sure to add an approver from the
-`prod-readiness-review` team, which will be created in the `OWNERS_ALIASES` file
-of the enhancements repo. The enhancements verification CI must validate that a
-PRR approver is assigned to the KEP, and approves it prior to merging.
+The process will be enforced in the enhancements repository. A separate
+`prod-readiness` directory will be maintained, with an OWNERS file with
+PRR-specific reviewers and approvers. When targeting a release, the KEP author
+must:
+ * Update the `kep.yaml`, setting the `stage`, `latest-milestone`, and the
+   `milestone` struct (which captures per-stage release versions).
+ * Create a `prod-readiness/<sig>/<KEP number>.yaml` file, with the PRR
+   approver's GitHub handle for the specific stage.
+
+The `kepval` utility / enhancements CI will be updated to enforce this.
 
 ## Implementation History
 
@@ -164,3 +166,4 @@ PRR approver is assigned to the KEP, and approves it prior to merging.
 - 2019-10-17: Review feedback, phase 1 implementable
 - 2019-11-12: Add establishment of subproject
 - 2020-04-21: Update for phase 2
+- 2020-12-15: Mark implemented, update phase 2 details

--- a/keps/sig-architecture/1194-prod-readiness/kep.yaml
+++ b/keps/sig-architecture/1194-prod-readiness/kep.yaml
@@ -10,9 +10,11 @@ reviewers:
   - "@vishh"
   - "@justaugustus"
   - "@alejandrox1"
+  - "@wojtek-t"
+  - "@deads2k"
 approvers:
   - "@derekwaynecarr"
   - "@dims"
 creation-date: 2019-07-31
-last-updated: 2020-04-21
-status: implementable
+last-updated: 2020-12-15
+status: implemented


### PR DESCRIPTION
In 1.21, PRR is required. This PR updates the associated KEP and the KEP template to reflect this.

/assign @wojtek-t @deads2k 