### PR TITLE
update streaming proxy redicts status: 1.22. Deprecated and default false

### DIFF
--- a/keps/prod-readiness/sig-node/1558.yaml
+++ b/keps/prod-readiness/sig-node/1558.yaml
@@ -1,0 +1,3 @@
+kep-number: 1558
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/1558-streaming-proxy-redirects/README.md
+++ b/keps/sig-node/1558-streaming-proxy-redirects/README.md
@@ -145,11 +145,11 @@ will in turn proxy the connection back to the client.
 3. release **1.20**
    1. `--redirect-container-streaming` can no longer be enabled. If the flag is set, log an error
       and continue as though it is unset.
-4. release **1.21** _(extra safe alternative: 1.22)_
+4. release **1.22** 
    1. Default `StreamingProxyRedirects` to disabled. If there is a >= 2 version skew between master
       and nodes, and the old nodes were enabling `--redirect-container-streaming`, this **will break
       them**. In this case, the `StreamingProxyRedirects` can still be manually enabled.
-5. release **1.22** _(extra safe alternative: 1.24)_
+5. release **1.24**
    1. Remove the `--redirect-container-streaming` flag.
    2. Remove the `StreamingProxyRedirects` feature.
 

--- a/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
+++ b/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
@@ -14,9 +14,10 @@ approvers:
   - "@Random-Liu"
   - "@derekwaynecarr"
 creation-date: 2019-12-05
+last-updated: 2021-05-11
 status: implementable
 replaces:
   - "https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#heading=h.4yfjiw58o8d3"
 
-latest-milestone: "0.0"
-stage: "alpha"
+latest-milestone: "1.22"
+stage: "stable"


### PR DESCRIPTION
part of https://github.com/kubernetes/enhancements/issues/1558

In 1.22 (previously: 1.21) kubernetes/kubernetes#101647 is opened.
> Default StreamingProxyRedirects to disabled. If there is a >= 2 version skew between master
> and nodes, and the old nodes were enabling --redirect-container-streaming, this will break
> them. In this case, the StreamingProxyRedirects can still be manually enabled.
