### PR TITLE
Updating Topology Hints KEP for 1.22

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/README.md
+++ b/keps/sig-network/2433-topology-aware-hints/README.md
@@ -200,11 +200,14 @@ continue to be supported as a means of configuring this feature.
 
 #### Interoperability
 
-If any of the following are true, topology hints will be ignored:
+Topology hints will be ignored if the TopologyKeys field has at least one entry.
+This field is deprecated and will be removed soon.
 
-- ExternalTrafficPolicy is set to Local
-- InternalTrafficPolicy is set to Local
-- TopologyKeys field has at least one entry
+Both ExternalTrafficPolicy and InternalTrafficPolicy will be given precedence
+over topology aware routing. For example, if `ExternalTrafficPolicy=Local` and
+topology was enabled, external traffic would be routed using the
+ExternalTrafficPolicy configuration while internal traffic would be routed with
+topology.
 
 #### Feature Gate
 
@@ -444,6 +447,7 @@ EndpointSliceSyncs = metrics.NewCounterVec(
 
 ### Graduation Criteria
 - Alpha should provide basic functionality covered with tests described above.
+- Interoperability with Internal and External TrafficPolicy fields.
 
 ### Version Skew Strategy
 This KEP requires updates to both the EndpointSlice Controller and kube-proxy.

--- a/keps/sig-network/2433-topology-aware-hints/kep.yaml
+++ b/keps/sig-network/2433-topology-aware-hints/kep.yaml
@@ -31,7 +31,7 @@ stage: alpha
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
 # latest-milestone: "v1.21"
-latest-milestone: "0.0"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This updates the KEP to correctly reference the annotation we ended up settling on in the last cycle (along with a suggested naming update). It also includes significant test plan updates.

Although this sticks with the 1.22 target for beta, I'm not completely sure I'll have the time to get all of the graduation criteria in place for this cycle (most notably the e2e tests). So although this is something I'm hoping to graduate in this cycle, it may not happen. 

/sig network
/cc @andrewsykim @aojea @bowei @maplain 
/assign @thockin 