### PR TITLE
Update structured logging for 1.21

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/1602.yaml
+++ b/keps/prod-readiness/sig-instrumentation/1602.yaml
@@ -1,0 +1,3 @@
+kep-number: 1602
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-instrumentation/1602-structured-logging/README.md
+++ b/keps/sig-instrumentation/1602-structured-logging/README.md
@@ -382,6 +382,11 @@ Adding guarding against regression and update user guideline:
 * Static analysis protects important log lines from reverting to string formating
 * [Kubernetes Logging convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) document is updated
 
+Components in scope:
+* Kubelet
+
+All other component migrations will be best effort.
+
 #### GA
 
 Logging formats become an API:
@@ -389,6 +394,7 @@ Logging formats become an API:
 * Format string methods are deprecated
 * Static analysis protects against creating new string format calls
 * Logging output formats fall under [Kubernetes deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+* All remaining components must be migrated
 
 ### Performance
 
@@ -734,3 +740,5 @@ _This section must be completed when targeting beta graduation to a release._
 * 2020-03-18 - Implementation started
 * 2020-05-18 - Updated PRR questionnaire added
 * 2020-05-28 - PRR review done
+* 2020-07-11 - Alpha in 1.19
+* 2021-01-04 - Begin best effort migration of logs to structured format

--- a/keps/sig-instrumentation/1602-structured-logging/kep.yaml
+++ b/keps/sig-instrumentation/1602-structured-logging/kep.yaml
@@ -4,6 +4,7 @@ authors:
   - "@serathius"
   - "@44past4"
   - "@DirectXMan12"
+  - "@ehashman"
 owning-sig: sig-instrumentation
 participating-sigs:
   - sig-architecture
@@ -18,13 +19,14 @@ approvers:
   - "@thockin"
 prr-approvers:
   - "@wojtek-t"
+  - "@johnbelamaric"
 see-also:
 replaces:
-stage: alpha
-latest-milestone: "v1.19"
+stage: beta
+latest-milestone: "v1.21"
 milestone:
   alpha: "v1.19"
-  beta: "v1.20"
+  beta: "v1.21"
   stable: "v1.22"
 feature-gates:
 disable-supported: true


### PR DESCRIPTION
/cc @serathius @dims @wojtek-t 

SIG Instrumentation would like to target beta for structured logging in 1.21. I am volunteering to help out @serathius with coordination. I can commit to migrating the kubelet in 1.21.

Once this change is approved/merges, I will go file issues documenting all the work required for this release.

ref #1602 