### PR TITLE
Updated the README.md to delete the 404 broken link

### DIFF
--- a/keps/sig-scheduling/624-scheduling-framework/README.md
+++ b/keps/sig-scheduling/624-scheduling-framework/README.md
@@ -603,9 +603,7 @@ kubescheduler.config.k8s.io/v1alpha1`. This new config format will be either
 configuration.
 
 *Note: Moving `KubeSchedulerConfiguration` to `v1` is outside the scope of this
-design, but see also
-https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md
-and https://github.com/kubernetes/community/pull/3008*
+design, but see also https://github.com/kubernetes/community/pull/3008*
 
 ### Interactions with Cluster Autoscaler
 


### PR DESCRIPTION
closes #2603 
Deleted the 404 broken link https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md  present in /keps/sig-scheduling/624-scheduling-framework/README.md
