### PR TITLE
Update new events KEP to indicate latest status

### DIFF
--- a/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md
+++ b/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md
@@ -24,6 +24,8 @@
   - [Graduation Criteria](#graduation-criteria)
     - [Deprecated Fields](#deprecated-fields)
     - [Beta to GA Graduation](#beta-to-ga-graduation)
+    - [Load Test](#load-test)
+    - [Components Migration](#components-migration)
 - [Considerations](#considerations)
   - [Performance Impact](#performance-impact)
   - [Backward Compatibility](#backward-compatibility)
@@ -72,7 +74,7 @@ The KEP aims at fixing few issues in the current way Events are structured and i
 
 Most sections and design details are copied from the original design doc: [Make Kubernetes Events Useful and Safe](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md).
 
-The new Event API v1beta1 has been implemented for a while and currently only scheduler was migrated to use it. This KEP proposes to graduate API to GA in 1.19, but not necessarily migrate all the remaining Kubernetes components to use the new Event API.
+The new Event API has been promoted from v1beta1 to v1 in 1.19 and currently only scheduler was migrated to use it. This KEP proposes to graduate the new Event API by migrating all the remaining Kubernetes components to use the new Event API.
 
 ## Motivation
 
@@ -368,7 +370,7 @@ Scalability and Performance:
 
 ### Graduation Criteria
 
-The new Event API is in Beta right now. The plan is to graduate API to GA in 1.19, but not necessarily require that all components will be migrated.
+The new Event API is in v1 right now and scheduler has been migrated to use new API. The plan is to do a load test and migrate all the remaining components.
 
 #### Deprecated Fields
 
@@ -381,6 +383,25 @@ This section lists the deprecated Event API fields that should be removed before
 
 - Remove deprecated fields listed above
 - Gather data from performance and scalability tests
+
+#### Load Test
+
+The idea is to use [ClusterLoader](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2) testing framework to do a load test to make sure events generated can be handled by etcd and there's no big performance reduction.
+
+#### Components Migration
+
+The list of components that need to be migrated is shown as follows:
+
+- kubelet
+- cloud-controller-manager
+- kube-controller-manager
+- leader election
+- node problem detector
+- gce ingress controller
+- event exporter
+
+(Note: there are more out-of-tree components that need to be migrated)
+
 
 ## Considerations
 

--- a/keps/sig-instrumentation/383-new-event-api-ga-graduation/kep.yaml
+++ b/keps/sig-instrumentation/383-new-event-api-ga-graduation/kep.yaml
@@ -16,8 +16,8 @@ approvers:
 prr-approvers:
   - "@wojtek-t"
 creation-date: 2019-01-31
-last-updated: 2020-09-24
-status: implemented
+last-updated: 2021-02-03
+status: implementable
 see-also:
 replaces:
 stage: stable


### PR DESCRIPTION
The KEP should be in implementable status since we haven't migrate all components to use the new API. Updated the KEP to indicate the remaining work that needs to be done for graduating new Event API.