### PR TITLE
deprecate Dynamic Kubelet Config feature

### DIFF
--- a/keps/sig-node/281-dynamic-kubelet-configuration/README.md
+++ b/keps/sig-node/281-dynamic-kubelet-configuration/README.md
@@ -3,14 +3,15 @@
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
 - [Summary](#summary)
+- [Deprecation](#deprecation)
   - [Risks and Mitigations](#risks-and-mitigations)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
-- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+- [Deprecation Readiness Review Questionnaire](#deprecation-readiness-review-questionnaire)
   - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
-  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Rollout, Upgrade, and Rollback Planning](#rollout-upgrade-and-rollback-planning)
   - [Monitoring Requirements](#monitoring-requirements)
   - [Dependencies](#dependencies)
   - [Scalability](#scalability)
@@ -30,7 +31,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Design details are appropriately documented
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [X] (R) Graduation criteria is in place
-- [ ] (R) Production readiness review completed
+- [X] (R) Production readiness review completed
 - [ ] Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
@@ -38,32 +39,66 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 ## Summary
 
-Dynamic Kubelet Configuration allows a new Kubelet configurations to be rolled out in a live cluster.
+Dynamic Kubelet Configuration allows a new Kubelet configurations to be rolled
+out in a live cluster.
 
 The feature predates the KEP process as it is defined today. Please find
 motivation, goals, and design section in [community repository](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/dynamic-kubelet-configuration.md).
 
+Dynamic Kubelet Configuration feature is deprecated at the version v1.22 due to
+lack of interest in promoting it to stable. See [Deprecation](#deprecation).
+
+## Deprecation
+
+Dynamic Kubelet Configuration feature was promoted to beta in [v1.11, 3 July 2018](https://kubernetes.io/blog/2018/06/27/kubernetes-1.11-release-announcement).
+As per the [Avoiding Permanent Beta](https://kubernetes.io/blog/2020/08/21/moving-forward-from-beta/#avoiding-permanent-beta)
+policy this feature is marked for deprecation as there were no interest expressed to
+promote the feature to stable. Removal of Dynamic Kubelet Configuration logic will
+simplify code and improve code reliability.
+
 ### Risks and Mitigations
 
-TODO for the feature deprecation effort
+The deprecation announcement may uncover wide feature usage.
+So far only one complain [was expressed](https://github.com/kubernetes/enhancements/issues/281#issuecomment-695751859).
+
+Mitigation is to suggest adoption of alternative solutions for
+configuration management. Since the feature existed for many releases,
+deprecation period may be prolonged comparing to the obligated one release
+as documented in [Rule #5b](https://kubernetes.io/docs/reference/using-api/deprecation-policy/#:~:text=rule%20%235b%3A)
+of the deprecation policy.
 
 ### Test Plan
 
-TODO for the feature deprecation effort
+All tests will be running while the feature is marked as deprecated.
 
 ### Graduation Criteria
 
-TODO for the feature deprecation effort
+Graduation criteria for Dynamic Kubelet Config was to receive feedback on
+feature usage and shortcomings and address those before promoting it to stable.
+So far the big feedback is that the feature needs to be expanded to provide
+better reliability promises and allow to restrict the set of configuration
+options available for change. Some Kubernetes vendors already using alternative
+solutions for Kubelet Configuration distribution and update.
+
+Since graduation criteria wasn't met for many releases, the feature is marked for
+deprecation.
+
+Note, there will be a separate update of this doc when feature will be marked
+for removal.
 
 ### Upgrade / Downgrade Strategy
 
-TODO for the feature deprecation effort
+Not applicable for deprecation.
 
 ### Version Skew Strategy
 
-TODO for the feature deprecation effort
+N/A
 
-## Production Readiness Review Questionnaire
+TODO: Section is to be updated once feature is scheduled for removal.
+
+## Deprecation Readiness Review Questionnaire
+
+Note, this is **deprecation** readiness questionnaire.
 
 ### Feature Enablement and Rollback
 
@@ -71,116 +106,134 @@ _This section must be completed when targeting alpha to a release._
 
 * **How can this feature be enabled / disabled in a live cluster?**
 
-TODO for the feature deprecation effort
+Feature will be marked as deprecated and deprecated warnings will be displayed.
 
 * **Does enabling the feature change any default behavior?**
 
-TODO for the feature deprecation effort
+Deprecated warnings will be shown when the feature is being used.
 
 * **Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?**
 
-TODO for the feature deprecation effort
+There is a slight chance the feature will be un-deprecated if it will
+find an owner committed to it.
 
 * **What happens if we reenable the feature if it was previously rolled back?**
 
-TODO for the feature deprecation effort
+N/A
+
+TODO: Section is to be updated once feature is scheduled for removal.
 
 * **Are there any tests for feature enablement/disablement?**
 
-TODO for the feature deprecation effort
+There will be no tests for the deprecation warnings.
 
-### Rollout, Upgrade and Rollback Planning
+TODO: Section is to be updated once feature is scheduled for removal.
+
+### Rollout, Upgrade, and Rollback Planning
 
 * **How can a rollout fail? Can it impact already running workloads?**
 
-TODO for the feature deprecation effort
+No, feature deprecation will not impact any workload. 
+
+TODO: Section is to be updated once feature is scheduled for removal.
 
 * **What specific metrics should inform a rollback?**
 
-TODO for the feature deprecation effort
+TODO: Section is to be updated once feature is scheduled for removal.
 
 * **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
 
-TODO for the feature deprecation effort
+TODO: Section is to be updated once feature is scheduled for removal.
 
 ### Monitoring Requirements
 
 * **How can an operator determine if the feature is in use by workloads?**
 
-TODO for the feature deprecation effort
+Deprecated warnings will be displayed for the operator to learn about deprecation.
+
+Operator can also track metrics that report the assigned (node_config_assigned),
+last-known-good (node_config_last_known_good), and active (node_config_active)
+config sources. Metrics will indicate that the feature is in use and the migration
+effort needs to be scheduled.
 
 * **What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?**
 
-TODO for the feature deprecation effort
+TODO: Section is to be updated once feature is scheduled for removal.
 
 * **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
 
-TODO for the feature deprecation effort
+TODO: Section is to be updated once feature is scheduled for removal.
 
 * **Are there any missing metrics that would be useful to have to improve observability of this feature?**
 
-TODO for the feature deprecation effort
+TODO: Section is to be updated once feature is scheduled for removal.
 
 ### Dependencies
 
 * **Does this feature depend on any specific services running in the cluster?**
 
-TODO for the feature deprecation effort
+No
 
 ### Scalability
 
 * **Will enabling / using this feature result in any new API calls?**
 
-TODO for the feature deprecation effort
+No
 
 * **Will enabling / using this feature result in introducing new API types?**
 
-TODO for the feature deprecation effort
+No
+
+TODO: Section is to be updated once feature is scheduled for removal.
 
 * **Will enabling / using this feature result in any new calls to the cloud provider?**
 
-TODO for the feature deprecation effort
+No
 
 * **Will enabling / using this feature result in increasing size or count of the existing API objects?**
 
-TODO for the feature deprecation effort
+No
 
 * **Will enabling / using this feature result in increasing time taken by any operations covered by [existing SLIs/SLOs]?**
 
-TODO for the feature deprecation effort
+No
 
 * **Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?**
 
-TODO for the feature deprecation effort
+No
 
 ### Troubleshooting
 
 * **How does this feature react if the API server and/or etcd is unavailable?**
 
-TODO for the feature deprecation effort
+N/A
 
 * **What are other known failure modes?**
 
-TODO for the feature deprecation effort
+None
 
 * **What steps should be taken if SLOs are not being met to determine the problem?**
 
-TODO for the feature deprecation effort
+N/A
 
 ## Implementation History
 
 - 1.8 Alpha release
 - 1.9 Incremental improvements working towards 1.10 goals
 - 1.11 Beta release
+- 1.21 Feature is marked for deprecation
 
 ## Drawbacks
 
-TODO for the feature deprecation effort
+The biggest drawback of feature deprecation is potential use of the feature.
 
 ## Alternatives
 
-TODO for the feature deprecation effort
+Alternatives for Dynamic Kubelet Configuration feature is a solution that updates
+kubelet configuration file and restarts kubelet which is preferred solution as it
+increases kubelet reliability and simplifies it's code. While allowing extra features
+for kubelet configuring be implemented faster and specific to the kubernetes environment.
 
 ## Infrastructure Needed (Optional)
 
-TODO for the feature deprecation effort
+None

--- a/keps/sig-node/281-dynamic-kubelet-configuration/kep.yaml
+++ b/keps/sig-node/281-dynamic-kubelet-configuration/kep.yaml
@@ -16,23 +16,25 @@ approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
 prr-approvers:
-  - "TODO"
+  - "@johnbelamaric"
 see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: beta (deprecated)
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.11"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.8"
   beta: "v1.11"
-  stable:
+  stable: "never"
+  deprecated: "v1.22"
+  removed: "v1.24"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
I didn't find a good guidance for features deprecation. 

This first update is for deprecation. I think it will be a good idea to update the  PRR-like questionnaire once we will decide to move on with the feature removal. So I left some TODOs in the questions.

/assign @johnbelamaric
/assign @dchen1107 
/sig node
/cc @xlgao-zju
/kind deprecation