### PR TITLE
Migrate remaining autoscaling keps to new template

### DIFF
--- a/keps/sig-autoscaling/117-hpa-metrics-specificity/README.md
+++ b/keps/sig-autoscaling/117-hpa-metrics-specificity/README.md
@@ -1,23 +1,3 @@
----
-title: Enhance HPA Metrics Specificity
-authors:
-  - "@directxman12"
-owning-sig: sig-autoscaling
-participating-sigs:
-  - sig-instrumentation
-reviewers:
-  - "@brancz"
-  - "@maciekpytel"
-approvers:
-  - "@brancz"
-  - "@maciekpytel"
-  - "@directxman12"
-editor: "@directxman12"
-creation-date: 2018-04-19
-last-updated: 2018-04-19
-status: implemented
----
-
 # Enhance HPA Metrics Specificity
 
 ## Table of Contents

--- a/keps/sig-autoscaling/117-hpa-metrics-specificity/kep.yaml
+++ b/keps/sig-autoscaling/117-hpa-metrics-specificity/kep.yaml
@@ -1,0 +1,18 @@
+title: Enhance HPA Metrics Specificity
+kep-number: 117
+authors:
+  - "@directxman12"
+owning-sig: sig-autoscaling
+participating-sigs:
+  - sig-instrumentation
+reviewers:
+  - "@brancz"
+  - "@maciekpytel"
+approvers:
+  - "@brancz"
+  - "@maciekpytel"
+  - "@directxman12"
+editor: "@directxman12"
+creation-date: 2018-04-19
+last-updated: 2018-04-19
+status: implemented

--- a/keps/sig-autoscaling/1610-container-resource-autoscaling/README.md
+++ b/keps/sig-autoscaling/1610-container-resource-autoscaling/README.md
@@ -1,20 +1,3 @@
----
-title: Container Resource based Autoscaling
-authors:
-  - "@arjunrn"
-owning-sig: sig-autoscaling
-reviewers:
-  - "@josephburnett"
-  - "@mwielgus"
-  - "@gjtempleton"
-approvers:
-  - "@josephburnett"
-  - "@gjtempleton"
-creation-date: 2020-02-18
-last-updated: 2020-11-03
-status: implementable
----
-
 # Kubernetes Enhancement Proposal Process
 
 ## Table of Contents

--- a/keps/sig-autoscaling/1610-container-resource-autoscaling/kep.yaml
+++ b/keps/sig-autoscaling/1610-container-resource-autoscaling/kep.yaml
@@ -1,0 +1,15 @@
+title: Container Resource based Autoscaling
+kep-number: 1610
+authors:
+  - "@arjunrn"
+owning-sig: sig-autoscaling
+reviewers:
+  - "@josephburnett"
+  - "@mwielgus"
+  - "@gjtempleton"
+approvers:
+  - "@josephburnett"
+  - "@gjtempleton"
+creation-date: 2020-02-18
+last-updated: 2020-11-03
+status: implementable

--- a/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
+++ b/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
@@ -1,23 +1,3 @@
----
-title: Configurable scale up/down velocity for HPA
-authors:
-  - "@gliush"
-  - "@arjunrn"
-owning-sig: sig-autoscaling
-participating-sigs:
-reviewers:
-  - "@mwielgus"
-  - "@josephburnett"
-approvers:
-  - "@mwielgus"
-  - "@josephburnett"
-editor: TBD
-creation-date: 2019-03-07
-last-updated: 2020-01-29
-status: implemented
-superseded-by:
----
-
 # Configurable scale up/down velocity for HPA
 
 ## Table of Contents

--- a/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/kep.yaml
+++ b/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/kep.yaml
@@ -1,0 +1,18 @@
+title: Configurable scale up/down velocity for HPA
+kep-number: 853
+authors:
+  - "@gliush"
+  - "@arjunrn"
+owning-sig: sig-autoscaling
+participating-sigs:
+reviewers:
+  - "@mwielgus"
+  - "@josephburnett"
+approvers:
+  - "@mwielgus"
+  - "@josephburnett"
+editor: TBD
+creation-date: 2019-03-07
+last-updated: 2020-01-29
+status: implemented
+superseded-by:


### PR DESCRIPTION
Not status changes or other changes - just migrating existing info to new templates.

This will be useful to strengthen validation of kep.yaml eventually.