### PR TITLE
Cleanup metadata in metrics stability kep

### DIFF
--- a/keps/sig-api-machinery/1693-warnings/README.md
+++ b/keps/sig-api-machinery/1693-warnings/README.md
@@ -276,7 +276,7 @@ disable the server sending warnings during the beta period.
 * Implement in-process deprecated API warnings, metrics, audit annotations
 * Complete test plan for implemented items
 * API server output of `Warning` headers for deprecated API use is feature-gated and enabled by default
-* The metric for deprecated API use is registered at [stability level `ALPHA`](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md#stability-classes)
+* The metric for deprecated API use is registered at [stability level `ALPHA`](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1290-metrics-stability/kubernetes-control-plane-metrics-stability.md#stability-classes)
 * Implement admission webhook warning contributions
 * Implement custom resource version deprecation
 * client-go logs warnings with code `299` by default
@@ -290,7 +290,7 @@ disable the server sending warnings during the beta period.
 * Implement in-process helpers for field-level validation warnings and admission warnings
 * Complete test plan for implemented items
 * API server output of `Warning` headers for deprecated API use is unconditionally enabled
-* Server metric for deprecated API use is registered at [stability level `STABLE`](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md#stability-classes)
+* Server metric for deprecated API use is registered at [stability level `STABLE`](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md#stability-classes)
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-instrumentation/1209-metrics-stability/README.md
+++ b/keps/sig-instrumentation/1209-metrics-stability/README.md
@@ -76,10 +76,10 @@ Historically, the implementation was split into four documents:
 
 This document is not net new and ties the four together in order to document the lifecycle of this feature.
 
-[Metrics Stability Framework]: 20190404-kubernetes-control-plane-metrics-stability.md
-[Metrics Stability Migration]: 20190605-metrics-stability-migration.md
-[Metrics Validation and Verification]: 20190605-metrics-validation-and-verification.md
-[Metrics Stability to Beta]: 20191028-metrics-stability-to-beta.md
+[Metrics Stability Framework]: kubernetes-control-plane-metrics-stability.md
+[Metrics Stability Migration]: metrics-stability-migration.md
+[Metrics Validation and Verification]: metrics-validation-and-verification.md
+[Metrics Stability to Beta]: metrics-stability-to-beta.md
 
 ## Motivation
 
@@ -90,10 +90,10 @@ See:
 1. [Metrics Validation and Verification#Motivation]
 1. [Metrics Stability to Beta#Motivation]
 
-[Metrics Stability Framework#Motivation]: 20190404-kubernetes-control-plane-metrics-stability.md#motivation
-[Metrics Stability Migration#Motivation]: 20190605-metrics-stability-migration.md#motivation
-[Metrics Validation and Verification#Motivation]: 20190605-metrics-validation-and-verification.md#motivation
-[Metrics Stability to Beta#Motivation]: 20191028-metrics-stability-to-beta.md#motivation
+[Metrics Stability Framework#Motivation]: kubernetes-control-plane-metrics-stability.md#motivation
+[Metrics Stability Migration#Motivation]: metrics-stability-migration.md#motivation
+[Metrics Validation and Verification#Motivation]: metrics-validation-and-verification.md#motivation
+[Metrics Stability to Beta#Motivation]: metrics-stability-to-beta.md#motivation
 
 ## Proposal
 
@@ -106,10 +106,10 @@ See:
 
 https://github.com/kubernetes/enhancements/blob/77a84d2d55b5802a615f3fe98e7e7c9bd26c9efc/keps/sig-instrumentation/1209-metrics-stability/keps/sig-instrumentation/1209-metrics-stability/20190404-kubernetes-control-plane-metrics-stability.md#implementation-history
 
-[Metrics Stability Framework#Proposal]: 20190404-kubernetes-control-plane-metrics-stability.md#proposal
-[Metrics Stability Migration#General Migration Strategy]: 20190605-metrics-stability-migration.md#general-migration-strategy
-[Metrics Validation and Verification#Proposal]: 20190605-metrics-validation-and-verification.md#proposal
-[Metrics Stability to Beta#Proposal]: 20191028-metrics-stability-to-beta.md#proposal
+[Metrics Stability Framework#Proposal]: kubernetes-control-plane-metrics-stability.md#proposal
+[Metrics Stability Migration#General Migration Strategy]: metrics-stability-migration.md#general-migration-strategy
+[Metrics Validation and Verification#Proposal]: metrics-validation-and-verification.md#proposal
+[Metrics Stability to Beta#Proposal]: metrics-stability-to-beta.md#proposal
 
 ## Design Details
 
@@ -118,8 +118,8 @@ See:
 1. [Metrics Stability Framework#Design Details]
 1. [Metrics Validation and Verification#Design Details]
 
-[Metrics Stability Framework#Design Details]: 20190404-kubernetes-control-plane-metrics-stability.md#design-details
-[Metrics Validation and Verification#Design Details]: 20190605-metrics-validation-and-verification.md#design-details
+[Metrics Stability Framework#Design Details]: kubernetes-control-plane-metrics-stability.md#design-details
+[Metrics Validation and Verification#Design Details]: metrics-validation-and-verification.md#design-details
 
 ### Graduation Criteria
 
@@ -130,8 +130,8 @@ See:
 1. [Metrics Stability Framework#Graduation Criteria]
 1. [Metrics Stability Migration#Graduation Criteria]
 
-[Metrics Stability Framework#Graduation Criteria]: 20190404-kubernetes-control-plane-metrics-stability.md#graduation-criteria
-[Metrics Stability Migration#Graduation Criteria]: 20190605-metrics-stability-migration.md#graduation-criteria
+[Metrics Stability Framework#Graduation Criteria]: kubernetes-control-plane-metrics-stability.md#graduation-criteria
+[Metrics Stability Migration#Graduation Criteria]: metrics-stability-migration.md#graduation-criteria
 
 #### Alpha -> Beta Graduation
 
@@ -140,24 +140,24 @@ See:
 1. [Metrics Validation and Verification#Graduation Criteria]
 1. [Metrics Stability to Beta#Graduation Criteria]
 
-[Metrics Validation and Verification#Graduation Criteria]: 20190605-metrics-validation-and-verification.md#graduation-criteria
-[Metrics Stability to Beta#Graduation Criteria]: 20191028-metrics-stability-to-beta.md#graduation-criteria
+[Metrics Validation and Verification#Graduation Criteria]: metrics-validation-and-verification.md#graduation-criteria
+[Metrics Stability to Beta#Graduation Criteria]: metrics-stability-to-beta.md#graduation-criteria
 
 #### Beta -> GA Graduation
 
 - Metrics are now eligible to be promoted to STABLE status (we have some candidates in kube-apiserver).
     - [apiserver_storage_object_counts](https://github.com/kubernetes/kubernetes/issues/98270)
     - `apiserver_request_total` will also be promoted (as discussed in biweekly SIG apimachinery meeting)
-- Implement the ability to turn off individual metrics (see [here](20191028-metrics-stability-to-beta.md#non-goals))
+- Implement the ability to turn off individual metrics (see [here](metrics-stability-to-beta.md#non-goals))
     - We need this because of stuff like this: [Unbounded valuesets for metric labels](https://github.com/kubernetes/kubernetes/issues/76302)
 
 ### Upgrade / Downgrade Strategy
 
 See:
 
-- [Deprecation Lifecycle](20190404-kubernetes-control-plane-metrics-stability.md#deprecation-lifecycle)
-- [Deprecation of modified metrics from metrics overhaul KEP](20190605-metrics-stability-migration.md#deprecation-of-modified-metrics-from-metrics-overhaul-kep)
-- [Escape Hatch](20191028-metrics-stability-to-beta.md#escape-hatch)
+- [Deprecation Lifecycle](kubernetes-control-plane-metrics-stability.md#deprecation-lifecycle)
+- [Deprecation of modified metrics from metrics overhaul KEP](metrics-stability-migration.md#deprecation-of-modified-metrics-from-metrics-overhaul-kep)
+- [Escape Hatch](metrics-stability-to-beta.md#escape-hatch)
 
 https://github.com/kubernetes/enhancements/blob/0f5bb1138a6dfd7f3d52fa901c2fba7abb7fb731/keps/sig-instrumentation/1209-metrics-stability/keps/sig-instrumentation/1209-metrics-stability/20190404-kubernetes-control-plane-metrics-stability.md#implementation-history
 
@@ -229,7 +229,7 @@ See:
 1. [Metrics Validation and Verification#Implementation History]
 1. [Metrics Stability to Beta#Implementation History]
 
-[Metrics Stability Framework#Implementation History]: 20190404-kubernetes-control-plane-metrics-stability.md#implementation-history
-[Metrics Stability Migration#Implementation History]: 20190605-metrics-stability-migration.md#implementation-history
-[Metrics Validation and Verification#Implementation History]: 20190605-metrics-validation-and-verification.md#implementation-history
-[Metrics Stability to Beta#Implementation History]: 20191028-metrics-stability-to-beta.md#implementation-history
+[Metrics Stability Framework#Implementation History]: kubernetes-control-plane-metrics-stability.md#implementation-history
+[Metrics Stability Migration#Implementation History]: metrics-stability-migration.md#implementation-history
+[Metrics Validation and Verification#Implementation History]: metrics-validation-and-verification.md#implementation-history
+[Metrics Stability to Beta#Implementation History]: metrics-stability-to-beta.md#implementation-history

--- a/keps/sig-instrumentation/1209-metrics-stability/kep.yaml
+++ b/keps/sig-instrumentation/1209-metrics-stability/kep.yaml
@@ -12,6 +12,7 @@ participating-sigs:
   - sig-scheduling
   - sig-cluster-lifecycle
   - sig-cloud-provider
+  - sig-testing
 status: implementable
 creation-date: 2019-04-04
 reviewers:

--- a/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md
+++ b/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md
@@ -1,32 +1,3 @@
----
-title: Kubernetes Control-Plane Metrics Stability
-authors:
-  - "@logicalhan"
-owning-sig: sig-instrumentation
-participating-sigs:
-  - sig-instrumentation
-  - sig-api-machinery
-  - sig-node
-reviewers:
-  - "@brancz"
-  - "@x13n"
-  - "@DirectXMan12"
-  - "@lavalamp"
-  - "@dashpole"
-  - "@ehashman"
-  - "@mml"
-approvers:
-  - "@brancz"
-  - "@x13n"
-editor: "@brancz"
-creation-date: 2019-04-04
-last-updated: 2020-10-14
-stage: beta
-status: implementable
-see-also:
-  - 20181106-kubernetes-metrics-overhaul
----
-
 # Kubernetes Control-Plane Metrics Stability
 
 ## Table of Contents
@@ -331,11 +302,11 @@ Alternatively, one lightweight solution which was previously suggested was docum
 
 ### Static Analysis for Validation
 
-[_resolved_](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md)
+[_resolved_](./metrics-validation-and-verification.md)
 
 ### Beta Stability Level
 
-_discussed during [stability-to-beta](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20191028-metrics-stability-to-beta.md), and decided it wasn't necessary_
+_discussed during [stability-to-beta](./metrics-stability-to-beta.md), and decided it wasn't necessary_
 
 ### Prometheus Labels vs OpenCensus-type Tags
 

--- a/keps/sig-instrumentation/1209-metrics-stability/metrics-stability-migration.md
+++ b/keps/sig-instrumentation/1209-metrics-stability/metrics-stability-migration.md
@@ -1,32 +1,3 @@
----
-title: Metrics Stability Migration
-authors:
-  - "@logicalhan"
-  - "@solodov"
-owning-sig: sig-instrumentation
-participating-sigs:
-  - sig-scheduling
-  - sig-node
-  - sig-api-machinery
-  - sig-cluster-lifecycle
-  - sig-cloud-provider
-reviewers:
-  - "@brancz from sig-instrumentation"
-  - "@dashpole from sig-node"
-  - "@sttts from sig-api-machinery"
-  - "@DirectXMan12 from sig-cluster-lifecycle"
-  - "@bsalamat from sig-scheduling"
-  - "@andrewsykim from sig-cloud-provider"
-approvers:
-  - "@brancz"
-creation-date: 2019-06-05
-last-updated: 2019-06-27
-status: implemented
-see-also:
-  - 20181106-kubernetes-metrics-overhaul
-  - 20190404-kubernetes-control-plane-metrics-stability
----
-
 # Metrics Stability Migration
 
 ## Table of Contents
@@ -47,11 +18,11 @@ see-also:
 
 ## Summary
 
-This KEP intends to document and communicate the general strategy for migrating the control-plane metrics stability framework across the Kubernetes codebase. Most of the framework design decisions have been determined and outlined in [an earlier KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md).
+This KEP intends to document and communicate the general strategy for migrating the control-plane metrics stability framework across the Kubernetes codebase. Most of the framework design decisions have been determined and outlined in [an earlier KEP](./kubernetes-control-plane-metrics-stability.md).
 
 ## Motivation
 
-We want to start using the metrics stability framework built based off the [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md), so that we can define stability levels for metrics in the Kubernetes codebase. These stability levels would provide API compatibility guarantees across version bumps.
+We want to start using the metrics stability framework built based off the [Kubernetes Control-Plane Metrics Stability KEP](./kubernetes-control-plane-metrics-stability.md), so that we can define stability levels for metrics in the Kubernetes codebase. These stability levels would provide API compatibility guarantees across version bumps.
 
 ### Goals
 
@@ -119,7 +90,7 @@ TBD (since this is not yet implemented)
 
 ## Graduation Criteria
 
-- [x] Prior to migrating a [component, automated static analysis testing](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md) is in place to validate and verify API guarantees.
+- [x] Prior to migrating a [component, automated static analysis testing](./metrics-validation-and-verification.md) is in place to validate and verify API guarantees.
 - [x] Adequate [documentation exists for new flags on components](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/)
 - [x] Update [instrumentation documents to reflect changes](https://github.com/kubernetes/website/pull/17578)
 

--- a/keps/sig-instrumentation/1209-metrics-stability/metrics-stability-to-beta.md
+++ b/keps/sig-instrumentation/1209-metrics-stability/metrics-stability-to-beta.md
@@ -1,27 +1,3 @@
----
-title: Metrics Stability Framework to Beta
-authors:
-  - "@logicalhan"
-  - "@RainbowMango"
-owning-sig: sig-instrumentation
-participating-sigs:
-  - sig-instrumentation
-reviewers:
-  - "@brancz"
-approvers:
-  - "@brancz"
-editor: "@brancz"
-creation-date: 2019-10-28
-last-updated: 2020-10-14
-status: implemented
-stage: beta
-see-also:
-  - 20181106-kubernetes-metrics-overhaul
-  - 20190404-kubernetes-control-plane-metrics-stability
-  - 20190605-metrics-stability-migration
-  - 20190605-metrics-validation-and-verification
----
-
 # Metrics Stability Framework to Beta
 
 ## Table of Contents

--- a/keps/sig-instrumentation/1209-metrics-stability/metrics-validation-and-verification.md
+++ b/keps/sig-instrumentation/1209-metrics-stability/metrics-validation-and-verification.md
@@ -1,26 +1,3 @@
----
-title: Metrics Validation and Verification
-authors:
-  - "@serathius"
-  - "@solodov"
-  - "@logicalhan"
-owning-sig: sig-instrumentation
-participating-sigs:
-  - sig-instrumentation
-  - sig-testing
-reviewers:
-  - "@brancz"
-approvers:
-  - "@brancz"
-editor: TBD
-creation-date: 2019-06-05
-last-updated: 2020-10-14
-status: implemented
-see-also:
-  - 20190404-kubernetes-control-plane-metrics-stability
-  - 20190605-metrics-stability-migration
----
-
  # Metrics Validation and Verification
 
  ## Table of Contents
@@ -49,13 +26,13 @@ see-also:
 ## Summary
 
 This Kubernetes Enhancement Proposal (KEP) builds off of the framework proposed
-in the [Kubernetes Control-Plane Metrics Stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md)
+in the [Kubernetes Control-Plane Metrics Stability KEP](./kubernetes-control-plane-metrics-stability.md)
 and proposes a strategy for ensuring conformance of metrics with official
 stability guarantees.
 
 ## Motivation
 
-While the [Kubernetes Control Plane metrics stability KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md)
+While the [Kubernetes Control Plane metrics stability KEP](./kubernetes-control-plane-metrics-stability.md)
 provides a framework to define stability levels for control-plane metrics,
 it does not provide a strategy for verifying and validating conformance to stated guarantees.
 This KEP intends to propose a framework for validating and verifying metric guarantees.
@@ -74,7 +51,7 @@ This KEP intends to propose a framework for validating and verifying metric guar
 
 ## Proposal
 
-We will provide validation for metrics under the [new framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) with static analysis.
+We will provide validation for metrics under the [new framework](./kubernetes-control-plane-metrics-stability.md) with static analysis.
 
 ## Design Details
 

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -149,7 +149,7 @@ If `--opentelemetry-config-file` is not specified, the API Server will not send 
 
 ### Controlling use of the OpenTelemetry library
 
-As the community found in the [Metrics Stability Framework KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md#kubernetes-control-plane-metrics-stability), having control over how the client libraries are used in kubernetes can enable maintainers to enforce policy and make broad improvements to the quality of telemetry.  To enable future improvements to tracing, we will restrict the direct use of the OpenTelemetry library within the kubernetes code base, and provide wrapped versions of functions we wish to expose in a utility library.
+As the community found in the [Metrics Stability Framework KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md#kubernetes-control-plane-metrics-stability), having control over how the client libraries are used in kubernetes can enable maintainers to enforce policy and make broad improvements to the quality of telemetry.  To enable future improvements to tracing, we will restrict the direct use of the OpenTelemetry library within the kubernetes code base, and provide wrapped versions of functions we wish to expose in a utility library.
 
 ### Test Plan
 

--- a/keps/sig-node/727-resource-metrics-endpoint/README.md
+++ b/keps/sig-node/727-resource-metrics-endpoint/README.md
@@ -73,7 +73,7 @@ This proposal deals with the first problem, which is that the Summary API is a p
 
 The kubelet will expose an endpoint at `/metrics/resource` in prometheus text exposition format using the prometheus client library.
 
-The metrics in this endpoint will make use of the [Kubernetes Metrics Stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) for stability and deprecation policies.
+The metrics in this endpoint will make use of the [Kubernetes Metrics Stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md) for stability and deprecation policies.
 
 
 ### API


### PR DESCRIPTION
Ref #2220 

Given it's effectively a single KEP, just different parts are splitted across multiple `sub-keps`, this cleans it up by merging all metadata to (and removed dates from the names, which was the old convention).

/assign @logicalhan @brancz @dashpole @ehashman 