### PR TITLE
Change populators stage back to alpha

### DIFF
--- a/keps/prod-readiness/sig-storage/1495.yaml
+++ b/keps/prod-readiness/sig-storage/1495.yaml
@@ -1,3 +1,3 @@
 kep-number: 1495
-beta:
+alpha:
   approver: "@deads2k"

--- a/keps/sig-storage/1495-volume-populators/README.md
+++ b/keps/sig-storage/1495-volume-populators/README.md
@@ -133,8 +133,8 @@ Introduce a new field on PVCs called `DataSourceRef`. This new field operates li
 `DataSource` except that it never ignores input -- contents are always accepted or the
 entire PVC is rejected if the contents are deemed invalid.
 
-Deprecate the `DataSource` field, but continue to support it in a backwards-compatible
-way. In particular:
+Deprecate the `DataSource` field once `DataSourceRef` reaches GA, but continue to
+support it in a backwards-compatible way, never removing it. In particular:
 
 1. If `DataSource` and `DataSourceRef` are both unset; accept
 1. If `DataSource` is set valid (PVC or VolumeSnapshot) AND `DataSourceRef` is not set;
@@ -550,7 +550,7 @@ resource usage (CPU, RAM, disk, IO, ...) in any components?**
 - KEP updated to new format September 2020
 - Webhook replaced with controller in December 2020
 - KEP updated Feb 2021 for v1.21
-- Resign with new `DataSourceRef` field in May 2021 for v1.22, still alpha
+- Redesign with new `DataSourceRef` field in May 2021 for v1.22, still alpha
 
 ## Alternatives
 

--- a/keps/sig-storage/1495-volume-populators/kep.yaml
+++ b/keps/sig-storage/1495-volume-populators/kep.yaml
@@ -20,7 +20,7 @@ prr-approvers:
   - "@deads2k"
 replaces:
   - "/keps/sig-storage/20200120-generic-data-populators.md"
-stage: beta
+stage: alpha
 latest-milestone: "v1.22"
 milestone:
   alpha: "v1.18"


### PR DESCRIPTION
This feature was planned to go to beta, but API review required another API change that required the feature to stay alpha. The KEP was updated, but the change to the stage field in key.yaml was overlooked.
