### PR TITLE
Replace prydonius with soltysh for sig-apps leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,7 @@ aliases:
     - janetkuo
     - kow3ns
     - mattfarina
-    - prydonius
+    - soltysh
   sig-architecture-leads:
     - derekwaynecarr
     - dims


### PR DESCRIPTION
Following the announcement in https://groups.google.com/g/kubernetes-sig-apps/c/GS7-HNoeDPo/m/aQpoWhqsAwAJ.
/assign @justaugustus 