### PR TITLE
Rename RandomReplicaSetDownScale feature gate to LogarithmicScaleDown

### DIFF
--- a/keps/sig-apps/2185-random-pod-select-on-replicaset-downscale/README.md
+++ b/keps/sig-apps/2185-random-pod-select-on-replicaset-downscale/README.md
@@ -200,15 +200,15 @@ be relatively balanced.
 ### Graduation Criteria
 
 Alpha (v1.21): 
-- Add RandomReplicaSetDownscale feature gate to kube-controller-manager 
+- Add LogarithmicScaleDown feature gate to kube-controller-manager 
 (disabled by default).
 - Unit and e2e tests
 
 Beta (v1.22): 
-- Enable RandomReplicaSetDownscale feature gate by default
+- Enable LogarithmicScaleDown feature gate by default
 
 Stable (v1.23):
-- Remove RandomReplicaSetDownscale feature gate
+- Remove LogarithmicScaleDown feature gate
 - Make this behavior standard
 
 ### Upgrade / Downgrade Strategy
@@ -233,7 +233,7 @@ _This section must be completed when targeting alpha to a release._
 
 * **How can this feature be enabled / disabled in a live cluster?**
   - [x] Feature gate (also fill in values in `kep.yaml`)
-    - Feature gate name: RandomReplicaSetDownscale
+    - Feature gate name: LogarithmicScaleDown
     - Components depending on the feature gate: kube-controller-manager
   - [ ] Other
     - Describe the mechanism:

--- a/keps/sig-apps/2185-random-pod-select-on-replicaset-downscale/kep.yaml
+++ b/keps/sig-apps/2185-random-pod-select-on-replicaset-downscale/kep.yaml
@@ -30,7 +30,7 @@ milestone:
   stable: "v1.23"
 
 feature-gates:
-  - name: RandomReplicaSetDownscale
+  - name: LogarithmicScaleDown
     components:
       - kube-controller-manager
 disable-supported: true


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/99212, we mistakenly added this feature gate as `LogarithmicScaleDown`. This is not a huge error, as both are relatively descriptive, but since it is past code freeze it is probably easier to update the KEP to be consistent rather than rename the flag.

There is also a PR to document this flag in https://github.com/kubernetes/website/pull/27221