### PR TITLE
Migrate remaining architecture keps to new template

### DIFF
--- a/keps/sig-architecture/1143-node-role-labels/README.md
+++ b/keps/sig-architecture/1143-node-role-labels/README.md
@@ -1,27 +1,3 @@
----
-title: Appropriate use of node-role labels
-authors:
-  - "@smarterclayton"
-owning-sig: sig-architecture
-participating-sigs:
-  - sig-api-machinery
-  - sig-network
-  - sig-node
-  - sig-testing
-reviewers:
-  - "@lavalamp"
-  - "@derekwaynecarr"
-  - "@liggitt"
-approvers:
-  - "@thockin"
-  - "@derekwaynecarr"
-prr-approvers:
-  - "@wojtek-t"
-creation-date: 2019-07-16
-last-updated: 2020-06-01
-status: implementable
----
-
 # Appropriate use of node-role labels
 
 ## Table of Contents

--- a/keps/sig-architecture/1143-node-role-labels/kep.yaml
+++ b/keps/sig-architecture/1143-node-role-labels/kep.yaml
@@ -1,0 +1,22 @@
+title: Appropriate use of node-role labels
+kep-number: 1143
+authors:
+  - "@smarterclayton"
+owning-sig: sig-architecture
+participating-sigs:
+  - sig-api-machinery
+  - sig-network
+  - sig-node
+  - sig-testing
+reviewers:
+  - "@lavalamp"
+  - "@derekwaynecarr"
+  - "@liggitt"
+approvers:
+  - "@thockin"
+  - "@derekwaynecarr"
+prr-approvers:
+  - "@wojtek-t"
+creation-date: 2019-07-16
+last-updated: 2020-06-01
+status: implementable

--- a/keps/sig-architecture/1333-conformance-without-beta/README.md
+++ b/keps/sig-architecture/1333-conformance-without-beta/README.md
@@ -1,28 +1,3 @@
----
-title: Ensure Conformance Tests Do Not Require Beta APIs or Features
-authors:
-  - "@liggitt"
-owning-sig: sig-architecture
-participating-sigs:
-  - sig-testing
-  - sig-api-machinery
-reviewers:
-  - "@deads2k"
-  - "@bentheelder"
-  - "@timothysc"
-  - "@smarterclayton"
-  - "@johnbelamaric"
-approvers:
-  - "@timothysc"
-  - "@smarterclayton"
-  - "@johnbelamaric"
-creation-date: 2019-10-23
-last-updated: 2019-10-23
-status: implementable
-see-also:
-  - "/keps/sig-architecture/20190412-conformance-behaviors.md"
----
-
 # Ensure Conformance Tests Do Not Require Beta REST APIs or Features
 
 ## Table of Contents

--- a/keps/sig-architecture/1333-conformance-without-beta/kep.yaml
+++ b/keps/sig-architecture/1333-conformance-without-beta/kep.yaml
@@ -1,0 +1,23 @@
+title: Ensure Conformance Tests Do Not Require Beta APIs or Features
+kep-number: 1333
+authors:
+  - "@liggitt"
+owning-sig: sig-architecture
+participating-sigs:
+  - sig-testing
+  - sig-api-machinery
+reviewers:
+  - "@deads2k"
+  - "@bentheelder"
+  - "@timothysc"
+  - "@smarterclayton"
+  - "@johnbelamaric"
+approvers:
+  - "@timothysc"
+  - "@smarterclayton"
+  - "@johnbelamaric"
+creation-date: 2019-10-23
+last-updated: 2019-10-23
+status: implementable
+see-also:
+  - "/keps/sig-architecture/20190412-conformance-behaviors.md"

--- a/keps/sig-architecture/917-go-modules/README.md
+++ b/keps/sig-architecture/917-go-modules/README.md
@@ -1,23 +1,3 @@
----
-title: go modules
-authors:
-  - "@liggitt"
-owning-sig: sig-architecture
-participating-sigs:
-  - sig-api-machinery
-  - sig-release
-  - sig-testing
-reviewers:
-  - "@sttts"
-  - "@lavalamp"
-approvers:
-  - "@smarterclayton"
-  - "@thockin"
-creation-date: 2019-03-19
-last-updated: 2019-11-01
-status: implementable
----
-
 # go modules
 
 ## Table of Contents

--- a/keps/sig-architecture/917-go-modules/kep.yaml
+++ b/keps/sig-architecture/917-go-modules/kep.yaml
@@ -1,0 +1,18 @@
+title: go modules
+kep-number: 917
+authors:
+  - "@liggitt"
+owning-sig: sig-architecture
+participating-sigs:
+  - sig-api-machinery
+  - sig-release
+  - sig-testing
+reviewers:
+  - "@sttts"
+  - "@lavalamp"
+approvers:
+  - "@smarterclayton"
+  - "@thockin"
+creation-date: 2019-03-19
+last-updated: 2019-11-01
+status: implementable


### PR DESCRIPTION
Not status changes or other changes - just migrating existing info to new templates.

This will be useful to strengthen validation of kep.yaml eventually.