### PR TITLE
Look at PRR approval request when querying KEPs

### DIFF
--- a/pkg/kepval/prrs/approvals.go
+++ b/pkg/kepval/prrs/approvals.go
@@ -42,7 +42,7 @@ type Approval struct {
 	Beta   Milestone `json:"beta" yaml:"beta"`
 	Stable Milestone `json:"stable" yaml:"stable"`
 
-	Error    error  `json:"-" yaml:"-"`
+	Error error `json:"-" yaml:"-"`
 }
 
 type Parser struct{}
@@ -74,4 +74,16 @@ func (p *Parser) Parse(in io.Reader) *Approval {
 
 	approval.Error = yaml.UnmarshalStrict(body.Bytes(), approval)
 	return approval
+}
+
+func (a *Approval) ApproverForStage(stage string) string {
+	switch stage {
+	case "alpha":
+		return a.Alpha.Approver
+	case "beta":
+		return a.Beta.Approver
+	case "stable":
+		return a.Stable.Approver
+	}
+	return ""
 }


### PR DESCRIPTION
While querying for KEPs needing PRR approval, I saw we were still missing some KEPs. This is because people aren't setting `prrApprovers` in `kep.yaml` and are instead just setting it in the PRR approval request yaml. This hacky PR allows us to search those too.

/assign @wojtek-t @deads2k 
/cc @jeremyrickard 