### PR TITLE
Migrated KEP to new format | sig-node | kubelet-container-resources-cri-api-changes 

### DIFF
--- a/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
+++ b/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
@@ -26,6 +26,6 @@ creation-date: 2018-11-06
 last-updated: 2020-01-14
 status: implementable
 see-also:
-  - "/keps/sig-node/20191025-kubelet-container-resources-cri-api-changes.md"
+  - "/keps/sig-node/2273-kubelet-container-resources-cri-api-changes"
 replaces:
 superseded-by:

--- a/keps/sig-node/2273-kubelet-container-resources-cri-api-changes/README.md
+++ b/keps/sig-node/2273-kubelet-container-resources-cri-api-changes/README.md
@@ -1,27 +1,3 @@
----
-title: Container Resources CRI API Changes for Pod Vertical Scaling
-authors:
-  - "@vinaykul"
-  - "@quinton-hoole"
-owning-sig: sig-node
-participating-sigs:
-reviewers:
-  - "@Random-Liu"
-  - "@yujuhong"
-  - "@PatrickLang"
-approvers:
-  - "@dchen1107"
-  - "@derekwaynecarr"
-editor: TBD
-creation-date: 2019-10-25
-last-updated: 2020-01-14
-status: implementable
-see-also:
-  - "/keps/sig-node/20181106-in-place-update-of-pod-resources.md"
-replaces:
-superseded-by:
----
-
 # Container Resources CRI API Changes for Pod Vertical Scaling
 
 ## Table of Contents

--- a/keps/sig-node/2273-kubelet-container-resources-cri-api-changes/kep.yaml
+++ b/keps/sig-node/2273-kubelet-container-resources-cri-api-changes/kep.yaml
@@ -1,0 +1,22 @@
+title: Container Resources CRI API Changes for Pod Vertical Scaling
+kep-number: 2273
+authors:
+  - "@vinaykul"
+  - "@quinton-hoole"
+owning-sig: sig-node
+participating-sigs:
+reviewers:
+  - "@Random-Liu"
+  - "@yujuhong"
+  - "@PatrickLang"
+approvers:
+  - "@dchen1107"
+  - "@derekwaynecarr"
+editor: TBD
+creation-date: 2019-10-25
+last-updated: 2020-01-14
+status: implementable
+see-also:
+  - "/keps/sig-node/1287-in-place-update-pod-resources"
+replaces:
+superseded-by:


### PR DESCRIPTION
Migrated the one sig-node kep to the new format.

keps/sig-node/1342-kubelet-container-resources-cri-api-changes Folder added and few links updated.

ref: #2220