### PR TITLE
ContribEx: Migrate old keps to new format

### DIFF
--- a/keps/sig-contributor-experience/0000-community-forum/README.md
+++ b/keps/sig-contributor-experience/0000-community-forum/README.md
@@ -1,22 +1,3 @@
----
-title: A community forum for Kubernetes
-authors:
-  - "@castrojo"
-owning-sig: sig-contributor-experience
-participating-sigs:
-reviewers:
-  - "@jberkus"
-  - "@joebeda"
-  - "@cblecker"
-approvers:
-  - "@parispittman"
-  - "@grodrigues3"
-editor: TBD
-creation-date: 2018-04-03
-last-updated: 2018-04-17
-status: implemented
----
-
 # A community forum for Kubernetes
 
 ## Table of Contents

--- a/keps/sig-contributor-experience/0000-community-forum/kep.yaml
+++ b/keps/sig-contributor-experience/0000-community-forum/kep.yaml
@@ -1,0 +1,17 @@
+title: A community forum for Kubernetes
+kep-number: 0000
+authors:
+  - "@castrojo"
+owning-sig: sig-contributor-experience
+participating-sigs:
+reviewers:
+  - "@jberkus"
+  - "@joebeda"
+  - "@cblecker"
+approvers:
+  - "@parispittman"
+  - "@grodrigues3"
+editor: TBD
+creation-date: 2018-04-03
+last-updated: 2018-04-17
+status: implemented

--- a/keps/sig-contributor-experience/1553-issue-triage/kep.yaml
+++ b/keps/sig-contributor-experience/1553-issue-triage/kep.yaml
@@ -1,4 +1,5 @@
 title: Issue Triage Workflow and Automation
+kep-number: 1553
 status: implemented
 owning-sig: sig-contributor-experience
 participating-sigs:

--- a/keps/sig-contributor-experience/2225-contributor-site/README.md
+++ b/keps/sig-contributor-experience/2225-contributor-site/README.md
@@ -1,21 +1,3 @@
----
-title: Contributor Site
-authors:
-  - "@jbeda"
-owning-sig: sig-contributor-experience
-participating-sigs:
-  - sig-architecture
-  - sig-docs
-reviewers:
-  - "@castrojo"
-approvers:
-  - "@parispittman"
-editor: TBD
-creation-date: "2018-02-19"
-last-updated: "2018-03-07"
-status: implementable
----
-
 # Contributor Site
 
 ## Table of Contents

--- a/keps/sig-contributor-experience/2225-contributor-site/kep.yaml
+++ b/keps/sig-contributor-experience/2225-contributor-site/kep.yaml
@@ -1,0 +1,16 @@
+title: Contributor Site
+kep-number: 2225
+authors:
+  - "@jbeda"
+owning-sig: sig-contributor-experience
+participating-sigs:
+  - sig-architecture
+  - sig-docs
+reviewers:
+  - "@castrojo"
+approvers:
+  - "@parispittman"
+editor: TBD
+creation-date: "2018-02-19"
+last-updated: "2018-03-07"
+status: implementable


### PR DESCRIPTION
This is a no-op. Just migrates the old keps to the new format. 
The contributor site kep will need some follow-up to update the implementation history and details.

/kind cleanup
ref: #2220