### PR TITLE
Migrating from old kep to new template: sig-cloud-provider  keps

### DIFF
--- a/keps/sig-cloud-provider/2390-reporting-conformance-test-results-to-testgrid/README.md
+++ b/keps/sig-cloud-provider/2390-reporting-conformance-test-results-to-testgrid/README.md
@@ -1,21 +1,3 @@
----
-title: Reporting Conformance Test Results to Testgrid
-authors:
-  - "@andrewsykim"
-owning-sig: sig-cloud-provider
-participating-sigs:
-  - sig-testing
-  - sig-release
-reviewers:
-  - TBD
-approvers:
-  - TBD
-editor: TBD
-creation-date: 2018-06-06
-last-updated: 2018-11-16
-status: implementable
----
-
 # Reporting Conformance Test Results to Testgrid
 
 ## Table of Contents

--- a/keps/sig-cloud-provider/2390-reporting-conformance-test-results-to-testgrid/kep.yaml
+++ b/keps/sig-cloud-provider/2390-reporting-conformance-test-results-to-testgrid/kep.yaml
@@ -1,0 +1,16 @@
+title: Reporting Conformance Test Results to Testgrid
+kep-number: 2390
+authors:
+  - "@andrewsykim"
+owning-sig: sig-cloud-provider
+participating-sigs:
+  - sig-testing
+  - sig-release
+reviewers:
+  - TBD
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2018-06-06
+last-updated: 2018-11-16
+status: implementable

--- a/keps/sig-cloud-provider/2392-cloud-controller-manager/README.md
+++ b/keps/sig-cloud-provider/2392-cloud-controller-manager/README.md
@@ -1,28 +1,3 @@
----
-title: Cloud Controller Manager
-authors:
-  - "@cheftako"
-  - "@calebamiles"
-  - "@hogepodge"
-owning-sig: sig-api-machinery
-participating-sigs:
-  - sig-cloud-provider
-  - sig-storage
-reviewers:
-  - "@andrewsykim"
-  - "@calebamiles"
-  - "@hogepodge"
-  - "@jagosan"
-approvers:
-  - "@thockin"
-editor: TBD
-creation-date: 2018-01-09
-last-updated: 2019-04-10
-status: provisional
-replaces:
-  - contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md
----
-
 # Cloud Controller Manager
 
 ## Table of Contents

--- a/keps/sig-cloud-provider/2392-cloud-controller-manager/kep.yaml
+++ b/keps/sig-cloud-provider/2392-cloud-controller-manager/kep.yaml
@@ -1,0 +1,23 @@
+title: Cloud Controller Manager
+kep-number: 2392
+authors:
+  - "@cheftako"
+  - "@calebamiles"
+  - "@hogepodge"
+owning-sig: sig-api-machinery
+participating-sigs:
+  - sig-cloud-provider
+  - sig-storage
+reviewers:
+  - "@andrewsykim"
+  - "@calebamiles"
+  - "@hogepodge"
+  - "@jagosan"
+approvers:
+  - "@thockin"
+editor: TBD
+creation-date: 2018-01-09
+last-updated: 2019-04-10
+status: provisional
+replaces:
+  - contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md

--- a/keps/sig-cloud-provider/2393-cloud-provider-documentation/README.md
+++ b/keps/sig-cloud-provider/2393-cloud-provider-documentation/README.md
@@ -1,28 +1,3 @@
----
-title: Cloud Provider Documentation
-authors:
-  - "@d-nishi"
-  - "@hogepodge"
-  - "@andrewsykim"
-owning-sig: sig-cloud-provider
-participating-sigs:
-  - sig-docs
-  - sig-cluster-lifecycle
-reviewers:
-  - "@andrewsykim"
-  - "@calebamiles"
-  - "@hogepodge"
-  - "@jagosan"
-approvers:
-  - "@andrewsykim"
-  - "@hogepodge"
-  - "@jagosan"
-editor: TBD
-creation-date: 2018-07-31
-last-updated: 2019-02-12
-status: implementable
----
-
 ## Documentation Requirements for Kubernetes Cloud Providers
 
 ### Table of Contents

