### PR TITLE
Migrate few missed keps to new template

### DIFF
--- a/keps/sig-docs/1326-third-party-content-in-docs/README.md
+++ b/keps/sig-docs/1326-third-party-content-in-docs/README.md
@@ -1,25 +1,4 @@
----
-title: doc-policies-for-third-party-content
-authors:
-  - "@aimeeu"
-  - "@jimangel"
-  - "@sftim"
-  - "@zacharysarah"
-owning-sig: sig-docs
-reviewers:
-  - "@jaredbhatti"
-  - "@kbarnard10"
-approvers:
-  - "@cblecker"
-  - "@derekwaynecarr"
-  - "@dims"
-editor: "@zacharysarah"
-creation-date: 2019-10-20
-last-updated: 2019-10-20
-status: provisional
----
-
-# doc-policies-for-third-party-content
+# Doc policies for third party content
 
 ## Table of Contents
 

--- a/keps/sig-docs/1326-third-party-content-in-docs/kep.yaml
+++ b/keps/sig-docs/1326-third-party-content-in-docs/kep.yaml
@@ -1,0 +1,19 @@
+title: doc-policies-for-third-party-content
+kep-number: 1326
+authors:
+  - "@aimeeu"
+  - "@jimangel"
+  - "@sftim"
+  - "@zacharysarah"
+owning-sig: sig-docs
+reviewers:
+  - "@jaredbhatti"
+  - "@kbarnard10"
+approvers:
+  - "@cblecker"
+  - "@derekwaynecarr"
+  - "@dims"
+editor: "@zacharysarah"
+creation-date: 2019-10-20
+last-updated: 2019-10-20
+status: provisional

--- a/keps/sig-network/1611-network-policy-validation/README.md
+++ b/keps/sig-network/1611-network-policy-validation/README.md
@@ -1,23 +1,3 @@
----
-title: Rearchitecting NetworkPolicy tests with a DSL for better upstream test coverage
-authors:
-  - "@jayunit100"
-  - "@abhiraut"
-  - "@sedefsavas"
-  - "@McCodeman"
-  - "@mattfenwick"
-owning-sig: sig-network
-reviewers:
-  - "bowei@"
-  - TBD
-approvers:
-  - TBD
-editor: TBD
-creation-date: 2020-02-04
-last-updated: 2020-5-01
-status: implementable
----
-
 Note that this approach of higher level DSLs for testing may be moved into sig-testing for a broader set of tests over time.
 
 # Architecting NetworkPolicy tests with a DSL for better upstream test coverage of all CNIs

--- a/keps/sig-network/1611-network-policy-validation/kep.yaml
+++ b/keps/sig-network/1611-network-policy-validation/kep.yaml
@@ -1,0 +1,18 @@
+title: Rearchitecting NetworkPolicy tests with a DSL for better upstream test coverage
+kep-number: 1611
+authors:
+  - "@jayunit100"
+  - "@abhiraut"
+  - "@sedefsavas"
+  - "@McCodeman"
+  - "@mattfenwick"
+owning-sig: sig-network
+reviewers:
+  - "bowei@"
+  - TBD
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2020-02-04
+last-updated: 2020-5-01
+status: implementable

--- a/keps/sig-node/375-cpu-manager/README.md
+++ b/keps/sig-node/375-cpu-manager/README.md
@@ -1,27 +1,3 @@
----
-title: CPU Manager
-authors:
-  - "@ConnorDoyle"
-  - "@flyingcougar"
-  - "@sjenning"
-owning-sig: sig-node
-participating-sigs:
-  - sig-node
-reviewers:
-  - "@derekwaynecarr"
-approvers:
-  - "@dawnchen"
-  - "@derekwaynecarr"
-editor: Connor Doyle
-creation-date: 2017-05-23
-last-updated: 2017-05-23
-status: implementable
-see-also:
-replaces:
-  - " kubernetes/community/contributors/design-proposals/node/cpu-manager.md"
-superseded-by:
----
-
 # CPU Manager
 
 _Authors:_

--- a/keps/sig-node/375-cpu-manager/kep.yaml
+++ b/keps/sig-node/375-cpu-manager/kep.yaml
@@ -1,0 +1,22 @@
+title: CPU Manager
+kep-number: 375
+authors:
+  - "@ConnorDoyle"
+  - "@flyingcougar"
+  - "@sjenning"
+owning-sig: sig-node
+participating-sigs:
+  - sig-node
+reviewers:
+  - "@derekwaynecarr"
+approvers:
+  - "@dawnchen"
+  - "@derekwaynecarr"
+editor: Connor Doyle
+creation-date: 2017-05-23
+last-updated: 2017-05-23
+status: implementable
+see-also:
+replaces:
+  - " kubernetes/community/contributors/design-proposals/node/cpu-manager.md"
+superseded-by:

--- a/keps/sig-testing/714-break-test-tarball/README.md
+++ b/keps/sig-testing/714-break-test-tarball/README.md
@@ -1,22 +1,3 @@
----
-title: Breaking apart the Kubernetes test tarball
-authors:
-  - "@ixdy"
-owning-sig: sig-testing
-participating-sigs:
-  - sig-release
-reviewers:
-  - "@akutz"
-  - "@amwat"
-approvers:
-  - "@spiffxp"
-  - "@tpepper"
-editor: TBD
-creation-date: 2019-01-18
-last-updated: 2019-03-06
-status: implemented
----
-
 # Breaking apart the kubernetes test tarball
 
 ## Table of Contents

--- a/keps/sig-testing/714-break-test-tarball/kep.yaml
+++ b/keps/sig-testing/714-break-test-tarball/kep.yaml
@@ -1,0 +1,17 @@
+title: Breaking apart the Kubernetes test tarball
+kep-number: 714
+authors:
+  - "@ixdy"
+owning-sig: sig-testing
+participating-sigs:
+  - sig-release
+reviewers:
+  - "@akutz"
+  - "@amwat"
+approvers:
+  - "@spiffxp"
+  - "@tpepper"
+editor: TBD
+creation-date: 2019-01-18
+last-updated: 2019-03-06
+status: implemented


### PR DESCRIPTION
Not status changes or other changes - just migrating existing info to new templates.

This will be useful to strengthen validation of kep.yaml eventually.

ref #2220