### PR TITLE
Fix query cmd `opts.Validate` and test func name

### DIFF
--- a/cmd/kepctl/query.go
+++ b/cmd/kepctl/query.go
@@ -32,7 +32,7 @@ func buildQueryCommand(k *kepctl.Client) *cobra.Command {
 		Long:    "Query the local filesystem, and optionally GitHub PRs for KEPs",
 		Example: `  kepctl query --sig architecture --status provisional --include-prs`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Validate(args)
+			return opts.Validate()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return k.Query(opts)

--- a/pkg/kepctl/query_test.go
+++ b/pkg/kepctl/query_test.go
@@ -23,48 +23,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
-func TestValidate(t *testing.T) {
+func TestValidateQueryOpt(t *testing.T) {
 	testcases := []struct {
 		name      string
 		queryOpts QueryOpts
-		err 			error
+		err       error
 	}{
 		{
 			name: "Valid SIG",
 			queryOpts: QueryOpts{
-				CommonArgs: CommonArgs {
-					Name:     "1011-test",
+				CommonArgs: CommonArgs{
+					Name: "1011-test",
 				},
-				SIG:         []string{"sig-multicluster"},
-				IncludePRs:  true,
-				Output:      "json",
+				SIG:        []string{"sig-multicluster"},
+				IncludePRs: true,
+				Output:     "json",
 			},
-			err:  nil,
+			err: nil,
 		},
 		{
 			name: "Invalid SIG",
 			queryOpts: QueryOpts{
-				CommonArgs: CommonArgs {
-					Name:     "1011-test-xyz",
+				CommonArgs: CommonArgs{
+					Name: "1011-test-xyz",
 				},
-				SIG:         []string{"sig-xyz"},
-				IncludePRs:  true,
-				Output:      "json",
+				SIG:        []string{"sig-xyz"},
+				IncludePRs: true,
+				Output:     "json",
 			},
-			err:  fmt.Errorf("No SIG matches any of the passed regular expressions"),
+			err: fmt.Errorf("No SIG matches any of the passed regular expressions"),
 		},
 		{
 			name: "Unsupported Output format",
 			queryOpts: QueryOpts{
-				CommonArgs: CommonArgs {
-					Name:     "1011-test-testing",
+				CommonArgs: CommonArgs{
+					Name: "1011-test-testing",
 				},
-				SIG:         []string{"sig-testing"},
-				IncludePRs:  true,
-				Output:      "PDF",
+				SIG:        []string{"sig-testing"},
+				IncludePRs: true,
+				Output:     "PDF",
 			},
-			err:  fmt.Errorf("unsupported output format: PDF. Valid values: [table json yaml]"),
+			err: fmt.Errorf("unsupported output format: PDF. Valid values: [table json yaml]"),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Ling Samuel <lingsamuelgrace@gmail.com>

#2298 deleted `Validate` args.
Also the test function name conflicts https://github.com/kubernetes/enhancements/blob/0f5924859f15b4f54c682dc9d3f11553c584b65b/pkg/kepctl/kepctl_test.go#L30