### PR TITLE
Going emeritus, remove myself and add irvifa

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,12 +39,12 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
+    - irvifa
     - jimangel
     - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
-    - zacharysarah
   sig-instrumentation-leads:
     - brancz
     - dashpole
@@ -130,7 +130,6 @@ aliases:
     - celestehorgan
     - jdumars
     - justaugustus
-    - zacharysarah
   wg-policy-leads:
     - ericavonb
     - hannibalhuang


### PR DESCRIPTION
As part of going fully emeritus, I'm removing myself as a lead from WGs and SIGs.

I've added @irvifa; she's been a SIG Docs chair for well over a year now.

/sig docs
/wg naming

Related PRs:
- https://github.com/kubernetes/community/pull/5733
- https://github.com/kubernetes/org/pull/2649
- https://github.com/kubernetes/website/pull/27637