### PR TITLE
Update CRIContainerLogRotation KEP

### DIFF
--- a/keps/sig-node/2411-cri-container-log-rotation/README.md
+++ b/keps/sig-node/2411-cri-container-log-rotation/README.md
@@ -33,13 +33,13 @@
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [x] (R) Graduation criteria is in place
-- [ ] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
+- [x] (R) Production readiness review completed
+- [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
@@ -117,7 +117,6 @@ The kubelet exposes a consistent log directory structure with embedded metadata 
 
 - Successfully run in production
 - Solicit feedback in SIG Node community that there are no issues with individual distributions production usage (OpenShift and GKE both report no major issue)
-- Fix https://github.com/kubernetes/kubernetes/issues/64760, which is an issue on loss of some logs during log rotation
 
 ### Upgrade / Downgrade Strategy
 


### PR DESCRIPTION
Update the graduation criteria for GA as one of the
issues mentioned no longer applies.

Based on the comment from https://github.com/kubernetes/kubernetes/issues/64760#issuecomment-773128499, the log loss issue does not apply to CRI container runtimes. Updating the KEP to remove it from the graduation criteria.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>