### PR TITLE
[KEP-2133]: Update milestone and metadata for Kubelet credential provider

### DIFF
--- a/keps/sig-node/2133-kubelet-credential-providers/README.md
+++ b/keps/sig-node/2133-kubelet-credential-providers/README.md
@@ -341,6 +341,7 @@ can be achieved using the exec plugin.
 
 * integration or e2e tests.
 * at least one working plugin implementation.
+   - there are two implementation currently for [ECR](https://github.com/kubernetes/cloud-provider-aws/tree/master/cmd/ecr-credential-provider) and [GCR](https://github.com/kubernetes/cloud-provider-gcp/tree/master/cmd/auth-provider-gcp).
 * kubelet metrics for failed calls to exec plugins.
 * improvements to concurrency and caching:
    - use `singleflight.Group` to ensure only a single call per image. Today the kubelet holds a single lock for every call to `Provide`.
@@ -397,7 +398,7 @@ _This section must be completed when targeting beta graduation to a release._
 
 * **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
 
-  No, upgrade->downgrade->upgrade were not tested. Manual validation will be done prior to promoting this feature to beta in v1.21.
+  No, upgrade->downgrade->upgrade were not tested. Manual validation will be done prior to promoting this feature to beta in v1.22.
 
 * **Is the rollout accompanied by any deprecations and/or removals of features, APIs,
 fields of API types, flags, etc.?**

--- a/keps/sig-node/2133-kubelet-credential-providers/kep.yaml
+++ b/keps/sig-node/2133-kubelet-credential-providers/kep.yaml
@@ -27,13 +27,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.20"
-  beta: "v1.21"
-  stable: "v1.23"
+  beta: "v1.22"
+  stable: "v1.24"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -44,5 +44,6 @@ feature-gates:
 disable-supported: true
 
 # The following PRR answers are required at beta release
-# metrics:
-#  - my_feature_metric
+metrics:
+  - kubelet_credential_provider_plugin_errors
+  - kubelet_credential_provider_plugin_duration


### PR DESCRIPTION
Updates the KEP to target Beta for 1.22

/sig node cloud-provider auth

Signed-off-by: Aditi Sharma <adi.sky17@gmail.com>