### PR TITLE
[1.24] update deprecated status of streaming proxy redirects

### DIFF
--- a/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
+++ b/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
@@ -19,6 +19,7 @@ status: implementable
 replaces:
   - "https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#heading=h.4yfjiw58o8d3"
 latest-milestone: "1.22"
+stage: beta (deprecated)
 milestone:
   alpha: "v1.5"
   beta: "v1.6"

--- a/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
+++ b/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
@@ -18,6 +18,10 @@ last-updated: 2021-05-11
 status: implementable
 replaces:
   - "https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#heading=h.4yfjiw58o8d3"
-
 latest-milestone: "1.22"
-stage: "stable"
+milestone:
+  alpha: "v1.5"
+  beta: "v1.6"
+  stable: "never"
+  deprecated: "v1.18"
+  removed: "v1.24"


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/pull/2707#discussion_r632009329

> This should not say stable, as it's a deprecation. I think Sergey set it to beta (deprecated) in another PR.

The feature  is deprecated but set to true by default since v1.18 and we set the default to false in 1.22 only.
```
milestone:
  alpha: "v1.5"
  beta: "v1.6"
  stable: "never"
  deprecated: "v1.18"
  removed: "v1.24"
```