### PR TITLE
Updated the README.md file to change the broken link with the new link

### DIFF
--- a/keps/sig-scheduling/624-scheduling-framework/README.md
+++ b/keps/sig-scheduling/624-scheduling-framework/README.md
@@ -604,7 +604,7 @@ configuration.
 
 *Note: Moving `KubeSchedulerConfiguration` to `v1` is outside the scope of this
 design, but see also
-https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md
+https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/783-component-base/README.md
 and https://github.com/kubernetes/community/pull/3008*
 
 ### Interactions with Cluster Autoscaler


### PR DESCRIPTION
closes #2603  
change the broken link as shown below with the working link

```diff
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/0032-create-a-k8s-io-component-repo.md
+ https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/wgs/783-component-base/README.md
```
present in  /keps/sig-scheduling/624-scheduling-framework/README.md