### PR TITLE
Make some cleanup in KEP PRR template and building scripts

### DIFF
--- a/hack/verify-build.sh
+++ b/hack/verify-build.sh
@@ -20,6 +20,8 @@ set -o pipefail
 
 PLATFORMS=(
     linux/amd64
+    windows/amd64
+    darwin/amd64
 )
 
 for PLATFORM in "${PLATFORMS[@]}"; do

--- a/hack/verify-build.sh
+++ b/hack/verify-build.sh
@@ -20,15 +20,6 @@ set -o pipefail
 
 PLATFORMS=(
     linux/amd64
-    linux/386
-    linux/arm
-    linux/arm64
-    linux/ppc64le
-    linux/s390x
-    windows/amd64
-    windows/386
-    freebsd/amd64
-    darwin/amd64
 )
 
 for PLATFORM in "${PLATFORMS[@]}"; do

--- a/keps/NNNN-kep-template/kep.yaml
+++ b/keps/NNNN-kep-template/kep.yaml
@@ -14,9 +14,14 @@ reviewers:
 approvers:
   - TBD
   - "@oscar.doe"
-prr-approvers:
-  - TBD
-  - "@bob.doe"
+
+##### WARNING !!! ######
+# prr-approvers has been moved to its own location
+# You should create your own in keps/prod-readiness
+# Please make a copy of keps/prod-readiness/template/nnnn.yaml
+# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
+#prr-approvers:
+
 see-also:
   - "/keps/sig-aaa/1234-we-heard-you-like-keps"
   - "/keps/sig-bbb/2345-everyone-gets-a-kep"

--- a/keps/prod-readiness/template/nnnn.yaml
+++ b/keps/prod-readiness/template/nnnn.yaml
@@ -1,3 +1,6 @@
-kep-number: 0000 
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group 
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 0000
 alpha:
   approver: ""

--- a/keps/prod-readiness/template/nnnn.yaml
+++ b/keps/prod-readiness/template/nnnn.yaml
@@ -1,0 +1,3 @@
+kep-number: 0000 
+alpha:
+  approver: ""


### PR DESCRIPTION
This PR:
* Cleans the verify-build.sh to build only for amd64 (as we run the tests in amd64 only, right?) cutting a bit the tests time
* Make some statement about creating the PRR file on the right place, removing it from kep.yaml