### PR TITLE
Set latest-milestone back to 1.20

### DIFF
--- a/keps/sig-api-machinery/1904-efficient-watch-resumption/kep.yaml
+++ b/keps/sig-api-machinery/1904-efficient-watch-resumption/kep.yaml
@@ -23,7 +23,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This should be set to 1.21 in the PRR approval request PR (#2274), not here. Otherwise this causes us to be unable to re-enable PRR validation in #2280.

/assign @wojtek-t 