### PR TITLE
Add log volume benchmark

### DIFF
--- a/keps/sig-instrumentation/1602-structured-logging/README.md
+++ b/keps/sig-instrumentation/1602-structured-logging/README.md
@@ -383,6 +383,7 @@ Bring feature quality up to and prevent regression during ongoing migration:
 * [Kubernetes Logging documentation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) is updated for structured logging.
 * JSON format should support same set of feature flags as text format, minus those we will decide to deprecate.
 * Structured logging interface design is verified by migrating one whole component (Kubelet) to structured logging. All other component migrations will be best effort.
+* Log volume (i.e. size of output) will be benchmarked and documented for kubelet in non-JSON and JSON format.
 
 #### GA
 


### PR DESCRIPTION
@serathius typically as part of beta, some benchmarking or measurements are performed. Since we will fully migrate the kubelet during this release, a teammate of mine suggested that after code freeze (but before test freeze) we should look at kubelet log volumes for 1.20, 1.21 non-JSON and 1.21 JSON.

WDYT?