### PR TITLE
Kustomize KEP cleanup

### DIFF
--- a/keps/sig-cli/1802-kustomize-components/README.md
+++ b/keps/sig-cli/1802-kustomize-components/README.md
@@ -605,9 +605,9 @@ Add unit tests for all the points raised in the "Design details" section.
 
 #### Alpha -> Beta
 
-- [ ] Implement the necessary functionality for this feature
-- [ ] Write the appropriate unit tests, and make the
-  [`TestComplexComposition_*`] tests now pass
+- [x] Implement the necessary functionality for this feature
+- [x] Write the appropriate unit tests, and make the
+  [`TestComplexComposition_*`](https://github.com/kubernetes-sigs/kustomize/blob/701973b73ecfb2b96f53cb3f080b9caaa662a01f/api/krusty/complexcomposition_test.go) tests now pass
 - [x] Add a [user story] in Kustomize's examples
 - [ ] Extend Kustomize's glossary with a reference to components, as well as
       other places where overlays are mentioned
@@ -618,6 +618,8 @@ Add unit tests for all the points raised in the "Design details" section.
 [user story]: https://github.com/kubernetes-sigs/kustomize/pull/2438
 
 ## Implementation History
+
+- Available in Kustomize's alpha API group (`kustomize.config.k8s.io/v1alpha1`) in v3.7.0+. https://kubectl.docs.kubernetes.io/guides/config_management/components/
 
 ## Alternatives
 

--- a/keps/sig-cli/1802-kustomize-components/kep.yaml
+++ b/keps/sig-cli/1802-kustomize-components/kep.yaml
@@ -8,15 +8,13 @@ owning-sig: sig-cli
 participating-sigs:
   - sig-cli
 reviewers:
-  - n/a
+  - "@pwittrock"
+  - "@monopole"
 approvers:
-  - n/a
+  - "@pwittrock"
+  - "@monopole"
 creation-date: 2020-05-20
 last-updated: 2020-05-20
-status: provisional
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
+status: implemented
+stage: alpha
+latest-milestone: "v1.19"

--- a/keps/sig-cli/2206-openapi-features-in-kustomize/README.md
+++ b/keps/sig-cli/2206-openapi-features-in-kustomize/README.md
@@ -435,11 +435,11 @@ Below are some examples to consider, in addition to the aforementioned [maturity
 
 #### Alpha -> Beta Graduation
 
-- Complete features required for this functionality
-- read schema from openapi field of kustomization
-- kustomize openapi fetch command
-- Write appropriate unit tests for the above features
-- Add documentation for these features 
+- [x] Complete features required for this functionality
+- [x] Read schema from openapi field of kustomization
+- [x] kustomize openapi fetch command
+- [x] Write appropriate unit tests for the above features
+- [x] Add documentation for these features 
 
 
 <!--
@@ -467,5 +467,7 @@ Major milestones might include:
 - the version of Kubernetes where the KEP graduated to general availability
 - when the KEP was retired or superseded
 -->
+
+- The `openapi` field is available in Kustomization as of kustomize [v4.1.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.1.0)
 
 

--- a/keps/sig-cli/2206-openapi-features-in-kustomize/kep.yaml
+++ b/keps/sig-cli/2206-openapi-features-in-kustomize/kep.yaml
@@ -9,16 +9,11 @@ reviewers:
   - "@monopole"
   - "@pwittrock"
 approvers:
-  - n/a
+  - "@monopole"
+  - "@pwittrock"
 creation-date: 2020-12-21
 last-updated: 2020-01-15
-status: implementable
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
+status: implemented
 
-latest-milestone: "0.0"
-stage: "alpha"
+latest-milestone: "1.22"
+stage: "beta"

--- a/keps/sig-cli/2299-kustomize-plugin-composition/kep.yaml
+++ b/keps/sig-cli/2299-kustomize-plugin-composition/kep.yaml
@@ -14,5 +14,7 @@ reviewers:
 approvers:
   - "@monopole"
   - "@pwittrock"
+see-also:
+- "/keps/sig-cli/993-kustomize-generators-transformers"
 stage: alpha
 latest-milestone: "v1.22"

--- a/keps/sig-cli/2377-Kustomize/README.md
+++ b/keps/sig-cli/2377-Kustomize/README.md
@@ -194,7 +194,7 @@ better work with one another through transformation to a common format.
 ## Implementation History
 
 kustomize was implemented in the kubectl repo before subprojects became a first class thing in Kubernetes.
-The code has been fully implemented, but it must be moved to a proper location.
+It was later moved to its own repo: https://github.com/kubernetes-sigs/kustomize. It is published as an independent CLI, and `kustomize build` is also available as `kubectl kustomize`. Some kubectl subcommands (e.g. apply) support Kustomization input via the `-k` flag.
 
 ## Drawbacks
 

--- a/keps/sig-cli/2383-extend-kustomize-patches-to-multiple-targets/README.md
+++ b/keps/sig-cli/2383-extend-kustomize-patches-to-multiple-targets/README.md
@@ -159,9 +159,11 @@ Update Kustomize and Kubectl docs with this new capability.
 Unit test matching Resources and performing customizations.
 
 ## Implementation History
-- Add `Patch` struct in `Kustomization` type.
-- Update the patching transformer to recognize `Patch` and match
+- [x] Add `Patch` struct in `Kustomization` type.
+- [x] Update the patching transformer to recognize `Patch` and match
   multiple resources
-- Add unit test and integration test
+- [x] Add unit test and integration test
+
+This feature was released in [v3.1.0](https://kubernetes-sigs.github.io/kustomize/blog/2019/07/26/v3.1.0/) of kustomize. 
 
 ## Alternatives

--- a/keps/sig-cli/2383-extend-kustomize-patches-to-multiple-targets/kep.yaml
+++ b/keps/sig-cli/2383-extend-kustomize-patches-to-multiple-targets/kep.yaml
@@ -13,11 +13,6 @@ approvers:
 editor: "@Liujingfang1"
 creation-date: 2019-03-14
 last-updated: 2019-03-18
-status: implementable
-see-also:
-replaces:
-superseded-by:
- - n/a
-
-latest-milestone: "0.0"
-stage: "alpha"
+status: implemented
+latest-milestone: "1.16"
+stage: "beta"

--- a/keps/sig-cli/993-kustomize-generators-transformers/README.md
+++ b/keps/sig-cli/993-kustomize-generators-transformers/README.md
@@ -404,6 +404,7 @@ NA - Client side only
 
 ## Implementation History
 
+- Alpha available in Kustomize (standalone binary, not kubectl kustomize) v2.1.0+ behind the `--enable-alpha-plugins` flag. https://kubectl.docs.kubernetes.io/blog/2019/06/18/v2.1.0/#generator-and-transformer-plugins
 
 ## Drawbacks [optional]
 

--- a/keps/sig-cli/993-kustomize-generators-transformers/kep.yaml
+++ b/keps/sig-cli/993-kustomize-generators-transformers/kep.yaml
@@ -9,9 +9,10 @@ reviewers:
   - "@sethpollack"
 approvers:
   - "@monopole"
-editor: TBD
+see-also:
+  - "/keps/sig-cli/2299-kustomize-plugin-composition"
 creation-date: 2019-03-25
 last-updated: 2019-04-30
-status: implementable
+status: implemented
 latest-milestone: "1.20"
 stage: "alpha"


### PR DESCRIPTION
This PR updates the KEP metadata and implementation history for several Kustomize-related KEPs that have already been implemented (alpha or beta).

Where the latest-milestone field was set to zero but the implementation has already merged, I looked up which Kubernetes release cycle it merged in. LMK if that's not the right thing to do.

I used the following heuristic for "stage": If it is behind an alpha flag, it's alpha. If it's a KRM resource or field therein, use the resource's version (i.e. beta for Kustomization and alpha for Component).


I'll make similar updates to the tracking issues. Here's what I think we should do for each after it is updated:
- #993 (tranformers/generators): still in alpha, leave open. To be closed when replaced with a beta graduation KEP, which I intend to work on soon.
- #2206 (openapi): close as complete
- #2299 (Composition): leave open.
- #2377 (original Kustomize KEP): close as complete
- #2383 (patches field): close as complete

/cc @eddiezane @monopole @natasha41575 