### PR TITLE
[KEP-1933] Production Readiness Review.

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/1933.yaml
+++ b/keps/prod-readiness/sig-instrumentation/1933.yaml
@@ -1,0 +1,3 @@
+kep-number: 1933
+beta:
+  approver: "@deads2k"

--- a/keps/sig-instrumentation/1933-secret-logging-static-analysis/README.md
+++ b/keps/sig-instrumentation/1933-secret-logging-static-analysis/README.md
@@ -133,7 +133,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [x] (R) Graduation criteria is in place
 - [x] (R) Production readiness review completed
-- [ ] Production readiness review approved
+- [x] Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
@@ -463,13 +463,16 @@ you need any help or guidance.
 
 ### Feature Enablement and Rollback
 
-As an addition to Kubernetes testing, enablement and rollback are managed
-by configuration changes in `kubernetes/test-infra`.
+As part of Prow, enablement is managed by configuration in `kubernetes/test-infra`.
+As the test target and tool version are fixed in `kubernetes/kubernetes/hack/tools`,
+rollback can be handled by reverting any offending commit to `hack/tools`.
 
 ### Rollout, Upgrade and Rollback Planning
 
 As a third-party dependency, analyzer upgrading is handled by upgrading
-the version targeted by `kubernetes/kubernetes/hack/tools/`. 
+the version targeted by `kubernetes/kubernetes/hack/tools/`.
+Tool configuration at `kubernetes/kubernetes/hack/testdata/levee` can be updated
+independently, though may be required during tool upgrading.
 
 ### Monitoring Requirements
 

--- a/keps/sig-instrumentation/1933-secret-logging-static-analysis/kep.yaml
+++ b/keps/sig-instrumentation/1933-secret-logging-static-analysis/kep.yaml
@@ -17,16 +17,16 @@ reviewers:
 approvers:
 - "@dashpole"
 - "@ehashman"
-#prr-approvers:
-#- TBD
+prr-approvers:
+- "@deads2k"
 see-also:
 - /keps/sig-instrumentation/1753-logs-sanitization
 - /keps/sig-instrumentation/1602-structured-logging
 replaces: []
 
-stage: alpha
+stage: beta
 
-latest-milestone: "v1.20"
+latest-milestone: "v1.21"
 
 milestone:
   alpha: "v1.20"


### PR DESCRIPTION
[KEP-1933](https://github.com/kubernetes/enhancements/issues/1933) associated analysis is currently running in Prow in `beta` state - running on every PR, but not yet blocking on failure.  [Failures](https://prow.k8s.io/?job=pull-kubernetes-verify-govet-levee&state=failure) are infrequent and appear to be related to build or merge failures, not failures in the test itself.  Execution of the test target itself [appears to be running soundly](https://prow.k8s.io/?job=pull-kubernetes-verify-govet-levee) overall.

