### PR TITLE
michmike vacating sig-windows chair position

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -96,10 +96,10 @@ aliases:
     - hpandeycodeit
     - tashimi
   sig-windows-leads:
-    - benmoss
     - ddebroy
+    - jayunit100
+    - jsturtevant
     - marosset
-    - michmike
   wg-api-expression-leads:
     - apelisse
     - kwiesmueller


### PR DESCRIPTION
as per kubernetes/community#5386, i am stepping down from sig-windows chair.
updating with the new chairs and TLs for sig-windows

Signed-off-by: Michael Michael michmike@cs.stanford.edu
