### PR TITLE
Apiserver tracing updates

### DIFF
--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -154,7 +154,7 @@ type TracingConfiguration struct {
 }
 ```
 
-If `--opentelemetry-config-file` is not specified, the API Server will not send any spans, even if incoming requests are sampled.
+If `--opentelemetry-config-file` is not specified, the API Server will not send any spans, even if incoming requests ask for sampling.
 
 ### Controlling use of the OpenTelemetry library
 

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -113,13 +113,14 @@ The API Server controls where traffic is sent using an [EgressSelector](https://
 ```golang
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// OpenTelemetryClientConfiguration provides versioned configuration for opentelemetry clients.
-type OpenTelemetryClientConfiguration struct {
+// TracingConfiguration provides versioned configuration for tracing clients.
+type TracingConfiguration struct {
   metav1.TypeMeta `json:",inline"`
 
   // +optional
   // URL of the collector that's running on the control-plane node.
-  // if URL is specified, APIServer uses the egressType ControlPlane when sending data to the collector.
+  // the APIServer uses the egressType ControlPlane when sending data to the collector.
+  // The default is localhost:4317
   URL *string `json:"url,omitempty" protobuf:"bytes,3,opt,name=url"`
 }
 ```

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -130,7 +130,7 @@ type TracingConfiguration struct {
 }
 ```
 
-If `--opentelemetry-config-file` is not specified, the API Server will not send any telemetry.
+If `--opentelemetry-config-file` is not specified, the API Server will not send any spans, even if incoming requests are sampled.
 
 ### Controlling use of the OpenTelemetry library
 

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -121,27 +121,6 @@ type OpenTelemetryClientConfiguration struct {
   // URL of the collector that's running on the master.
   // if URL is specified, APIServer uses the egressType Master when sending data to the collector.
   URL *string `json:"url,omitempty" protobuf:"bytes,3,opt,name=url"`
-
-  // +optional
-  // Service that's the frontend of the collector deployment running in the cluster.
-  // If Service is specified, APIServer uses the egressType Cluster when sending data to the collector.
-  Service *ServiceReference `json:"service,omitempty" protobuf:"bytes,1,opt,name=service"`
-}
-
-// ServiceReference holds a reference to Service.legacy.k8s.io
-type ServiceReference struct {
-  // `namespace` is the namespace of the service.
-  // Required
-  Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
-  // `name` is the name of the service.
-  // Required
-  Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
-
-  // If specified, the port on the service.
-  // Defaults to 4317, the IANA reserved port for OpenTelemetry.
-  // `port` should be a valid port number (1-65535, inclusive).
-  // +optional
-  Port *int32 `json:"port,omitempty" protobuf:"varint,3,opt,name=port"`
 }
 ```
 

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -132,7 +132,7 @@ The [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-co
 
 ### APIServer Configuration and EgressSelectors
 
-The API Server controls where traffic is sent using an [EgressSelector](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190226-network-proxy.md), and has separate controls for `ControlPlane`, `Cluster`, and `Etcd` traffic.  As described above, we would like to support either sending telemetry to a url using the `ControlPlane` egress, or a service using the `Cluster` egress.  To accomplish this, we will introduce a flag, `--opentelemetry-config-file`, that will point to the file that defines the opentelemetry exporter configuration.  That file will have the following format:
+The API Server controls where traffic is sent using an [EgressSelector](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190226-network-proxy.md), and has separate controls for `ControlPlane`, `Cluster`, and `Etcd` traffic.  As described above, we would like to support sending telemetry to a url using the `ControlPlane` egress.  To accomplish this, we will introduce a flag, `--opentelemetry-config-file`, that will point to the file that defines the opentelemetry exporter configuration.  That file will have the following format:
 
 ```golang
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -120,8 +120,13 @@ type TracingConfiguration struct {
   // +optional
   // URL of the collector that's running on the control-plane node.
   // the APIServer uses the egressType ControlPlane when sending data to the collector.
-  // The default is localhost:4317
-  URL *string `json:"url,omitempty" protobuf:"bytes,3,opt,name=url"`
+  // Defaults to localhost:4317
+  URL *string `json:"url,omitempty" protobuf:"bytes,1,opt,name=url"`
+
+  // +optional
+  // SamplingRatePerMillion is the number of samples to collect per million spans.
+  // Defaults to 0.
+  SamplingRatePerMillion *int32 `json:"samplingRatePerMillion,omitempty" protobuf:"varint,2,opt,name=samplingRatePerMillion"`
 }
 ```
 

--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -108,7 +108,7 @@ The [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-co
 
 ### APIServer Configuration and EgressSelectors
 
-The API Server controls where traffic is sent using an [EgressSelector](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190226-network-proxy.md), and has separate controls for `Master`, `Cluster`, and `Etcd` traffic.  As described above, we would like to support either sending telemetry to a url using the `Master` egress, or a service using the `Cluster` egress.  To accomplish this, we will introduce a flag, `--opentelemetry-config-file`, that will point to the file that defines the opentelemetry exporter configuration.  That file will have the following format:
+The API Server controls where traffic is sent using an [EgressSelector](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190226-network-proxy.md), and has separate controls for `ControlPlane`, `Cluster`, and `Etcd` traffic.  As described above, we would like to support either sending telemetry to a url using the `ControlPlane` egress, or a service using the `Cluster` egress.  To accomplish this, we will introduce a flag, `--opentelemetry-config-file`, that will point to the file that defines the opentelemetry exporter configuration.  That file will have the following format:
 
 ```golang
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -118,8 +118,8 @@ type OpenTelemetryClientConfiguration struct {
   metav1.TypeMeta `json:",inline"`
 
   // +optional
-  // URL of the collector that's running on the master.
-  // if URL is specified, APIServer uses the egressType Master when sending data to the collector.
+  // URL of the collector that's running on the control-plane node.
+  // if URL is specified, APIServer uses the egressType ControlPlane when sending data to the collector.
   URL *string `json:"url,omitempty" protobuf:"bytes,3,opt,name=url"`
 }
 ```
@@ -132,7 +132,7 @@ As the community found in the [Metrics Stability Framework KEP](https://github.c
 
 ### Test Plan
 
-We will e2e test this feature by deploying an OpenTelemetry Collector on the master, and configure it to export traces using the [stdout exporter](https://github.com/open-telemetry/opentelemetry-go/tree/master/exporters/stdout), which logs the spans in json format.  We can then verify that the logs contain our expected traces when making calls to the API Server.
+We will e2e test this feature by deploying an OpenTelemetry Collector on the control-plane node, and configure it to export traces using the [stdout exporter](https://github.com/open-telemetry/opentelemetry-go/tree/master/exporters/stdout), which logs the spans in json format.  We can then verify that the logs contain our expected traces when making calls to the API Server.
 
 ## Graduation requirements
 
@@ -328,7 +328,7 @@ _This section must be completed when targeting beta graduation to a release._
 
 ### Introducing a new EgressSelector type
 
-Instead of a configuration file to choose between a url on the `Master` network, or a service on the `Cluster` network, we considered introducing a new `OpenTelemetry` egress type, which could be configured separately.  However, we aren't actually introducing a new destination for traffic, so it is more conventional to make use of existing egress types.  We will also likely want to add additional configuration for the OpenTelemetry client in the future.
+Instead of a configuration file to choose between a url on the `ControlPlane` network, or a service on the `Cluster` network, we considered introducing a new `OpenTelemetry` egress type, which could be configured separately.  However, we aren't actually introducing a new destination for traffic, so it is more conventional to make use of existing egress types.  We will also likely want to add additional configuration for the OpenTelemetry client in the future.
 
 ### Other OpenTelemetry Exporters
 


### PR DESCRIPTION
I'm making some updates to the KEP based on feedback in the implementation PR: https://github.com/kubernetes/kubernetes/pull/94942

Major Changes:

* Remove service from the configuration
* Add sampling rate to the configuration
* Add User Stories

Naming Updates:
* Rename Master->ControlPlane
* Rename OpenTelemetryClientConfiguration->TracingConfiguration

Open Question:
* Should we change from a configuration file to just use flags?

/assign @lavalamp 
cc @logicalhan @lilic @sttts @ehashman @brancz 