### PR TITLE
Move keps/sig-auth/1687 to implementable

### DIFF
--- a/keps/sig-auth/1687-hierarchical-namespaces-subproject/README.md
+++ b/keps/sig-auth/1687-hierarchical-namespaces-subproject/README.md
@@ -201,3 +201,4 @@ contributors, moving to a different foundation is far more preferable.
 - KEP updated to include additional graduation criteria - April 28 2020
 - KEP updated with grammatical mistakes found in PR - May 5 2020
 - KEP updated with graduation criteria requested from reviewers - May 8 2020
+- KEP updated with status of `implementable` - Jan 6 2021

--- a/keps/sig-auth/1687-hierarchical-namespaces-subproject/kep.yaml
+++ b/keps/sig-auth/1687-hierarchical-namespaces-subproject/kep.yaml
@@ -7,11 +7,12 @@ owning-sig: sig-auth
 participating-sigs:
   - sig-auth
 reviewers:
-  - "TBD"
+  - "@mikedanese"
+  - "@liggitt"
 approvers:
   - "@mikedanese"
   - "@deads2k"
   - "@liggitt"
 creation-date: 2020-04-14
-last-updated: 2020-04-15
-status: provisional
+last-updated: 2021-01-06
+status: implementable


### PR DESCRIPTION
In the bi-weekly sig-auth meeting today, the leads have indicated this KEP has met the intake criteria and therefore should become a sub-project with it's own git repo. As such, we are moving the KEP to implementable so we can start work to create the repo.