### PR TITLE
Delete blank line from .notableofcontents

### DIFF
--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -2,4 +2,3 @@ keps/README.md
 keps/sig-cli/FAQ.md
 keps/sig-cluster-lifecycle/clusterapi/FAQ.md
 keps/sig-cluster-lifecycle/kubeadm/970-kubeadm-config/documentation-for-images.md
-


### PR DESCRIPTION
On the version of grep shipped with macs, the blank line in the `hack/.notableofcontents` file matches everything, breaking the `hack/update-toc.sh` script.