### PR TITLE
Adding PRR for AppProtocol KEP

### DIFF
--- a/keps/prod-readiness/sig-network/1507.yaml
+++ b/keps/prod-readiness/sig-network/1507.yaml
@@ -1,0 +1,3 @@
+kep-number: 1507
+stable:
+  approver: "@deads2k"

--- a/keps/sig-network/1507-app-protocol/README.md
+++ b/keps/sig-network/1507-app-protocol/README.md
@@ -15,6 +15,13 @@
 - [Alpha -&gt; Beta](#alpha---beta)
 - [Beta -&gt; GA](#beta---ga)
     - [Test plan](#test-plan)
+  - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+    - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+    - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+    - [Monitoring Requirements](#monitoring-requirements)
+    - [Dependencies](#dependencies)
+    - [Scalability](#scalability)
+    - [Troubleshooting](#troubleshooting)
 <!-- /toc -->
 
 ## Summary
@@ -111,3 +118,108 @@ already exists on EndpointSlice. Additionally, it will add tests that ensure
 that both the Endpoints and EndpointSlice controllers appropriately set the
 AppProtocol field on Endpoints and EndpointSlices when it is set on the
 corresponding Service.
+
+## Production Readiness Review Questionnaire
+
+### Feature Enablement and Rollback
+
+* **How can this feature be enabled / disabled in a live cluster?**
+  This was previously enabled with the `ServiceAppProtocol` feature gate. That
+  will be removed in Kubernetes 1.21.
+
+* **Does enabling the feature change any default behavior?**
+  No.
+
+* **Can the feature be disabled once it has been enabled (i.e. can we roll back
+  the enablement)?**
+  Not anymore.
+
+* **What happens if we reenable the feature if it was previously rolled back?**
+  N/A.
+
+* **Are there any tests for feature enablement/disablement?**
+  N/A.
+
+### Rollout, Upgrade and Rollback Planning
+
+* **How can a rollout fail? Can it impact already running workloads?**
+  If the `ServiceAppProtocol` gate is manually enabled on Kubernetes components
+  it will no longer be recognized in Kubernetes 1.21. Users should stop using
+  this feature gate.
+
+* **What specific metrics should inform a rollback?**
+  N/A.
+
+* **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
+  N/A.
+
+* **Is the rollout accompanied by any deprecations and/or removals of features,
+  APIs, fields of API types, flags, etc.?**
+  The v1.21 rollout will include the removal of the `ServiceAppProtcol` feature
+  gate.
+
+### Monitoring Requirements
+
+* **How can an operator determine if the feature is in use by workloads?**
+  If this field is set on any Services, it may be used by applications that
+  consume those Services. No core Kubernetes components consume this field.
+
+* **What are the SLIs (Service Level Indicators) an operator can use to
+  determine the health of the service?**
+  N/A.
+
+* **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
+  N/A.
+
+* **Are there any missing metrics that would be useful to have to improve
+  observability of this feature?**
+  No.
+
+### Dependencies
+
+* **Does this feature depend on any specific services running in the cluster?**
+  No.
+
+
+### Scalability
+
+* **Will enabling / using this feature result in any new API calls?**
+  No.
+
+* **Will enabling / using this feature result in introducing new API types?**
+  No.
+
+* **Will enabling / using this feature result in any new calls to the cloud
+  provider?**
+  No.
+
+* **Will enabling / using this feature result in increasing size or count of the
+  existing API objects?**
+  Describe them, providing:
+  - API type(s): Service
+  - Estimated increase in size: 10B
+  - Estimated amount of new objects: This field could be specified on each port
+    in each Service in a cluster although that is unlikely.
+
+* **Will enabling / using this feature result in increasing time taken by any
+  operations covered by existing SLIs/SLOs?**
+  No.
+
+* **Will enabling / using this feature result in non-negligible increase of
+  resource usage (CPU, RAM, disk, IO, ...) in any components?**
+  No
+
+### Troubleshooting
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+
+* **How does this feature react if the API server and/or etcd is unavailable?**
+  N/A
+
+* **What are other known failure modes?**
+  N/A
+
+* **What steps should be taken if SLOs are not being met to determine the problem?**
+  N/A

--- a/keps/sig-network/1507-app-protocol/kep.yaml
+++ b/keps/sig-network/1507-app-protocol/kep.yaml
@@ -9,8 +9,10 @@ reviewers:
 approvers:
   - "@thockin"
   - "@dcbw"
+prr-approvers:
+  - "@deads2k"
 creation-date: "2019-12-27"
-last-updated: "2020-09-29"
+last-updated: "2021-02-05"
 status: implementable
 
 # The target maturity stage in the current dev cycle for this KEP.
@@ -19,7 +21,7 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.21"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This feature has already reached GA. The only thing happening in the 1.21 release cycle is removing the feature gate. As a follow up to https://github.com/kubernetes/enhancements/issues/1507#issuecomment-770334761 and the [associated Slack thread](https://kubernetes.slack.com/archives/C1L57L91V/p1611855486052700), this adds a PRR to this KEP. 

/assign @deads2k 
/sig network