### PR TITLE
1602-structured-logging: add note about excluded components

### DIFF
--- a/keps/sig-instrumentation/1602-structured-logging/README.md
+++ b/keps/sig-instrumentation/1602-structured-logging/README.md
@@ -369,6 +369,8 @@ Klog interface was selected as it is already supported by klog.v2 with `SetLogge
 
 ### Migration / Graduation Criteria
 
+NOTE: The components kubectl and kubeadm are out of scope for this migration effort until further notice.
+
 #### Alpha
 
 Introduce structured logging and JSON format:


### PR DESCRIPTION
A prior discussion determined kubectl and kubeadm
as components that should not be migrated.

/sig instrumentation
/cc @ehashman 
