### PR TITLE
Mark KEP 2161 as implemented and stable

### DIFF
--- a/keps/sig-api-machinery/2161-apiserver-default-labels/README.md
+++ b/keps/sig-api-machinery/2161-apiserver-default-labels/README.md
@@ -243,7 +243,8 @@ Since this has been reserved since 2017 (if not earlier), no backwards guarantee
 - release note
 
 1.22:
-- gate enabled by default
+- promote to GA
+- cannot be disabled
 - release note
 
 1.23:

--- a/keps/sig-api-machinery/2161-apiserver-default-labels/kep.yaml
+++ b/keps/sig-api-machinery/2161-apiserver-default-labels/kep.yaml
@@ -10,7 +10,7 @@ owning-sig: sig-api-machinery
 participating-sigs:
   - sig-api-machinery
   - sig-network
-status: implementable
+status: implemented
 creation-date: 2020-11-22
 reviewers:
   - "@liggitt"
@@ -21,8 +21,8 @@ approvers:
   - "@liggitt"
   - "@deads2k"
 replaces:
-stage: beta
-latest-milestone: "v1.21"
+stage: stable
+latest-milestone: "v1.22"
 milestone:
   beta: "v1.21"
   stable: "v1.22"
@@ -30,4 +30,4 @@ feature-gates:
   - name: NamespaceDefaultLabelName
     components:
       - kube-apiserver
-disable-supported: true
+disable-supported: false


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubernetes/pull/101342
