### PR TITLE
keps: Fix incorrect stages on PRR targeting v1.21

### DIFF
--- a/keps/prod-readiness/sig-storage/625.yaml
+++ b/keps/prod-readiness/sig-storage/625.yaml
@@ -1,3 +1,3 @@
 kep-number: 625
-stable:
+beta:
   approver: "@wojtek-t"

--- a/keps/sig-api-machinery/2161-apiserver-default-labels/kep.yaml
+++ b/keps/sig-api-machinery/2161-apiserver-default-labels/kep.yaml
@@ -21,7 +21,7 @@ approvers:
   - "@liggitt"
   - "@deads2k"
 replaces:
-stage: alpha
+stage: beta
 latest-milestone: "v1.21"
 milestone:
   beta: "v1.21"


### PR DESCRIPTION
Validation errors found as a result of https://github.com/kubernetes/enhancements/pull/2409.
ref: https://github.com/kubernetes/enhancements/pull/2409#discussion_r573545015, https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/enhancements/2409/pull-enhancements-verify/1359402306486931456

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @wojtek-t 