### PR TITLE
Updating Topology Aware Proxying KEP for 1.21 release cycle

### DIFF
--- a/keps/prod-readiness/sig-network/2030.yaml
+++ b/keps/prod-readiness/sig-network/2030.yaml
@@ -1,0 +1,3 @@
+kep-number: 2030
+alpha:
+  approver: "@wojtek-t"

--- a/keps/sig-network/2030-topology-aware-proxying/README.md
+++ b/keps/sig-network/2030-topology-aware-proxying/README.md
@@ -1,4 +1,4 @@
-# KEP-2030: EndpointSlice Subsetting and Selection
+# KEP-2030: Topology Aware Proxying
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
@@ -9,11 +9,6 @@
 - [Proposal](#proposal)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
-  - [API Consumption](#api-consumption)
-    - [Select EndpointSlices Without Labels](#select-endpointslices-without-labels)
-    - [Select EndpointSlices With Matching Zone](#select-endpointslices-with-matching-zone)
-    - [Select EndpointSlices With Matching Region](#select-endpointslices-with-matching-region)
-    - [Kube-Proxy](#kube-proxy)
   - [Controller Implementation](#controller-implementation)
   - [Backwards Compatibility](#backwards-compatibility)
 - [Test Plan](#test-plan)
@@ -23,6 +18,13 @@
   - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
 - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
 - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
@@ -32,12 +34,12 @@
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
-- [ ] (R) Graduation criteria is in place
-- [ ] (R) Production readiness review completed
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [x] (R) Graduation criteria is in place
+- [x] (R) Production readiness review completed
 - [ ] Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
@@ -53,7 +55,8 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 Segment EndpointSlices into logical chunks enabling API consumers like
 kube-proxy to watch only a subset of all EndpointSlices. This provides a natural
 starting point for topology aware routing and dramatically increases
-scalability.
+scalability. This is closely tied to [KEP 2004: Topology Aware
+Subsetting](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2004-topology-aware-subsetting).
 
 ## Motivation
 
@@ -116,40 +119,18 @@ This approach does not allow a single EndpointSlice to target multiple zones or
 regions. Any approach that enabled that would be significantly more complicated.
 The initial proposal in [KEP
 #2004](https://github.com/kubernetes/enhancements/issues/2004) suggests that
-this won't be an issue. 
+this won't be an issue.
 
 ## Design Details
 
-### API Consumption
-
-EndpointSlice API consumers can use the following selectors to consume
-EndpointSlices:
-
-#### Select EndpointSlices Without Labels
-This is required to support producers of EndpointSlices that don't set these
-labels, including older versions of the EndpointSlice controller.
-
-```
-matchExpressions:
-  - {key: endpointslice.kubernetes.io/for-zone, operator: DoesNotExist}
-  - {key: endpointslice.kubernetes.io/for-region, operator: DoesNotExist}
-```
-
-#### Select EndpointSlices With Matching Zone
-```
-matchLabels:
-  endpointslice.kubernetes.io/for-zone: example-zone
-```
-
-#### Select EndpointSlices With Matching Region
-```
-matchLabels:
-  endpointslice.kubernetes.io/for-region: example-region
-```
-
-#### Kube-Proxy
-When the `EndpointSliceSubsetting` feature gate is set to true on `Kube-Proxy`,
-it will use these selectors to filter EndpointSlices.
+When the `EndpointSliceSubsetting` feature gate is set to true on Kube-Proxy,
+Kube-Proxy will be updated to use the `endpointslice.kubernetes.io/for-zone` and
+`endpointslice.kubernetes.io/for-region` labels. When kube-proxy is able to
+detect the zone or region it is running in and there are EndpointSlices matching
+the zone or region for a Service, only those endpoints will be used. If not,
+existing behavior will be used to route traffic randomly to all endpoints for a
+Service. In all cases, all EndpointSlice objects will be watched and filtering
+will be done purely on the Kube-Proxy side.
 
 ### Controller Implementation
 Although a controller implementation is out of scope for this KEP, it is worth
@@ -196,8 +177,8 @@ There's nothing in any current consumer implementation that would break if
 additional labels like `for-zone` or `for-region` were added to EndpointSlices.
 All consumers will need to care about for this or the original approach is the
 `kubernetes.io/service-name` label. If they want to support subsetting, they can
-update their selectors as described in this KEP, but subsetting won't actually
-break any existing functionality.
+update their filtering behavior as described in this KEP, but subsetting won't
+actually break any existing functionality.
 
 ## Test Plan
 This KEP is quite small in scope. The only new functionality being added will be
@@ -216,24 +197,30 @@ or disabled.
   kube-proxy running in the same region when this feature is enabled.
 * Ensure EndpointSlices delivered to a specific region will not be consumed by
   kube-proxy running in a different region when this feature is enabled.
+* Ensure transition between EndpointSlices without zone specified to
+  EndpointSlices with zone specified results in appropriate iptables rules
+  without leftover endpoints.
+* Ensure endpoints from other zones will be used as a fallback if no endpoints
+  have been delivered to the zone.
 
 ## Graduation Criteria
 
 ### Alpha Release
 
 - Proposed labels are added as well known labels in Discovery API types.
-- Implement new selectors in kube-proxy.
 - Implement test plan.
+- Implement support for zone filtering
 
 ### Alpha -> Beta Graduation
 
 - EndpointSlice controller supports publishing EndpointSlices in subsets. (See
   [KEP 2004](https://github.com/kubernetes/enhancements/issues/2004) for more
   info).
+- Implement support for region filtering
 
 ## Upgrade / Downgrade Strategy
 
-This functionality will be guarded by the `EndpointSliceSubsetting` feature gate
+This functionality will be guarded by the `TopologyAwareProxying` feature gate
 on kube-proxy. This will be fully backwards compatible and will only make a
 difference in a cluster if EndpointSlices are being published with the labels
 described in this KEP.
@@ -244,6 +231,130 @@ This is designed with backwards compatibility in mind. Enabling this feature is
 not reliant on any other feature being enabled in any other release. [KEP
 #2004](https://github.com/kubernetes/enhancements/issues/2004) will be dependent
 on this KEP though.
+
+## Production Readiness Review Questionnaire
+
+### Feature Enablement and Rollback
+
+* **How can this feature be enabled / disabled in a live cluster?**
+  - [x] Feature gate (also fill in values in `kep.yaml`)
+    - Feature gate name: TopologyAwareProxying
+    - Components depending on the feature gate: kube-proxy
+
+* **Does enabling the feature change any default behavior?**
+  Not really. Kube-Proxy will still consume endpoints without these topology
+  labels (the default). When these labels are set, kube-proxy will only consume
+  a subset of endpoints closest to it. This will not be noticeable in most
+  cases.
+
+* **Can the feature be disabled once it has been enabled (i.e. can we roll back
+  the enablement)?**
+  Yes - kube-proxy will simply revert to using all endpoints without any
+  filtering.
+
+* **What happens if we reenable the feature if it was previously rolled back?**
+  A potentially smaller set of endpoints may be routed to if this feature was
+  also enabled as described in KEP 2004.
+
+* **Are there any tests for feature enablement/disablement?**
+  There are not, but there will be tests covering the state of this feature when
+  it is and is not enabled. There is nothing significant involved in the
+  transition process, just turning the feature gate on or off. Given disabling
+  the feature gate requires restart and kube-proxy (where this feature is
+  effectively implemented) doesn't persistent its state, testing transitions
+  won't provide additional value.
+
+### Rollout, Upgrade and Rollback Planning
+
+* **How can a rollout fail? Can it impact already running workloads?**
+  This feature increases the likelihood that individual endpoints could get
+  overloaded. This is most likely if a large amount of traffic originates in a
+  zone with a small number of endpoints allocated.
+
+* **What specific metrics should inform a rollback?**
+  Existing kube-proxy metrics can be used to determine the health of kube-proxy
+  and therefore this feature. Indicators include
+  `sync_proxy_rules_endpoint_changes_pending` consistently being too high or
+  `sync_proxy_rules_last_timestamp_seconds` being significantly older than the
+  latest changes to relevant EndpointSlices.
+
+* **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
+  The feature has not been implemented yet but this will be tested manually.
+
+* **Is the rollout accompanied by any deprecations and/or removals of features,
+  APIs, fields of API types, flags, etc.?**
+  No.
+
+### Monitoring Requirements
+
+* **How can an operator determine if the feature is in use by workloads?**
+  This feature requires EndpointSlices with the `for-zone` or `for-region`
+  labels set. Enabling this feature requires that the `TopologyAwareProxying`
+  feature gate to be enabled on kube-proxy.
+
+* **What are the SLIs (Service Level Indicators) an operator can use to
+  determine the health of the service?**
+  Any SLIs that already apply to kube-proxy should continue to apply here.
+
+* **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
+  There's nothing particularly unique about this feature as far
+
+* **Are there any missing metrics that would be useful to have to improve
+  observability of this feature?**
+  No.
+
+### Dependencies
+
+* **Does this feature depend on any specific services running in the cluster?**
+  No new dependencies.
+
+
+### Scalability
+
+* **Will enabling / using this feature result in any new API calls?**
+  No. All filtering will be done within kube-proxy.
+
+* **Will enabling / using this feature result in introducing new API types?**
+  No
+
+* **Will enabling / using this feature result in any new calls to the cloud
+  provider?**
+  No
+
+* **Will enabling / using this feature result in increasing size or count of the
+  existing API objects?**
+  No, but the related KEP 2004 may.
+
+* **Will enabling / using this feature result in increasing time taken by any
+  operations covered by [existing SLIs/SLOs]?**
+  The expectation is that this will have minimal effects but could slightly
+  speed up some kube-proxy metrics since it would be dealing with less
+  endpoints.
+
+* **Will enabling / using this feature result in non-negligible increase of
+  resource usage (CPU, RAM, disk, IO, ...) in any components?**
+  Depending on how widely KEP 2004 is used, this could result in significant
+  decreases in CPU and memory util for kube-proxy. No increases in utilization
+  are expected.
+
+### Troubleshooting
+
+* **How does this feature react if the API server and/or etcd is unavailable?**
+  No changes for kube-proxy, existing behavior would continue to exist.
+
+* **What are other known failure modes?**
+  - Detection: EndpointSlices are delivered to some but not all zones leaving a
+    zone without any endpoints to route to.
+  - Mitigations: Disable this feature gate on Kube-Proxy or
+    Kube-Controller-Manager.
+  - Diagnostics: This would likely surface as error logs from the EndpointSlice
+    controller (runs as part of kube-controller-manager).
+  - Testing: This will essentially be equivalent to no endpoints existing for a
+    Service which we do have test coverage for.
+
+* **What steps should be taken if SLOs are not being met to determine the problem?**
+  Problems here would likely be most noticeable if they were caused by something
+  in KEP 2004, refer to that for further troubleshooting.
 
 ## Implementation History
 

--- a/keps/sig-network/2030-topology-aware-proxying/kep.yaml
+++ b/keps/sig-network/2030-topology-aware-proxying/kep.yaml
@@ -17,6 +17,8 @@ reviewers:
   - "@wojtek-t"
 approvers:
   - "@thockin"
+prr-approvers:
+  - "@wojtek-t"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
@@ -24,7 +26,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-# latest-milestone: "v1.21"
+latest-milestone: "v1.21"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -35,7 +37,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: EndpointSliceSubsetting
+  - name: TopologyAwareProxying
     components:
       - kube-proxy
 disable-supported: true


### PR DESCRIPTION
These changes include a new name (previously EndpointSlice Subsetting) and a completed PRR.

See Also: #2355
Enhancement Issue: #2030

/sig network
/cc @danwinship @andrewsykim @bowei @wojtek-t 
/assign @thockin