### PR TITLE
Update P&F KEP with support for watch initialization

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/kep.yaml
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 1040
 authors:
 - "@MikeSpreitzer"
 - "@yue9944882"
+- "@wojtek-t"
 owning-sig: sig-api-machinery
 participating-sigs:
 - wg-multitenancy
@@ -26,13 +27,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.18"
   beta: "v1.20"
-  stable: "v1.22"
+  stable: "v1.23"
 
 # The following PRR answers are required at alpha release.
 # List the feature gate name and the components for which it must be enabled.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/enhancements/issues/1040

/assign @lavalamp @deads2k 
/cc @MikeSpreitzer @tkashem 

I was playing a bit with the idea on Friday and did a very simple POC of this mechanism (without handling any corner cases): https://github.com/kubernetes/kubernetes/pull/101785 And it works relatively well.

I briefly chatted with David about this idea and he seemed to be supportive [it's surprisingly simple approach and watch initialization is often hitting us during any kube-apiserver restarts with large clusters due to huge number (due to huge number (even hundreds of thousands) of watches of secrets/configmaps].