### PR TITLE
Ensure GitHub token is set for kepctl

### DIFF
--- a/pkg/kepctl/commands/query.go
+++ b/pkg/kepctl/commands/query.go
@@ -110,6 +110,7 @@ func runQuery(opts *repo.QueryOpts) error {
 	if err != nil {
 		return errors.Wrap(err, "creating repo client")
 	}
+	rc.TokenPath = rootOpts.TokenPath
 
 	return rc.Query(opts)
 }

--- a/pkg/repo/query.go
+++ b/pkg/repo/query.go
@@ -110,8 +110,11 @@ func (r *Repo) Query(opts *QueryOpts) error {
 		fmt.Fprintf(r.Out, "Searching for KEPs...\n")
 	}
 
-	if tokenErr := r.SetGitHubToken(r.TokenPath); tokenErr != nil {
-		return errors.Wrapf(tokenErr, "setting GitHub token")
+	if r.TokenPath != "" {
+		logrus.Infof("Setting GitHub token: %v", r.TokenPath)
+		if tokenErr := r.SetGitHubToken(r.TokenPath); tokenErr != nil {
+			return errors.Wrapf(tokenErr, "setting GitHub token")
+		}
 	}
 
 	allKEPs := make([]*api.Proposal, 0, 10)


### PR DESCRIPTION
Prior to this patch, even when I was setting the GitHub token, it wasn't getting passed through and my GitHub API requests weren't authenticated (so I was getting rate limited).

/cc @justaugustus @johnbelamaric 