### PR TITLE
Update EndpointSlice GA to include zone for 1.21

### DIFF
--- a/keps/prod-readiness/sig-network/0752.yaml
+++ b/keps/prod-readiness/sig-network/0752.yaml
@@ -1,0 +1,3 @@
+kep-number: 0752
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-network/0752-endpointslices/kep.yaml
+++ b/keps/sig-network/0752-endpointslices/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 752
 authors:
   - "@freehan"
   - "@robscott"
+  - "@swetharepakula"
 owning-sig: sig-network
 reviewers:
   - "@bowei"
@@ -15,10 +16,10 @@ approvers:
 prr-approvers:
   - "@wojtek-t"
 creation-date: 2019-06-01
-last-updated: 2020-09-29
+last-updated: 2021-01-28
 status: implementable
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively


### PR DESCRIPTION
This PR proposes to add a per endpoint `zone` field and remove the per endpoint `topology` field. The proposal includes how to preserve the information in the `topology` field once resources are upgraded to v1
/cc @robscott 

/sig network