### PR TITLE
Update target stable milestone for scheduler CC

### DIFF
--- a/keps/sig-scheduling/1451-multi-scheduling-profiles/kep.yaml
+++ b/keps/sig-scheduling/1451-multi-scheduling-profiles/kep.yaml
@@ -22,7 +22,7 @@ latest-milestone: "v1.19"
 milestone:
   alpha: "v1.18"
   beta: "v1.19"
-  stable: "v1.21"
+  stable: "v1.22"
 metrics:
   - "schedule_attempts_total"
   - "e2e_scheduling_duration_seconds"

--- a/keps/sig-scheduling/785-scheduler-component-config-api/kep.yaml
+++ b/keps/sig-scheduling/785-scheduler-component-config-api/kep.yaml
@@ -20,4 +20,4 @@ stage: beta
 latest-milestone: "v1.19"
 milestone:
   beta: "v1.19"
-  stable: "v1.21"
+  stable: "v1.22"


### PR DESCRIPTION
We are releasing a v1beta2 in 1.21 that we intend to graduate to v1 next release.

With it, scheduling profiles will graduate too.

/sig scheduling