### PR TITLE
Init `valErrMap` on `Validate()`

### DIFF
--- a/pkg/repo/validate.go
+++ b/pkg/repo/validate.go
@@ -32,6 +32,10 @@ func (r *Repo) Validate() (
 	valErrMap map[string][]error,
 	err error,
 ) {
+	if valErrMap == nil {
+		valErrMap = make(map[string][]error)
+	}
+
 	if r.ProposalPath == "" {
 		return warnings, valErrMap, errors.New("proposal path cannot be empty")
 	}


### PR DESCRIPTION
If the map is `nil`, then the assignment of

```go
valErrMap[filename] = append(valErrMap[filename], err)
```

will cause a runtime panic. This has been fixed by pre-initialization of
the map, whereas the errors are now reported correctly.
