### PR TITLE
Initialize map before inserting elements

### DIFF
--- a/pkg/repo/validate.go
+++ b/pkg/repo/validate.go
@@ -106,6 +106,10 @@ func (r *Repo) Validate() (
 			return warnings, valErrMap, errors.Wrapf(kep.Error, "%v has an error", filename)
 		}
 
+		if valErrMap == nil {
+			valErrMap = make(map[string][]error)
+		}
+
 		err = kepval.ValidatePRR(kep, prrHandler, prrDir)
 		if err != nil {
 			valErrMap[filename] = append(valErrMap[filename], err)


### PR DESCRIPTION
Validation errors are masked because of the following error:
```
panic: assignment to entry in nil map [recovered]
panic: assignment to entry in nil map
```

Example run: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/enhancements/2673/pull-enhancements-verify/1389750336436047872