### PR TITLE
Remove the restriction on empty namespaceSelector in podaffinity

### DIFF
--- a/keps/sig-scheduling/2249-pod-affinity-namespace-selector/README.md
+++ b/keps/sig-scheduling/2249-pod-affinity-namespace-selector/README.md
@@ -316,28 +316,6 @@ if the namespace where they are created have a resource quota object with
 `CrossNamespaceAffinity` scope and a hard limit equal to the number of pods that are
 allowed to.
 
-Moreover, to prevent accidentally selecting a large number of namespaces, we will reject empty
-selectors. For example, users can do the following:
-
-```yaml
-podAntiAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-  - namespaceSelector:
-      matchExpressions:
-        - key: workload
-          operator: In
-          values:
-          - HPC
-```
-
-but can't do the following:
-
-```yaml
-podAntiAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-  - namespaceSelector: {}
-```
-
 For more protection, admission webhooks like gatekeeper can be used to further
 restrict the use of this field.
 
@@ -700,7 +678,8 @@ information to express the idea and why it was not acceptable.
 
 ## Implementation History
  - 2021-01-11: Initial KEP sent for review
-
+ - 2021-02-10: Remove the restriction on empty namespace selector
+ 
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.
 Major milestones might include:


### PR DESCRIPTION
#2249

We initially proposed to disallow empty namespaceSelector. Users however can select all namespaces as follows:
```
- Key: unused-label
  operator: DoesNotExist
```

Selecting all namespaces will likely be a common usage pattern, which we can easily special case and optimize in the scheduler implementation (by avoiding listing namespaces and matching against their labels since all namespaces are eligible). And so I am suggesting we drop the restriction on empty namespaceSelector to avoid forcing users to opt into the pattern above which requires more processing.

@wojtek-t @liggitt @Huang-Wei @alculquicondor 