### PR TITLE
query_test.go added - TestValidate method defined

### DIFF
--- a/pkg/kepctl/query.go
+++ b/pkg/kepctl/query.go
@@ -53,8 +53,8 @@ type QueryOpts struct {
 	Output      string
 }
 
-// Validate checks the args and cleans them up if needed
-func (c *QueryOpts) Validate(args []string) error {
+
+func (c *QueryOpts) Validate() error {
 	if len(c.SIG) > 0 {
 		sigs, err := selectByRegexp(util.Groups(), c.SIG)
 		if err != nil {

--- a/pkg/kepctl/query_test.go
+++ b/pkg/kepctl/query_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kepctl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+
+func TestValidate(t *testing.T) {
+	testcases := []struct {
+		name      string
+		queryOpts QueryOpts
+		err 			error
+	}{
+		{
+			name: "Valid SIG",
+			queryOpts: QueryOpts{
+				CommonArgs: CommonArgs {
+					Name:     "1011-test",
+				},
+				SIG:         []string{"sig-multicluster"},
+				IncludePRs:  true,
+				Output:      "json",
+			},
+			err:  nil,
+		},
+		{
+			name: "Invalid SIG",
+			queryOpts: QueryOpts{
+				CommonArgs: CommonArgs {
+					Name:     "1011-test-xyz",
+				},
+				SIG:         []string{"sig-xyz"},
+				IncludePRs:  true,
+				Output:      "json",
+			},
+			err:  fmt.Errorf("No SIG matches any of the passed regular expressions"),
+		},
+		{
+			name: "Unsupported Output format",
+			queryOpts: QueryOpts{
+				CommonArgs: CommonArgs {
+					Name:     "1011-test-testing",
+				},
+				SIG:         []string{"sig-testing"},
+				IncludePRs:  true,
+				Output:      "PDF",
+			},
+			err:  fmt.Errorf("unsupported output format: PDF. Valid values: [table json yaml]"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var queryOpts = tc.queryOpts
+			var err = queryOpts.Validate()
+			if tc.err == nil {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err, tc.err.Error())
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Related to https://github.com/kubernetes/enhancements/issues/2297

```


$ go test -v query_test.go create.go  kepctl.go  promote.go query.go  

=== RUN   TestValidate
=== RUN   TestValidate/Valid_SIG
=== RUN   TestValidate/Invalid_SIG
=== RUN   TestValidate/Unsupported_Output_format
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/Valid_SIG (0.00s)
    --- PASS: TestValidate/Invalid_SIG (0.00s)
    --- PASS: TestValidate/Unsupported_Output_format (0.00s)
PASS
ok  	command-line-arguments	2.798s
```