--- a/keps/sig-cloud-provider/2393-cloud-provider-documentation/kep.yaml
+++ b/keps/sig-cloud-provider/2393-cloud-provider-documentation/kep.yaml
@@ -1,0 +1,23 @@
+title: Cloud Provider Documentation
+kep-number: 2393
+authors:
+  - "@d-nishi"
+  - "@hogepodge"
+  - "@andrewsykim"
+owning-sig: sig-cloud-provider
+participating-sigs:
+  - sig-docs
+  - sig-cluster-lifecycle
+reviewers:
+  - "@andrewsykim"
+  - "@calebamiles"
+  - "@hogepodge"
+  - "@jagosan"
+approvers:
+  - "@andrewsykim"
+  - "@hogepodge"
+  - "@jagosan"
+editor: TBD
+creation-date: 2018-07-31
+last-updated: 2019-02-12
+status: implementable

--- a/keps/sig-cloud-provider/2394-support-out-of-tree-AWS-cloud-provider/README.md
+++ b/keps/sig-cloud-provider/2394-support-out-of-tree-AWS-cloud-provider/README.md
@@ -1,18 +1,3 @@
----
-title: Support Out-of-Tree AWS Cloud Provider
-authors:
-  - "@andrewsykim"
-owning-sig: sig-cloud-provider
-reviewers:
-  - TBD
-approvers:
-  - TBD
-editor: TBD
-creation-date: 2019-01-25
-last-updated: 2019-01-25
-status: provisional
----
-
 # Supporting Out-of-Tree AWS Cloud Provider
 
 ## Table of Contents
@@ -46,12 +31,12 @@ status: provisional
 
 ## Summary
 
-Build support for the out-of-tree AWS cloud provider. This involves a well-tested version of the cloud-controller-manager 
-that has feature parity to the kube-controller-manager. 
+Build support for the out-of-tree AWS cloud provider. This involves a well-tested version of the cloud-controller-manager
+that has feature parity to the kube-controller-manager.
 
 ## Motivation
 
-Motivation for supporting out-of-tree providers can be found in the [Cloud Controller Manager KEP](/keps/sig-cloud-provider/20180530-cloud-controller-manager.md). 
+Motivation for supporting out-of-tree providers can be found in the [Cloud Controller Manager KEP](/keps/sig-cloud-provider/20180530-cloud-controller-manager.md).
 This KEP is specifically tracking progress for the AWS cloud provider.
 
 ### Goals

--- a/keps/sig-cloud-provider/2394-support-out-of-tree-AWS-cloud-provider/kep.yaml
+++ b/keps/sig-cloud-provider/2394-support-out-of-tree-AWS-cloud-provider/kep.yaml
@@ -1,0 +1,13 @@
+title: Support Out-of-Tree AWS Cloud Provider
+kep-number: 2394
+authors:
+  - "@andrewsykim"
+owning-sig: sig-cloud-provider
+reviewers:
+  - TBD
+approvers:
+  - TBD
+editor: TBD
+creation-date: 2019-01-25
+last-updated: 2019-01-25
+status: provisional

--- a/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md
+++ b/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md
@@ -1,31 +1,3 @@
----
-title: Removing In-Tree Cloud Providers
-authors:
-  - "@andrewsykim"
-  - "@cheftako"
-owning-sig: sig-cloud-provider
-participating-sigs:
-  - sig-apps
-  - sig-api-machinery
-  - sig-network
-  - sig-storage
-reviewers:
-  - "@andrewsykim"
-  - "@cheftako"
-  - "@d-nishi"
-  - "@dims"
-  - "@hogepodge"
-  - "@mcrute"
-  - "@steward-yu"
-approvers:
-  - "@thockin"
-  - "@liggit"
-editor: TBD
-creation-date: 2018-12-18
-last-updated: 2019-04-11
-status: implementable
----
-
 # Removing In-Tree Cloud Provider Code
 
 ## Table of Contents

--- a/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/kep.yaml
+++ b/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/kep.yaml
@@ -1,0 +1,26 @@
+title: Removing In-Tree Cloud Providers
+kep-number: 2395
+authors:
+  - "@andrewsykim"
+  - "@cheftako"
+owning-sig: sig-cloud-provider
+participating-sigs:
+  - sig-apps
+  - sig-api-machinery
+  - sig-network
+  - sig-storage
+reviewers:
+  - "@andrewsykim"
+  - "@cheftako"
+  - "@d-nishi"
+  - "@dims"
+  - "@hogepodge"
+  - "@mcrute"
+  - "@steward-yu"
+approvers:
+  - "@thockin"
+  - "@liggit"
+editor: TBD
+creation-date: 2018-12-18
+last-updated: 2019-04-11
+status: implementable


### PR DESCRIPTION
Related to: #2220

Migrating the old KEP files into new format - sig-cloud-provider 