### PR TITLE
Updating latest-milestone to 1.22 for KEP-536

### DIFF
--- a/keps/sig-network/536-topology-aware-routing/kep.yaml
+++ b/keps/sig-network/536-topology-aware-routing/kep.yaml
@@ -9,6 +9,7 @@ reviewers:
   - "@johnbelamaric"
 approvers:
   - "@thockin"
+latest-milestone: "v1.22"
 creation-date: 2018-10-24
-last-updated: 2021-04-30
+last-updated: 2021-05-12
 status: replaced


### PR DESCRIPTION
This is a follow up to https://github.com/kubernetes/enhancements/issues/536#issuecomment-840054528.

/sig network
/assign @johnbelamaric 