### PR TITLE
Updating KEP 536 to note that it has been replaced by KEP 2433

### DIFF
--- a/keps/sig-network/536-topology-aware-routing/README.md
+++ b/keps/sig-network/536-topology-aware-routing/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 <!-- toc -->
+- [Status](#status)
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-goals](#non-goals)
@@ -24,6 +25,11 @@
     - [Alpha -&gt; Beta](#alpha---beta)
       - [Beta -&gt; GA Graduation](#beta---ga-graduation)
 <!-- /toc -->
+
+## Status
+This KEP has been replaced by [KEP 2433: Topology Aware
+Hints](https://github.com/kubernetes/enhancements/issues/2433). It will be fully
+removed in Kubernetes 1.22.
 
 ## Motivation
 

--- a/keps/sig-network/536-topology-aware-routing/kep.yaml
+++ b/keps/sig-network/536-topology-aware-routing/kep.yaml
@@ -10,5 +10,5 @@ reviewers:
 approvers:
   - "@thockin"
 creation-date: 2018-10-24
-last-updated: 2019-10-17
-status: implementable
+last-updated: 2021-04-30
+status: replaced


### PR DESCRIPTION
This also commits us to removing the implementation in the 1.22 cycle.

/sig network
/assign @thockin 