### PR TITLE
api: Add `Scope` field to the `Proposal` document

### DIFF
--- a/api/proposal.go
+++ b/api/proposal.go
@@ -46,6 +46,7 @@ type Proposal struct {
 	ID       string `json:"id"`
 	PRNumber string `json:"prNumber,omitempty"`
 	Name     string `json:"name,omitempty"`
+	Scope    string `json:"scope" yaml:"scope"`
 
 	Title             string   `json:"title" yaml:"title" validate:"required"`
 	Number            string   `json:"kep-number" yaml:"kep-number"`

--- a/pkg/kepval/approval.go
+++ b/pkg/kepval/approval.go
@@ -105,6 +105,14 @@ func isPRRRequired(kep *api.Proposal) (required, missingMilestone, missingStage 
 	missingMilestone = kep.IsMissingMilestone()
 	missingStage = kep.IsMissingStage()
 
+	// TODO: These checks are currently gameable
+	//       i.e., if we elide some of these fields, a contributor can circumvent
+	//       PRR review
+	if kep.Scope != "in-tree" {
+		required = false
+		return required, missingMilestone, missingStage, nil
+	}
+
 	if kep.Status != "implementable" {
 		required = false
 		return required, missingMilestone, missingStage, nil


### PR DESCRIPTION
Starting work on https://github.com/kubernetes/enhancements/issues/2311, https://github.com/kubernetes/enhancements/issues/1783 (part of https://github.com/kubernetes/enhancements/issues/2348).

### TODO

- [ ] assume `in-tree` if the field is not specified
- [ ] non-blocking warning when the field is missing
- [ ] move any `scope` logic to the repo/proposal validation logic
- [ ] define the `scope`s and (eventually) reject invalid inputs 

/hold for discussion ~and to rebase out https://github.com/kubernetes/enhancements/pull/2409~