### PR TITLE
Expose default through OpenAPI

### DIFF
--- a/keps/sig-api-machinery/1929-built-in-default/README.md
+++ b/keps/sig-api-machinery/1929-built-in-default/README.md
@@ -271,17 +271,12 @@ example further down).
 
 ### Default publishing
 
-CRDs do not publish default via the OpenAPI spec on the /openapi/v2
-endpoint today, but we have to decide what to do with the new default
-values of built-in types. The kube-openapi generated schemas will
-include them.
+Before 1.22, CRDs and build-in types were not exposing their default values through the `/openapi/v2` endpoint but will expose them in Kubernetes v1.22.
 
-We propose to:
+These default values can be valuable for generating documentation, and can be required for clients that are trying to merge associative lists with defaulted keys.
 
-1. Clients should NOT be modified to use that default for fields that are not specified, and the documentation must make that very clear. The default is informational only, according to OpenAPI documentation: 
-  > The default value is the one that the server uses if the client does not supply the parameter value in the request.
- 
-2. Kustomize and clients can't merge associative lists with default key fields if the default isn't visible, e.g. unable to merge port/protocol lists in the client.
+Please note that clients absolutely MUST NOT use these default values to populate fields that haven't been otherwise specified, as noted in the OpenAPI documentation:
+> The default value is the one that the server uses if the client does not supply the parameter value in the request.
 
 
 ### Marker format

--- a/keps/sig-api-machinery/1929-built-in-default/README.md
+++ b/keps/sig-api-machinery/1929-built-in-default/README.md
@@ -277,7 +277,7 @@ values of built-in types. The kube-openapi generated schemas will
 include them.
 
 We propose to:
-1. leave CRDs not publishing defaults
+1. to allow the CRDs to publish the defaults field which helps the client to set the <zero-value>.
 2. filter out defaults in the built-in type schemas too in a first step
 3. but possibly reconsider this behaviour in the future when the
 necessity of defaults for client-side merging (e.g. through kustomize)

--- a/keps/sig-api-machinery/1929-built-in-default/README.md
+++ b/keps/sig-api-machinery/1929-built-in-default/README.md
@@ -276,7 +276,7 @@ endpoint today, but we have to decide what to do with the new default
 values of built-in types. The kube-openapi generated schemas will
 include them.
 
-We proppose to:
+We propose to:
 1. leave CRDs not publishing defaults
 2. filter out defaults in the built-in type schemas too in a first step
 3. but possibly reconsider this behaviour in the future when the

--- a/keps/sig-api-machinery/1929-built-in-default/README.md
+++ b/keps/sig-api-machinery/1929-built-in-default/README.md
@@ -277,8 +277,12 @@ values of built-in types. The kube-openapi generated schemas will
 include them.
 
 We propose to:
-1. to allow the CRDs to publish the defaults field which helps the client to set the <zero-value>.
-2. publish out defaults in the built-in type schemas.
+
+1. Clients should NOT be modified to use that default for fields that are not specified, and the documentation must make that very clear. The default is informational only, according to OpenAPI documentation: 
+  > The default value is the one that the server uses if the client does not supply the parameter value in the request.
+ 
+2. Kustomize and clients can't merge associative lists with default key fields if the default isn't visible, e.g. unable to merge port/protocol lists in the client.
+
 
 ### Marker format
 

--- a/keps/sig-api-machinery/1929-built-in-default/README.md
+++ b/keps/sig-api-machinery/1929-built-in-default/README.md
@@ -278,10 +278,7 @@ include them.
 
 We propose to:
 1. to allow the CRDs to publish the defaults field which helps the client to set the <zero-value>.
-2. filter out defaults in the built-in type schemas too in a first step
-3. but possibly reconsider this behaviour in the future when the
-necessity of defaults for client-side merging (e.g. through kustomize)
-and influences on the ecosystem of default mis-use is better understood.
+2. publish out defaults in the built-in type schemas.
 
 ### Marker format
 


### PR DESCRIPTION
This pull request proposes that we start exposing default through the OpenAPI, both for built-in types and CRDs in Kubernetes 1.22.

By following the marker-
`// +default=<any>`