### PR TITLE
Mark KEP 1972 as withdrawn

### DIFF
--- a/keps/sig-node/1972-kubelet-exec-probe-timeouts/README.md
+++ b/keps/sig-node/1972-kubelet-exec-probe-timeouts/README.md
@@ -27,8 +27,8 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Design details are appropriately documented
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [X] (R) Graduation criteria is in place
-- [ ] (R) Production readiness review completed
-- [ ] Production readiness review approved
+- [x] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes

--- a/keps/sig-node/1972-kubelet-exec-probe-timeouts/kep.yaml
+++ b/keps/sig-node/1972-kubelet-exec-probe-timeouts/kep.yaml
@@ -5,7 +5,7 @@ authors:
   - "@SergeyKanzhelev"
 owning-sig: sig-node
 participating-sigs:
-status: implemented
+status: withdrawn
 creation-date: 2020-09-08
 reviewers:
   - "@dchen1107"
@@ -20,7 +20,7 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -32,5 +32,5 @@ feature-gates:
   - name: ExecProbeTimeouts
     components:
       - kubelet
-disable-supported: true
+disable-supported: false
 


### PR DESCRIPTION
KEP 1972 is stable since v1.20. Should we mark it as withdrawn  in v1.22?
