### PR TITLE
Re-enable PRR approval requirement

### DIFF
--- a/cmd/kepval/main_test.go
+++ b/cmd/kepval/main_test.go
@@ -90,10 +90,7 @@ func TestValidation(t *testing.T) {
 				t.Errorf("%v has an error: %v", filename, kep.Error)
 			}
 
-			// temporarily disable PRR enforcement per https://github.com/kubernetes/enhancements/issues/2239
-			// so setting this to something always false
-			requiredPRRApproval := len(kep.Number) < 0
-			//requiredPRRApproval := len(kep.Number) > 0 && kep.LatestMilestone >= "v1.21"
+			requiredPRRApproval := len(kep.Number) > 0 && kep.LatestMilestone >= "v1.21" && kep.Status == "implementable"
 			if !requiredPRRApproval {
 				return
 			}


### PR DESCRIPTION
This re-enables the enforcement of PRR approval, as discussed in the recent leads meeting.

One is in conjunction with https://github.com/kubernetes/community/pull/5413 which addresses:
* additional documentation around how to request approval, including an example PR
* clarification around the date by which approval is required
* details on how to join the PRR approver team
* explain why these reviews require a separate team that is not simply the SIG leads

One other concern raised was that this could be a bottleneck. Our experience based upon our dry runs in 1.19 and 1.20 is that this is not the case. With three team members and ~40 or so KEPs needing review per release cycle, the burden is not unreasonable. Especially since the team does not review code, but rather just the KEPs and answers to the questions. Tooling is in place to help reviewers identify KEPs needing review.

/assign @wojtek-t @deads2k @mrbobbytables
/cc @ehashman @kubernetes/enhancements

/hold for lazy consensus until 4pm Pacific time, January 20th.

