### PR TITLE
Switch to the reserved port for opentelemetry

### DIFF
--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -132,7 +132,7 @@ type ServiceReference struct {
   Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
   // If specified, the port on the service.
-  // Defaults to 55680.
+  // Defaults to 4317, the IANA reserved port for OpenTelemetry.
   // `port` should be a valid port number (1-65535, inclusive).
   // +optional
   Port *int32 `json:"port,omitempty" protobuf:"varint,3,opt,name=port"`


### PR DESCRIPTION
OpenTelemetry recently got its own reserved port number, 4317.  https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt

/assign @ehashman @brancz @logicalhan 