### PR TITLE
Add stable hostname to Indexed job

### DIFF
--- a/keps/sig-apps/2214-indexed-job/kep.yaml
+++ b/keps/sig-apps/2214-indexed-job/kep.yaml
@@ -6,13 +6,12 @@ owning-sig: sig-apps
 status: implemented
 creation-date: 2020-12-29
 reviewers:
-  - "@soltysh"
   - "@erictune"
   - "@ahg"
   - "@liggitt"
 approvers:
+  - "@soltysh"
   - "@janetkuo"
-  - "@kow3ns"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta


### PR DESCRIPTION
As part of beta graduation, to support tightly coupled parallel jobs.

As presented in https://github.com/kubernetes/kubernetes/issues/99497#issuecomment-819694258

/sig apps

This PR builds on top of #2616 (beta graduation update with no extra features).