### PR TITLE
Updating Topology Aware Subsetting KEP for 1.21

### DIFF
--- a/keps/prod-readiness/sig-network/2004.yaml
+++ b/keps/prod-readiness/sig-network/2004.yaml
@@ -1,0 +1,3 @@
+kep-number: 2004
+alpha:
+  approver: "@wojtek-t"

--- a/keps/sig-network/2004-topology-aware-subsetting/README.md
+++ b/keps/sig-network/2004-topology-aware-subsetting/README.md
@@ -10,7 +10,6 @@
   - [Configuration](#configuration)
     - [Interoperability](#interoperability)
     - [Feature Gate](#feature-gate)
-    - [Controller Configuration](#controller-configuration)
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -41,21 +40,28 @@
   - [Observability](#observability)
   - [Graduation Criteria](#graduation-criteria)
   - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
 <!-- /toc -->
 
 ## Release Signoff Checklist
 
-
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
-- [ ] (R) Graduation criteria is in place
-- [ ] (R) Production readiness review completed
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [x] (R) Graduation criteria is in place
+- [x] (R) Production readiness review completed
 - [ ] Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
@@ -73,7 +79,8 @@ unfortunately network routing has not caught up with that. This KEP proposes an
 automatic topology aware subsetting mechanism with a new Service annotation.
 This new annotation will enable users to opt-in to EndpointSlice subsetting
 functionality that will enable topology aware routing. Currently our proposal
-will only focus on topology aware routing at zone level.
+will only focus on topology aware routing at zone level. This is closely tied
+to [KEP 2030: Topology Aware Proxying](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/2030-topology-aware-proxying).
 
 ## Motivation
 
@@ -81,10 +88,10 @@ Kubernetes clusters are increasingly deployed in multi-zone environments.
 Network traffic is routed randomly to any endpoint matching a Service. Some
 users might want the traffic to stay in the same zone for the following
 reasons:
-  - Cost savings: Keeping traffic within a zone can limit cross-zone networking
-costs.
-  - Performance: Traffic within a zone usually has less latency and bandwidth
-constraints, having a better performance than traffic leaving the zone.
+- Cost savings: Keeping traffic within a zone can limit cross-zone networking
+  costs.
+- Performance: Traffic within a zone usually has less latency and bandwidth
+  constraints, having a better performance than traffic leaving the zone.
 
 In this KEP we are going to focus on avoiding cross-zone traffic when in-zone
 endpoints would suffice. We're attempting to provide a simple and more automatic
@@ -130,18 +137,19 @@ for most use cases.
 
 ### Configuration
 
-This proposal builds off of the [EndpointSlice API](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/).
+A new `endpointslice.kubernetes.io/subsetting` annotation will be supported on
+Services. This will have 2 potential values:
 
-We propose a new Service annotation that would act as a hint for the
-EndpointSlice controller: `endpointslice.kubernetes.io/subsetting`. If set to
-`Auto` the EndpointSlice controller will conduct a more conservative routing
-mechanism. It will keep traffic in zone as long as each zone has a sufficient
-number of endpoints. If a zone does not have a sufficient number of endpoints,
-traffic will be routed to other zones. This will be explained in more detail
-below.
+- `Auto`: When there are a sufficient number of endpoints for the Service, the
+  EndpointSlice controller will subset them into proportional amounts for each
+  zone in a cluster. When Topology Aware Proxying (KEP 2004) is enabled,
+  each instance of kube-proxy will only consume the subset of endpoints labeled
+  for the zone it is in.
+- `Disabled`: EndpointSlices will not be subset for this feature.
 
-If this annotation is unspecified or empty, the EndpointSlice controller will
-continue to behave as it already does with no form of subsetting.
+When this annotation is either unspecified or not set to `Auto`, the `Disabled`
+behavior will be default. A future KEP will explore changing the default
+behavior from `Disabled` to `Auto` with a new feature gate.
 
 #### Interoperability
 
@@ -152,12 +160,6 @@ will be given precedence and this annotation will be ignored.
 
 This functionality will be guarded by the `TopologyAwareSubsetting` feature
 gate. This gate should not be enabled if the `ServiceTopology` gate is enabled.
-
-#### Controller Configuration
-
-In addition to the Service-level annotation, a global default can be configured
-on the EndpointSlice controller. This will define the behavior of the controller
-for Services without an annotation specified.
 
 ### Notes/Constraints/Caveats
 
@@ -258,7 +260,7 @@ of EndpointSlices 15%) .
 | in-zone traffic | 90% in-zone traffic = 90 credits | 45% |
 | max overload | 30% max overload = 100 - 30 = 70 credits | 20% |
 | mean overload | 10% mean overload = 100 - 10 = 90 credits | 20% |
-| # of EndpointSlices | 6 EndpointSlices with Prefer, 3 EndpointSlices with Random = (3/6 * 100) = 50 credits | 15% |
+| # of EndpointSlices | 6 EndpointSlices with Auto, 3 EndpointSlices when disabled = (3/6 * 100) = 50 credits | 15% |
 
 #### Test Results
 We have tested various algorithms with all the dataset and calculated their
@@ -290,7 +292,7 @@ ZoneA gives one extra endpoint to ZoneC.
 #### Optimizations
 _Downgrading:_
 1. If failed to maintain an overload less than overload threshold, we downgrade
-   the whole mechanism to the `Random` approach.
+   the whole mechanism to the `Disabled` approach.
 
 Each zone expects 1.67 endpoints.
 
@@ -302,7 +304,7 @@ Any zone ending up with 1 endpoint will have an overload = 67% (above threshold 
 
 _Starting Threshold -- default 3x of zone number:_
 1. As we evaluated algorithms on different datasets, we found that at small
-   scales of endpoints number, it is too risky to conduct a `Prefer` approach.
+   scales of endpoints number, it is too risky to conduct a `Auto` approach.
    It results in a high probability of EndpointSlice churn (higher ratio change
    when updating endpoints) and imbalanced traffic load for endpoints. With
    all that said, we determined a starting threshold based on the test results
@@ -364,7 +366,7 @@ endpoints as full as possible.
    - `endpoints_available` pool is empty.
    - `endpoints_require` pool is empty.
 4. If `endpoints_available` pool is empty and `endpoints_require` pool is not
-   empty, downgrade to `Random` approach.
+   empty, downgrade to `Disabled` approach.
 5. Otherwise, iterate all zones again, assign endpoints from zones in
    `endpoints_available` pool to zones with endpoints fewer than expected
    endpoints. In this step, zones in `endpoints_available` pool only provide
@@ -407,7 +409,7 @@ feedback from users.
 #### Potential Issues
 1. Possibility of overloaded endpoints if a large portion of traffic originates
    from a single zone.
-2. Higher number of EndpointSlices compared to `Random` approach.
+2. Higher number of EndpointSlices compared to when subsetting is disabled.
 
 ### Other Algorithms Evaluated
 #### Local-Shared
@@ -489,20 +491,18 @@ In the future we may expand this functionality if needed. This could include:
 | Test Name | Test Type | Test Details | Expected Output | Comments |
 | :--- | :--- | :--- | :--- | :--- |
 | Single Approach Test | Unit Test | Small/Large number of nodes | Distribute EndpointSlices as expected | |
-| |  | Random/Imrandom endpoints | Distribute EndpointSlices as expected | |
 | |  | Zero endpoints in some zones | Distribute EndpointSlices as expected | |
 | |  | Invalid annotation | Approach sets to default, distribute EndpointSlices as expected | |
-| `Prefer` Test | Unit Test | Invalid starting threshold | Set starting threshold to default and start `Prefer` approach with condition meets| This is applicable for customized starting threshold only|
-| |  | Endpoints below `starting threshold + padding` | `Prefer` approach will not be conducted | |
-| |  | Endpoints above `starting threshold + padding` | `Prefer` works as expected | |
-| Approach Transition Test | Unit Test | 1. Set annotation to `Prefer` <br> 2. Increase endpoints number to above `starting threshold` but below `starting threshold + padding` | `Prefer` will not be conducted | If capable, monitor the churn of EndpointSlices during the rolling update |
-|  |  | 1. Set annotation to `Prefer` <br> 2. Increase endpoints number to above `starting threshold + padding` | Distribution will be changed from `Random` to `Prefer` | Same as above |
-|  |  | 1. Set annotation to `Prefer` <br> 2. Decrease endpoints number to below `starting threshold` but above `starting threshold - padding` | Distribution will remain `Prefer` | Same as above |
-|  |  | 1. Set annotation to `Prefer` <br> 2. Decrease endpoints number to below `starting threshold - padding` | Distribution will be changed from `Prefer` to `Random` | Same as above |
-|  |  | 1. Set annotation to one of the three <br> 2. Set endpoints to above `starting threshold + padding` <br> 3. Manually change the annotation to another approach | Distribution will be changed based on the new value | Step 2 is only needed for `Prefer` |
-|  |  | 1. Set approach to `Random` <br> 2. Set endpoints to above `starting threshold + padding` <br> 3. Manually change the annotation to `Require` or `Prefer` <br> 4. Change the approach back to `Random` | Distribution will be changed from `Random` to `Require` or `Prefer` and changed back to `Random` | Step 2 is only needed for `Prefer` |
-| Rolling Update Test | Integration Test |1. Use integration framework to mock pods <br> 2. Set annotation to `Prefer` <br> 3. Conduct an aggressive rolling update policy for endpoints update <br> 4. Set endpoints to test corner cases | In the desired state, EndpointSlices are distributed as expected | If capable, monitor the churn of EndpointSlices during the rolling update |
-| Traffic Reliability Test | E2E Test |1. Set annotation to `Require` and `Prefer` <br> 2. Set endpoints above `starting threshold + padding` <br> 3. Reuse the current traffic reachability test | Endpoints are reachable from different zones as expected | Step 2 is only needed for `Prefer` |
+| `Auto` Test | Unit Test | Invalid starting threshold | Set starting threshold to default and start `Auto` approach with condition meets| This is applicable for customized starting threshold only|
+| |  | Endpoints below `starting threshold + padding` | `Auto` approach will not be conducted | |
+| |  | Endpoints above `starting threshold + padding` | `Auto` works as expected | |
+| Approach Transition Test | Unit Test | 1. Set annotation to `Auto` <br> 2. Increase endpoints number to above `starting threshold` but below `starting threshold + padding` | `Auto` will not be conducted | If capable, monitor the churn of EndpointSlices during the rolling update |
+|  |  | 1. Set annotation to `Auto` <br> 2. Increase endpoints number to above `starting threshold + padding` | Distribution will be changed from `Disabled` to `Auto` | Same as above |
+|  |  | 1. Set annotation to `Auto` <br> 2. Decrease endpoints number to below `starting threshold` but above `starting threshold - padding` | Distribution will remain `Auto` | Same as above |
+|  |  | 1. Set annotation to `Auto` <br> 2. Decrease endpoints number to below `starting threshold - padding` | Distribution will be changed from `Auto` to `Disabled` | Same as above |
+|  |  | 1. Set annotation to one of the three <br> 2. Set endpoints to above `starting threshold + padding` <br> 3. Manually change the annotation to another approach | Distribution will be changed based on the new value | Step 2 is only needed for `Auto` |
+| Rolling Update Test | Integration Test |1. Use integration framework to mock pods <br> 2. Set annotation to `Auto` <br> 3. Conduct an aggressive rolling update policy for endpoints update <br> 4. Set endpoints to test corner cases | In the desired state, EndpointSlices are distributed as expected | If capable, monitor the churn of EndpointSlices during the rolling update |
+| Traffic Reliability Test | E2E Test |1. Set annotation to `Auto` <br> 2. Set endpoints above `starting threshold + padding` <br> 3. Reuse the current traffic reachability test | Endpoints are reachable from different zones as expected | Step 2 is only needed for `Auto` |
 
 ### Observability
 We can reuse some of the metrics of EndpointSlice Controller that we already
@@ -510,20 +510,21 @@ have in the current version to observe the changes of endpoints (addition,
 deletion and update).
 Meanwhile we can add more metrics to have a glimpse of different approaches.
 
-- `endpoint_slice_controller/changes_endpointslices_per_sync`
+- `endpoint_slice_controller/endpointslices_changed_per_sync`
 - `endpoint_slice_controller/reallocated_endpoints_per_sync`
-- `endpoint_slice_controller/total_endpoints (this has already been defined by endpoint_slice_controller)`
+- `endpoint_slice_controller/syncs`
+- `endpoint_slice_controller/total_endpoints` (this has already been defined)
 ```
 const SubSystem = "endpoint_slice_controller"
 
 // This metric observes churn of EndpointSlices per sync
-EPSChangesPerSync = metrics.NewHistogramVec(
+EPSChangedPerSync = metrics.NewHistogramVec(
 	&metrics.HistogramOpts{
 		Subsystem: Subsystem,
-		Name: "changes_endpointslices_per_sync",
+		Name: "endpointslices_changed_per_sync",
 		Help: "Number of EndpointSlices be changed on each Service sync",
 	},
-	[]string{"approach"},
+	[]string{"approach"}, // either "random" or "auto"
 )
 
 // This metric observes reallocated endpoints per sync
@@ -535,6 +536,18 @@ EPEachZonePerSync = metrics.NewHistogramVec(
 	},
 	[]string{},
 )
+
+// EndpointSliceSyncs tracks the number of sync operations the controller runs along with their result.
+EndpointSliceSyncs = metrics.NewCounterVec(
+  &metrics.CounterOpts{
+    Subsystem:      EndpointSliceSubsystem,
+    Name:           "syncs",
+    Help:           "Number of EndpointSlice syncs",
+    StabilityLevel: metrics.ALPHA,
+  },
+  []string{"result"}, // either "success" or "failure"
+)
+
 ```
 
 ### Graduation Criteria
@@ -564,6 +577,162 @@ for a Service by querying EndpointSlices with the `kubernetes.io/service-name`
 label. Each approach may group the endpoints in slightly different
 combinations of EndpointSlices, but it will still be just as easy to list all
 endpoints for a Service.
+
+## Production Readiness Review Questionnaire
+
+### Feature Enablement and Rollback
+
+* **How can this feature be enabled / disabled in a live cluster?**
+  - [x] Feature gate (also fill in values in `kep.yaml`)
+    - Feature gate name: TopologyAwareSubsetting
+    - Components depending on the feature gate: kube-controller-manager
+  - [x] Other
+    - Describe the mechanism:
+      `endpointslice.kubernetes.io/subsetting` annotation on Service.
+    - Will enabling / disabling the feature require downtime of the control
+      plane?
+      No
+    - Will enabling / disabling the feature require downtime or reprovisioning
+      of a node?
+      No
+
+* **Does enabling the feature change any default behavior?**
+  In most cases, this feature will be intentionally enabled on specific Services
+  with the annotation described above. This will only have an effect if the
+  feature gate is enabled on kube-controller-manager. Even then, this will just
+  represent a different way to group EndpointSlices and will not have any
+  significant effect unless the consumer of EndpointSlices is also configured to
+  support this feature (see KEP 2030). If all of those bits are enabled, traffic
+  will be more likely to be routed to endpoints within the same zone. A future
+  KEP will explore enabling this feature by default on Services with a separate
+  feature gate.
+
+* **Can the feature be disabled once it has been enabled (i.e. can we roll back
+  the enablement)?**
+  Yes. It can easily be disabled universally by turning off the feature gate or
+  on a specific Service by setting the annotation to `Disable`.
+
+* **What happens if we reenable the feature if it was previously rolled back?**
+  EndpointSlices will be subset again resulting in changes to existing
+  EndpointSlices for Services that have this feature enabled.
+
+* **Are there any tests for feature enablement/disablement?**
+  This feature is not yet implemented but per-Service enablement/disablement is
+  covered in depth as part of the test plan.
+
+### Rollout, Upgrade and Rollback Planning
+
+* **How can a rollout fail? Can it impact already running workloads?**
+  The biggest risk here is that EndpointSlices may be created for some but not
+  all zones. This could result in a service being unreachable from zones that do
+  not have corresponding EndpointSlices if a client did not properly account for
+  that possibility. Although this is an unlikely scenario, kube-proxy will
+  include a fallback to all endpoints if no endpoints are available for the
+  current zone. It is recommended that other clients do the same.
+
+* **What specific metrics should inform a rollback?**
+  If the proportion of `endpoint_slice_controller/syncs` with a "failure" result
+  is greater than 10%, a rollback may be considered. It is worth noting that
+  other issues can cause sync failures such as an out of date informer cache.
+  The key indicator should be a significantly elevated error rate when compared
+  with before the feature was enabled.
+
+* **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
+  This feature is not yet implemented but per-Service enablement/disablement is
+  covered in depth as part of the test plan.
+
+* **Is the rollout accompanied by any deprecations and/or removals of features,
+  APIs, fields of API types, flags, etc.?**
+  Yes, this represents a replacement to the approach tracked with KEP 536. This
+  KEP included an alpha implementation but did not graduate beyond that.
+
+### Monitoring Requirements
+
+* **How can an operator determine if the feature is in use by workloads?**
+  If the `endpointslices_changed_per_sync` metric has a non-zero value for the
+  `auto` approach, this feature is in use.
+
+* **What are the SLIs (Service Level Indicators) an operator can use to
+  determine the health of the service?**
+  - [x] Metrics
+    - Metric name: `endpoint_slice_controller/syncs`
+    - [Optional] Aggregation method: Counter
+    - Components exposing the metric: EndpointSlice Controller
+    - The relative failure rate over time can be used to track the health of
+      this controller.
+
+* **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
+  As a starting point, it is likely reasonable for the EndpointSlice controller
+  to experience up to a 10% sync failure rate. This is largely related to it
+  trying to update stale EndpointSlices. When we are able to find a solution for
+  that issue the expected sync failure rate should be significantly lower. This
+  specific problem is most notable for large Services that have rapidly updating
+  endpoints.
+
+* **Are there any missing metrics that would be useful to have to improve
+  observability of this feature?**
+  None that I can think of.
+
+### Dependencies
+
+* **Does this feature depend on any specific services running in the cluster?**
+  This primarily depends on API Server. Kube-Proxy depends on this controller.
+
+### Scalability
+
+* **Will enabling / using this feature result in any new API calls?**
+  This will result in more EndpointSlices which would result in more create and
+  update calls.
+
+* **Will enabling / using this feature result in introducing new API types?**
+  No.
+
+* **Will enabling / using this feature result in any new calls to the cloud
+  provider?**
+  No.
+
+* **Will enabling / using this feature result in increasing size or count of the
+  existing API objects?**
+  In most cases this will result in some additional EndpointSlices. This will be
+  dependent on the number of endpoints for each Service. In a 3 zone cluster:
+  * <12 endpoints: no additional EndpointSlices, feature will not kick in until
+    threshold.
+  * 12-100 endpoints: 3 EndpointSlices instead of 1.
+  * 100-300 endpoints: 3-5 EndpointSlices instead of 1-3.
+  * \>300 endpoints: Generally equivalent amount of EndpointSlices.
+
+* **Will enabling / using this feature result in increasing time taken by any
+  operations covered by [existing SLIs/SLOs]?**
+  Although the EndpointSlice controller may take slightly longer to create
+  EndpointSlices, kube-proxy performance should also be slightly improved. I do
+  not anticipate any impact on existing SLIs or SLOs.
+
+* **Will enabling / using this feature result in non-negligible increase of
+  resource usage (CPU, RAM, disk, IO, ...) in any components?**
+  This could result in increased CPU utilization for kube-controller-manager
+  (specifically  the EndpointSlice controller). Profiling will be performed to
+  ensure that this increase is minimal.
+
+### Troubleshooting
+
+* **How does this feature react if the API server and/or etcd is unavailable?**
+  The EndpointSlice controller will stop functioning.
+
+* **What are other known failure modes?**
+  - The API server is unavailable. This is not specific to this controller and
+    detections and mitigations are likely already widely covered.
+
+* **What steps should be taken if SLOs are not being met to determine the problem?**
+  This feature should be disabled. It is easy to leave this enabled for a single
+  Service for debugging, but if SLOs are not being met the fastest solution is
+  likely to disable this feature for any critical Services.
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+
+## Implementation History
+
+- KEP Merged: October 2020
 
 ## Drawbacks
 1. Increased complexity in EndpointSlice controller

--- a/keps/sig-network/2004-topology-aware-subsetting/kep.yaml
+++ b/keps/sig-network/2004-topology-aware-subsetting/kep.yaml
@@ -18,7 +18,9 @@ prr-approvers:
   - "@wojtek-t"
 
 see-also:
+  - "github.com/kubernetes/enhancements/blob/master/keps/sig-network/2030-topology-aware-proxying"
 replaces:
+  - "github.com/kubernetes/enhancements/tree/master/keps/sig-network/536-topology-aware-routing"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
@@ -44,7 +46,8 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - endpoint_slice_controller/endpointslices_changes_per_sync
+  - endpoint_slice_controller/endpointslices_changed_per_sync
   - endpoint_slice_controller/reallocated_endpoints_per_sync
+  - endpoint_slice_controller/syncs
   - endpoint_slice_controller/total_endpoints
 


### PR DESCRIPTION
This includes adding a PRR, adding a new syncs metric, and a variety of additional cleanup.

See also: https://github.com/kubernetes/enhancements/pull/2354
Enhancement Issue: #2004 

/sig network
/cc @andrewsykim @bowei @freehan 
/assign @thockin @wojtek-t 