### PR TITLE
Fixed kepctl compile error

### DIFF
--- a/pkg/kepval/keps/proposals.go
+++ b/pkg/kepval/keps/proposals.go
@@ -75,6 +75,7 @@ type Proposal struct {
 	DisableSupported bool          `json:"disableSupported" yaml:"disable-supported"`
 	Metrics          []string      `json:"metrics" yaml:"metrics"`
 
+	Filename string `json:"-" yaml:"-"`
 	Error    error  `json:"-" yaml:"-"`
 	Contents string `json:"markdown" yaml:"-"`
 }


### PR DESCRIPTION
The `Filename` field was (accidentally?)  getting removed in this PR. https://github.com/kubernetes/enhancements/commit/fd2a0c4480d82dd98c810c2e0a25f13382935429

Without this field, `kepctl` won't compile.
```
$go build -o kepctl ./cmd/kepctl
# k8s.io/enhancements/pkg/kepctl
pkg/kepctl/create.go:118:3: t.Filename undefined (type *keps.Proposal has no field or method Filename)
```

After this PR, `go build -o kepctl ./cmd/kepctl` worked.