### PR TITLE
Update CRI KEP with pinned Image requirement

### DIFF
--- a/keps/sig-node/2040-kubelet-cri/kep.yaml
+++ b/keps/sig-node/2040-kubelet-cri/kep.yaml
@@ -21,7 +21,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -30,4 +30,4 @@ milestone:
 
 # The following PRR answers are required at beta release
 metrics:
-  - TBD
+  - "N/A"


### PR DESCRIPTION
This reflects the new requirement of CRI going to Beta that the CRI implementation
must be able to indicate to the Kubelet an image should not be garbage collected.

This functionality will be used in leu of the Kubelet's current behavior
of keeping track of the pause image version to stop the pause image from being garbage collected.

Signed-off-by: Peter Hunt <pehunt@redhat.com>