### PR TITLE
Migrate some apps KEPs to new template

### DIFF
--- a/keps/sig-apps/592-ttl-after-finish/README.md
+++ b/keps/sig-apps/592-ttl-after-finish/README.md
@@ -1,27 +1,3 @@
----
-title: TTL After Finished
-authors:
-  - "@janetkuo"
-owning-sig: sig-apps
-participating-sigs:
-  - sig-api-machinery
-reviewers:
-  - "@enisoc"
-  - "@tnozicka"
-approvers:
-  - "@kow3ns"
-editor: TBD
-creation-date: 2018-08-16
-last-updated: 2018-08-16
-status: provisional
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
----
-
 # TTL After Finished Controller
 
 ## Table of Contents

--- a/keps/sig-apps/592-ttl-after-finish/kep.yaml
+++ b/keps/sig-apps/592-ttl-after-finish/kep.yaml
@@ -1,0 +1,22 @@
+title: TTL After Finished
+kep-number: 592
+authors:
+  - "@janetkuo"
+owning-sig: sig-apps
+participating-sigs:
+  - sig-api-machinery
+reviewers:
+  - "@enisoc"
+  - "@tnozicka"
+approvers:
+  - "@kow3ns"
+editor: TBD
+creation-date: 2018-08-16
+last-updated: 2018-08-16
+status: provisional
+see-also:
+  - n/a
+replaces:
+  - n/a
+superseded-by:
+  - n/a

--- a/keps/sig-apps/706-portable-service-definitions/README.md
+++ b/keps/sig-apps/706-portable-service-definitions/README.md
@@ -1,32 +1,3 @@
-# KEP: Portable Service Definitions
-
----
-title: Portable Service Definitions
-authors:
-  - "@mattfarina"
-owning-sig: sig-apps
-participating-sigs:
-  - sig-service-catalog
-reviewers:
-  - "@carolynvs"
-  - "@kibbles-n-bytes"
-  - "@duglin"
-  - "@jboyd01"
-  - "@prydonius"
-  - "@kow3ns"
-approvers:
-  - "@mattfarina"
-  - "@prydonius"
-  - "@kow3ns"
-editor: TBD
-creation-date: 2018-11-13
-last-updated: 2018-11-19
-status: provisional
-see-also:
-replaces:
-superseded-by:
----
-
 # Portable Service Definitions
 
 ## Table of Contents

--- a/keps/sig-apps/706-portable-service-definitions/kep.yaml
+++ b/keps/sig-apps/706-portable-service-definitions/kep.yaml
@@ -1,0 +1,25 @@
+title: Portable Service Definitions
+kep-number: 706
+authors:
+  - "@mattfarina"
+owning-sig: sig-apps
+participating-sigs:
+  - sig-service-catalog
+reviewers:
+  - "@carolynvs"
+  - "@kibbles-n-bytes"
+  - "@duglin"
+  - "@jboyd01"
+  - "@prydonius"
+  - "@kow3ns"
+approvers:
+  - "@mattfarina"
+  - "@prydonius"
+  - "@kow3ns"
+editor: TBD
+creation-date: 2018-11-13
+last-updated: 2018-11-19
+status: provisional
+see-also:
+replaces:
+superseded-by:

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -1,28 +1,3 @@
----
-title: Implement maxUnavailable for StatefulSets
-authors:
-  - "@krmayankk"
-owning-sig: sig-apps
-participating-sigs:
-  - sig-apps
-reviewers:
-  - "@janetkuo"
-  - "@kow3ns"
-approvers:
-  - "@janetkuo"
-  - "@kow3ns"
-editor: TBD
-creation-date: 2018-12-29
-last-updated: 2019-08-10
-status: implementable
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
----
-
 # Implement maxUnavailable in StatefulSet
 
 ## Table of Contents

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -1,0 +1,23 @@
+title: Implement maxUnavailable for StatefulSets
+kep-number: 961
+authors:
+  - "@krmayankk"
+owning-sig: sig-apps
+participating-sigs:
+  - sig-apps
+reviewers:
+  - "@janetkuo"
+  - "@kow3ns"
+approvers:
+  - "@janetkuo"
+  - "@kow3ns"
+editor: TBD
+creation-date: 2018-12-29
+last-updated: 2019-08-10
+status: implementable
+see-also:
+  - n/a
+replaces:
+  - n/a
+superseded-by:
+  - n/a

--- a/keps/sig-apps/981-poddisruptionbudget-for-custom-resources/README.md
+++ b/keps/sig-apps/981-poddisruptionbudget-for-custom-resources/README.md
@@ -1,26 +1,3 @@
----
-title: pdb-support-for-custom-resources-with-scale-subresource
-authors:
-  - "@mortent"
-owning-sig: sig-apps
-participating-sigs:
-  - sig-scheduling
-  - sig-autoscaling
-reviewers:
-  - "@kow3ns"
-  - "@janetkuo"
-approvers:
-  - "@kow3ns"
-  - "@janetkuo"
-editor: TBD
-creation-date: 2019-04-12
-last-updated: 2019-04-12
-status: implementable
-see-also:
-replaces:
-superseded-by:
----
-
 # PDB support for custom resources with scale subresource
 
 ## Table of Contents

--- a/keps/sig-apps/981-poddisruptionbudget-for-custom-resources/kep.yaml
+++ b/keps/sig-apps/981-poddisruptionbudget-for-custom-resources/kep.yaml
@@ -1,0 +1,21 @@
+title: pdb-support-for-custom-resources-with-scale-subresource
+kep-number: 981
+authors:
+  - "@mortent"
+owning-sig: sig-apps
+participating-sigs:
+  - sig-scheduling
+  - sig-autoscaling
+reviewers:
+  - "@kow3ns"
+  - "@janetkuo"
+approvers:
+  - "@kow3ns"
+  - "@janetkuo"
+editor: TBD
+creation-date: 2019-04-12
+last-updated: 2019-04-12
+status: implementable
+see-also:
+replaces:
+superseded-by:


### PR DESCRIPTION
Not status changes or other changes - just migrating existing info to new templates.

This will be useful to strengthen validation of kep.yaml eventually.