### PR TITLE
WIP: Catch up Fair Queuing description with past and present

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -21,19 +21,26 @@
   - [Queuing](#queuing)
   - [Dispatching](#dispatching)
   - [Fair Queuing for Server Requests problem statement](#fair-queuing-for-server-requests-problem-statement)
-  - [Fair Queuing for Server Requests, with equal allocations](#fair-queuing-for-server-requests-with-equal-allocations)
-    - [Fair Queuing for Server Requests, with equal allocations, initial definition](#fair-queuing-for-server-requests-with-equal-allocations-initial-definition)
-    - [Fair Queuing for Server Requests, with equal allocations, intended behavior](#fair-queuing-for-server-requests-with-equal-allocations-intended-behavior)
-    - [Implementation of Fair Queuing for Server Requests with equal allocations, technique and problems](#implementation-of-fair-queuing-for-server-requests-with-equal-allocations-technique-and-problems)
-  - [Fair Queuing for Server Requests, with max-min fairness](#fair-queuing-for-server-requests-with-max-min-fairness)
-    - [Fair Queuing for Server Requests, with max-min fairness, behavior](#fair-queuing-for-server-requests-with-max-min-fairness-behavior)
-  - [More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness](#more-or-less-efficient-implementation-of-fair-queuing-for-server-requests-with-max-min-fairness)
+  - [Fair Queuing for Server Requests, with equal allocations and serial virtual execution](#fair-queuing-for-server-requests-with-equal-allocations-and-serial-virtual-execution)
+    - [Fair Queuing for Server Requests, with equal allocations and serial virtual execution, initial definition](#fair-queuing-for-server-requests-with-equal-allocations-and-serial-virtual-execution-initial-definition)
+    - [Fair Queuing for Server Requests, with equal allocations and serial virtual execution, intended behavior](#fair-queuing-for-server-requests-with-equal-allocations-and-serial-virtual-execution-intended-behavior)
+    - [Implementation of Fair Queuing for Server Requests with equal allocations and serial execution, technique and problems](#implementation-of-fair-queuing-for-server-requests-with-equal-allocations-and-serial-execution-technique-and-problems)
+  - [Fair Queuing for Server Requests, with max-min fairness and serial virtual execution](#fair-queuing-for-server-requests-with-max-min-fairness-and-serial-virtual-execution)
+    - [Fair Queuing for Server Requests, with max-min fairness and serial virtual execution, behavior](#fair-queuing-for-server-requests-with-max-min-fairness-and-serial-virtual-execution-behavior)
+  - [More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness and serial virtual execution](#more-or-less-efficient-implementation-of-fair-queuing-for-server-requests-with-max-min-fairness-and-serial-virtual-execution)
     - [Computing the max-min fair allocation](#computing-the-max-min-fair-allocation)
-    - [Scheduling in the virtual world](#scheduling-in-the-virtual-world)
-      - [Simplest virtual-world scheduling implementation](#simplest-virtual-world-scheduling-implementation)
-      - [Simplest correct virtual-world scheduling implementation](#simplest-correct-virtual-world-scheduling-implementation)
-      - [Sorted executing requests](#sorted-executing-requests)
-      - [Sorted queues](#sorted-queues)
+    - [Serial scheduling in the virtual world](#serial-scheduling-in-the-virtual-world)
+      - [Simplest virtual-world serial scheduling implementation](#simplest-virtual-world-serial-scheduling-implementation)
+      - [Sorted queues with serial executing requests](#sorted-queues-with-serial-executing-requests)
+  - [Fair Queuing for Server Requests, with max-min fairness and concurrent virtual execution](#fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution)
+    - [Fair Queuing for Server Requests, with max-min fairness and concurrent virtual execution, behavior](#fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution-behavior)
+  - [More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness and concurrent virtual execution](#more-or-less-efficient-implementation-of-fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution)
+    - [Computing the max-min fair allocation](#computing-the-max-min-fair-allocation-1)
+    - [Concurrent scheduling in the virtual world](#concurrent-scheduling-in-the-virtual-world)
+      - [Simplest virtual-world concurrent scheduling implementation](#simplest-virtual-world-concurrent-scheduling-implementation)
+      - [Simplest correct virtual-world concurrent scheduling implementation](#simplest-correct-virtual-world-concurrent-scheduling-implementation)
+      - [Sorted concurrent executing requests](#sorted-concurrent-executing-requests)
+      - [Sorted queues with concurrent executing requests](#sorted-queues-with-concurrent-executing-requests)
     - [Picking the next request to dispatch in the real world](#picking-the-next-request-to-dispatch-in-the-real-world)
   - [Derivation of Fair Queuing for Server Requests](#derivation-of-fair-queuing-for-server-requests)
     - [The original story](#the-original-story)
@@ -705,13 +712,20 @@ The Fair Queuing for Server Requests problem is as follows.
   return from the request handler, but _does_ extend the time that the
   request's seats are considered to be occupied.
 
-### Fair Queuing for Server Requests, with equal allocations
+### Fair Queuing for Server Requests, with equal allocations and serial virtual execution
 
-The is the technique currently used.  The following subsections cover:
-(a) the original KEP text used to create the initial implementation
-(which lacked generalizations for request width and extra latency),
-(b) equations that describe the intended behavior, and (c)
-implementation difficulties (solved and unsolved).
+The is the technique currently used.  It occupies one of four
+quadrants defined by two binary characteristics:
+- whether the allocations of concurrency are equal or max-min fair,
+  and
+- whether a non-empty queue has exactly one or many requests executing
+  at a time in the virtual world.
+
+The following subsections cover: (a) the original KEP text used to
+create the initial implementation (which lacked generalizations for
+request width and extra latency), (b) equations that describe the
+intended behavior, and (c) implementation difficulties (solved and
+unsolved).
 
 After all that is a presentation of a solution for truly fair queuing,
 with max-min fairness.  There is also a confounding difference: the
@@ -720,7 +734,7 @@ queue running only one request at a time while the max-min fair
 solution allows a queue to run concurrent requests in the virtual
 world.  These are two corners of a quad of possible approaches.
 
-#### Fair Queuing for Server Requests, with equal allocations, initial definition
+#### Fair Queuing for Server Requests, with equal allocations and serial virtual execution, initial definition
 
 Following is the design that motivated the code as it existed just
 before we started adding the concepts of width and extra latency.
@@ -807,7 +821,7 @@ service the queue’s virtual start time is advanced by G.  When a
 request finishes being served, and the actual service time was S, the
 queue’s virtual start time is decremented by G - S.
 
-#### Fair Queuing for Server Requests, with equal allocations, intended behavior
+#### Fair Queuing for Server Requests, with equal allocations and serial virtual execution, intended behavior
 
 Here is a succinct summary of behavior intended to solve the Fair
 Queuing for Server Requests problem but with equal allocations instead
@@ -885,10 +899,10 @@ world.  Thus, `NOS(i,t) = width(i,j)` for that relevant `j` whenever
 there is one.  Since `mu_equal(t)` can be greater or less than
 `width(i,j)`, `rate(i,t)` can be greater or less than 1.
 
-We use the above policy and rate and the concurrency limit to define
-the schedule in the virtual world.  The scheduling is thus done with
-almost no interactions between queues.  The interactions are limited
-to updating the `mu` allocations whenever the `rho` requests change.
+We use the above policy and rate to define the schedule in the virtual
+world.  The scheduling is thus done with almost no interactions
+between queues.  The interactions are limited to updating the `mu`
+allocations whenever the `rho` requests change.
 
 To make the scheduling technically easy to speccify, we suppose that
 no two requests arrive at the same time.  The implementation will be
@@ -949,7 +963,7 @@ as soon as allowed by that ordering, the concurrency bound in the
 problem statement, and of course not dispatching before arrival.
 
 
-#### Implementation of Fair Queuing for Server Requests with equal allocations, technique and problems
+#### Implementation of Fair Queuing for Server Requests with equal allocations and serial execution, technique and problems
 
 One of the key implementation ideas is taken from the original paper.
 Define a global meter of progress named `R`, and characterize each
@@ -1059,12 +1073,444 @@ Other queueus may accumulate a corresponding deficit (inappropriately
 large values for `B` and `E`).  Such a queue can have an arbitrarily
 long burst of inappropriate lossage to other queues.
 
-### Fair Queuing for Server Requests, with max-min fairness
+### Fair Queuing for Server Requests, with max-min fairness and serial virtual execution
 
-This is based on fair queuing but is modified to deal with serving
-requests in an apiserver instead of transmitting packets in a router.
+In this quadrant we achieve max-min fairness and a non-empty queue has
+exactly one request executing at a given time in the virtual world.
 
-#### Fair Queuing for Server Requests, with max-min fairness, behavior
+#### Fair Queuing for Server Requests, with max-min fairness and serial virtual execution, behavior
+
+The following behavior solves the problem.
+
+We imagine a virtual world in which request executions are scheduled
+(queued and executed) differently than in the real world.  In the
+virtual world, requests are generally executed with more or less
+concurrency than in the real world and with infinitesimal
+interleaving.
+
+The virtual world uses the same clock as the real world.
+
+Define the following.
+
+- `len(i,j)` is the execution duration for request `(i,j)` in the real
+  world, including `Y(i,j)`.  At first `len` is only a guess.  When
+  the real execution duration is eventually learned, `len` gets
+  updated with that information.
+
+- `B(i,j)` is the time when request `(i,j)` beings execution in the
+  virtual world.
+
+- `E(i,j)` is the time when request `(i,j)` ends execution in the
+  virtual world (this includes completion of `Y(i,j)`).  This is _not_
+  simply `B` plus `len` because requests generally execute at a
+  different rate in the two worlds.
+
+- `NOS(i,t)` is the Number of Occupied Seats by queue `i` at time `t`;
+  this is `Sum[over j such that B(i,j) <= t < E(i,j)] width(i,j)`.
+
+- `SAQ(t)` is the Set of Active Queues at time `t`: those `i` for
+  which there is a `j` such that `t_arrive(i,j) <= t < E(i,j)`.
+
+- `NEQ(t)` is the number of Non-Empty Queues at time `t`; it is the
+  number of queues in `SAQ(t)`.
+
+At time `t`, queue `i` is requesting `rho(i,t)` concurrency in the
+virtual world.  This is the sum of the widths of the requests that
+have arrived but not yet finished executing.
+
+```
+rho(i,t) = Sum[over j such that t_arrive(i,j) <= t < E(i,j)] width(i,j)
+```
+
+The allocations of concurrency are written as `mu(i,t)` seats for
+queue `i` at time `t`.  These allocations are max-min fair when
+
+```
+mu(i,t) = min(rho(i,t), mu_fair(t))
+```
+
+and `mu_fair(t)` is the minimum non-negative value that solves the
+equation
+
+```
+min(C, Sum[over i] rho(i,t)) = Sum[over i] min(rho(i,t), mu_fair(t))
+```
+
+In English: every queue gets what it wants if that adds up to no more
+than `C`, otherwise queues that request less than the `mu_fair`
+solution get all that they ask for and each of the others gets
+`mu_fair`.
+
+Each non-empty queue divides its allocated concurrency `mu` evenly
+among the seats it occupies in the virtual world, so that the
+aggregate rate work gets done on all the queue's seats is `mu`.
+
+```
+rate(i,t) = if NOS(i,t) > 0 then mu(i,t) / NOS(i,t) else 0
+```
+
+In this design, a queue executes one request at a time in the virtual
+world.  Thus, `NOS(i,t) = width(i,j)` for that relevant `j` whenever
+there is one.  Since `mu(i,t)` can be greater or less than
+`width(i,j)`, `rate(i,t)` can be greater or less than 1.
+
+We use the above policy and rate to define the schedule in the virtual
+world.  The scheduling is thus done with almost no interactions
+between queues.  The interactions are limited to updating the `mu`
+allocations whenever the `rho` requests change.
+
+To make the scheduling technically easy to speccify, we suppose that
+no two requests arrive at the same time.  The implementation will be
+serialized anyway, so this is no real restriction.
+
+```
+B(i,j) = if j = 0 or E(i,j-1) <= t_arrive(i,j)
+         then t_arrive(i,j)
+         else E(i,j-1)
+```
+
+That is, a newly arrived request is dispatched immediately if the
+queue had nothing executing otherwise the new request waits until all
+of the queue's earlier requests finish.  Note that the concurrency
+limit used here is different from the real world: a queue is allowed
+to run one request at a time, regardless of how many it has waiting to
+run and regardless of the server's concurrency limit `C`.  The
+independent virtual-world scheduling for each queue helps enable
+efficient implementations.
+
+The end of a request's virtual execution (`E(i,j)`) is the solution to
+the following equation.
+
+```
+Integral[from tau=B(i,j) to tau=E(i,j)] rate(i,tau) dtau = len(i,j)
+```
+
+That is, each of a queue's requests is executed in the virtual world
+at the aforementioned `rate`.  Before the real completion, `len` is
+only a guess.
+
+For a given request `(i,j)`, the initial guess at its execution
+duration is the sum of `Y(i,j)` and what the request context says is
+the available remaining time for serving the request.  If and whenever
+the passage of time later proves the current guessed `len` to be too
+small then it is increased by adding `G`.  That is the server's
+configured default request service time limit.
+
+Once a request `(i,j)` finishes executing in the real world, its
+actual execution duration is known and `len` gets set to that plus
+`Y(i,j)`.  This changes not only `E(i,j)` but also the `B` and `E` of
+the all the queue's requests that arrived between `t_arrive(i,j)` and
+the next of the queue's idle times.  Note that this can change
+`rho(i,t)` and thus `mu_equal(t)` at those intervening times, and thus
+the subsequent scheduling in other queues.  The computation of these
+changes can not happen until `(i,j)` finishes executing in the real
+world (which is `t_arrive(i,j) + len(i,j)`) --- but the request might
+finish much sooner in the virtual world.  We can have `E(i,j) <
+t_arrive(i,j) + len(i,j)` because of `rate` being greater than 1.  An
+accurate implementation would keep track of enough historical
+information to revise all that scheduling.
+
+The order of request dispatches in the real world is taken to be the
+order of request completions in the virtual world.  In the case of
+ties, round robin ordering is used starting from the queue that most
+closely follows the one last dispatched from.  Requests are dispatched
+as soon as allowed by that ordering, the concurrency bound in the
+problem statement, and of course not dispatching before arrival.
+
+### More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness and serial virtual execution
+
+We consider three issues in turn: (1) computing the max-min fair
+allocation for a given set of demands, (2) scheduling in the virtual
+world, and (3) picking the next request to execute in the real world.
+
+#### Computing the max-min fair allocation
+
+A single instance of the problem of finding the max-min fair
+allocations `mu(i,t1)` given capacity `C` and demands `rho(i,t1)`, for
+indices `0 <= i < N`, can be solved in `O(N log N)` time.  This is
+done by first sorting the indices according to increasing `rho`, then
+making one pass over the sorted indices to find the boundary between
+the demands that are fully met and those that are not.
+
+Fair Queuing for Server Requests is an on-line problem, and as such
+presents a series of max-min fair allocation problems --- each
+differing from the previous by a change in the demand of one queue.
+Thus we can use an incremental algorithm to solve each new instance
+based on the previous one, as follows.
+
+- Keep the queues in a data structure sorted by increasing `rho`.  Let
+  us say this is a permutation `RI`.  That is, at any given moment
+  `t`, `rho(RI(j),t) <= rho(RI(k),t)` for every `0 <= j < k < N`.
+  Also maintain the inverse permutation `IR` --- that is, `IR(RI(i)) =
+  i` for every `0 <= i < N`.
+
+- Maintain the sort index `L` of the first sorted queue that is
+  limited (does not get all it demands).  That is, `L` is the smallest
+  non-negative integer with the property that `mu(RI(j),t) <
+  rho(RI(j),t)` for all `j` such that `j >= L` and `j < N`.  Sort
+  index `L` can be as small as 0 (when no queue gets its full demand)
+  and as large as `N` (when every queue gets its full demand).
+
+- Maintain the quantity `CL = Sum[over j < L] rho(RI(j),t) * (N-j)`.
+  This is the capacity usage implied by all the fully granted demands,
+  including the implication that the queues with higher demands get at
+  least the highest fully granted demand.
+
+- The above imply that when `L < N`, `L` has the property that making
+  it one bigger would blow `CL` past the bound `C`: `CL +
+  rho(RI(L),t) * (N-L) > C`.
+
+- Given the above, `mu_fair(t)` is:
+
+  - `C / N` if `L = 0`
+  
+  - `rho(RI(L-1),t) + (C - CL) / (N - L)` if `0 < L < N`
+
+  - `rho(RI(N-1),t)` if `L = N`.
+
+The permutation `RI` and its inverse can be implemented in such a way
+that every operation we invoke on them costs no more than `O(log N)`
+time.  For example, use a [https://github.com/wangjia184/sortedset]
+where the keys are stringified `i` and the scores are `rho(i,t)`,
+making the rank for `i` be `IR(i) + 1` and thus
+`GetByRank(j+1,false).Score()` implements `rho(RI(j),t)`.
+
+With that representation, the time complexity of solving the next
+instance of the max-min fair allocation problem is `O((1 + N_Delta) *
+log N)` where `N_Delta` is the number of queues that cross the
+boundary.  Note that while the system stays out of overload, `N_Delta`
+is zero.  It also stays zero while the system stays overloaded by the
+same set of queues.
+
+#### Serial scheduling in the virtual world
+
+Next consider the problem of scheduling in the virtual world.  This is
+a matter of computing the `B` and `E` values in the virtual world.
+This is an on-line problem, and the relevant input events that come in
+from the real world are:
+- arrival of a request into a queue,
+- completion of execution of a request in the real world (causing an
+  update to its `len`), and
+- ejecting a request that, in the real world, is waiting in a queue
+  (in the virtual world this request could be waiting or executing).
+
+Requests get dispatched in the virtual world at the same moment when
+some request completes in the virtual world.  Note that a request's
+completion in the virtual world is a function of the fictitious
+execution schedule in the that world and so generally does _not_
+correspond in time with any real world event.
+
+Note also that aside from the cases where a request starts running as
+soon as it arrives, the implementation is dealing with estimates of
+what will happen in the future.  These estimates are made under the
+assumption that nothing else will change from now to then, and later
+updated as more information comes in.  Sadly, sometimes relevant
+information comes in after it was first needed.  [TODO: summarize
+coping better.]
+
+##### Simplest virtual-world serial scheduling implementation
+
+A queue has a linked list of requests.  When a request arrives, it is
+appended to the end of the list.  At some point, that request is
+dispatched in the real world.  Once the request completes in the real
+world, it is deleted from the linked list.
+
+We would not want to maintain the `B` and `E` value of every request
+known at the moment, because: (a) they are not all needed yet and (b)
+the `B` and `E` of waiting requests can change whenever the `len` of
+an executing request changes.  However, to support picking the next
+request to dispatch in the real world, it is necessary to maintain an
+efficient representation of the current estimated `E` of each queue's
+oldest request that is waiting in the real world --- for queues that
+have such a request.  Let us call that request `j_next(i)`, and name
+its estimated `E` as `nextEE(i)`.
+
+To maintain and incrementally update the `E` estimates in the face of
+`rate` varying over the course of a request's execution, it helps to
+define a notion of the "progress" `P(i,t)` that queue `i` has made up
+to time `t`.
+
+```
+P(i,t) = Integral[from tau=epoch(i) to tau=t] rate(i,t) dtau
+```
+
+`P(i,t)` is similar to the `R(t)` meter in the original Fair Queuing
+design but is queue-specific.  This is the amount of work _per seat_
+that has been done by requests dispatched from that queue since an
+arbitrary starting time `epoch(i)`.  This is the meter of progress
+made in the virtual world on serving individual requests from that
+queue.  A request's execution in the virtual world corresponds to a
+fixed interval on this progress meter, independent of how `mu` varies
+over time, as follows.
+
+```
+P(i,E(i,j)) - P(i,B(i,j)) = len(i,j)
+```
+
+Motivated by that, we define the convenient shorthands `PBeg(i,j) =
+P(i,B(i,j))` and `PEnd(i,j) = P(i,E(i,j))`.  The really nice property
+of `PEnd(i,j)` is that it is only set or changed when the request is
+dispatched or its `len` is updated --- changes to the queue's `rate`
+do not affect `PEnd(i,j)`.
+
+We can use `P(i,t)` at time `t` to estimate the future completion time
+`EE(i,j,t)` for request `(i,j)` as follows.
+
+```
+EE(i,j,t) = t + ( PEnd(i,j) - P(i,t) ) / rate(i,t)
+```
+
+Each queue tracks its `j_next` and the corresponding `PBeg`, which we
+call `nextPB`.
+
+```
+nextPB(i) = PBeg(i,j_next(i))
+```
+
+At any given time `t`, there is an `O(1)` compute time computation of
+`nextEE`:
+
+```
+nextEE(i) = t + ( nextPB(i) + len(i,j_next(i)) - P(i,t) ) / rate(i,t)
+```
+
+The simplest implementation explicitly represents each queue's `P`,
+`nextPB`, and `nextEE` and updates them as needed.  Each `rate` change
+is instantaneous, itself having no direct impact on `P` values
+(because they are integrals over time); it is the passage of time that
+requires updating `P` values.  Updating one queue's `P` to account for
+the passage of time during which `mu` and `NOS` did not change costs
+`O(1)` compute time.  After an update to `P` or `rate` (`mu` or `NOS`)
+at time `t`, `nextEE` is recalculated using the equation above.
+
+Reacting to a request arrival, dispatch, completion, ejection, or
+`len` update can be done in the sum of the following amounts of
+compute time.
+
+- `O((1 + N_Delta) * log N)` to compute the new max-min fair
+  allocation,
+
+- `O(1)` to update the directly affected queue,
+
+- `O(N_MuChange)` to update the `mu`, `P`, and `nextEE` of the other
+  affected queues.  Here `N_MuChange` is the number of queues whose
+  `mu` changes.  While the system stays out of overload, each
+  `N_MuChange` is 0 or 1.  If the system stays more-than-just-barely
+  overloaded by the same set of queues, this also limits `N_MuChange`
+  to 0 or 1.  In the worst case, `N_MuChange` is a fraction of `N` ---
+  that is, `O(N)`.  A really simple implementation would simply
+  recompute the `nextEE` of every queue, also taking `O(N)` compute
+  time.
+
+To pick the next request to dispatch in the real world, the simplest
+implementation looks through all the queue to find those with minimal
+`nextEE` and then takes the one that is next in round-robin order.
+
+In summary, the simplest implementation costs `O((1 + N_Delta) * log
+N + N)` compute time per request.
+
+##### Sorted queues with serial executing requests
+
+A more efficient approach is possible, based on using representations
+in which the data structure for a queue does not need to be updated in
+most cases when something happens in a different queue.  This enables
+the queues to be kept sorted according to their next estimated
+completion time.  This is done by dynamically splitting the queues
+into two categories, handling each in its own way, and handling a
+queue moving from one category to another whenever that happens.  To
+find the next-completing request among all the queues, we first find
+the next-completing request from each non-empty category of queues and
+then take the sooner of those two (when both categories are
+non-empty).
+
+The easier of the two categories is queues that are getting all the
+concurrency they demand.  That is, `i` for which `mu(i,t) = rho(i,t)`.
+Such a queue gets no interference from other queues.  Its `P` and
+`nextEE` need to be updated only when three is a change in that queue.
+Keep the queues of this category in a data structure sorted by
+`nextEE`.  That has a compute time cost of `O(log N)` for every
+request arrival and completion and every queue entry into, and
+departure from, this category of queues.
+
+The tougher category is queues that are _not_ getting all the
+concurrency they demand.  That is, `i` for which `mu(i,t) < rho(i,t)`.
+These queues all get the same allocation, `mu_fair(t)`.  BTW, we could
+alternatively distinguish the categories by comparing `mu` to
+`mu_fair` rather than `rho`; this will make a difference approximately
+never (i.e., only when some queue's demand exactly equals the fair
+allocation), and there is no significant consequence to that
+difference.  The fact that the allocations are equal is the key to an
+efficient representation for this category.  We use the same `R(t)`
+meter as the original Fair Queuing algorithm.
+
+```
+R(t) = Integral[from tau=epoch to tau=t] mu_fair(tau) dtau
+```
+
+For a given queue `i`, suppose
+- the equation `mu(i,t) = mu_fair(t)` has been true since `t = t_i0`,
+  and
+- `j_next(i)` has been constant throughout that time.
+
+Assume those will continue to hold and estimate as follows.
+
+```
+Integral[t_i0 <= tau <= nextEE(i)] rate(i,tau) dtau
+        = PEnd(i,j_next(i)) - P(i,t_i0)
+
+rate(i,tau) = mu_fair(tau) / width(i,j_next(i))
+
+Integral[t_i0 <= tau <= nextEE(i)] mu_fair(tau) dtau / width(i,j_next(i))
+        = PEnd(i,j_next(i)) - P(i,t_i0)
+
+Integral[t_i0 <= tau <= nextEE(i)] mu_fair(tau) dtau
+        = width(i,j_next(i)) * (PEnd(i,j_next(i)) - P(i,t_i0))
+
+R(nextEE(i)) = R(t_i0) + width(i,j_next(i)) * (PEnd(i,j_next(i)) - P(i,t_i0))
+```
+
+Define "next Estimated F" `nextEF(i) = R(nextEE(i))`.  These `nextEF`
+values do not change with the mere passage of time during which
+nothing changes.  They also do not change when `mu_fair(t)` and
+`mu(i,t)` change, as long as the equation `mu(i,t) = mu_fair(t)`
+continues to hold.  Thus, this representation is insulated from
+interference from other queues.
+
+Keep these queues in a data structure sorted by increasing `nextEF`.
+Enumerating the queues that have the minimal `nextEF` value can be
+done in `O(N_Min * log N)` compute time, where `N_Min` is the number
+of queues having that minimal `nextEF`.  Finding the one of those that
+is next in round-robin order can be done in `O(N_Min)` compute time.
+Given the high resolution of modern clocks, `N_Min` will very rarely
+be greater than 1.
+
+At time `t`, to translate a queue's `nextEF` value to an expected
+clock reading `EE` (for comparison with the expected `E` value from
+the easier category of queues), assume `mu_fair(t)` will hold steady
+into the future and reason as follows.
+
+```
+R(tau) - R(t) = (tau - t) * mu_fair(t)
+
+nextEF(i) = R(nextEE(i)) = R(t) + (nextEE(i) - t) * mu_fair(t)
+
+nextEE(i) = t + ( nextEF(i) - R(t) ) / mu_fair(t)
+```
+
+By maintaining these two sorted sets of queues, the runtime cost to
+find the next request to dispatch in the real world reduces from
+`O(N)` to `O(log N)` compute time.
+
+Thus, this implementation costs `O((1 + N_Delta) * log N)` compute
+time per request.
+
+
+### Fair Queuing for Server Requests, with max-min fairness and concurrent virtual execution
+
+In this quadrant we achieve max-min fairness and a queue generally has
+multiple requests executing at a given time in the virtual world.
+
+#### Fair Queuing for Server Requests, with max-min fairness and concurrent virtual execution, behavior
 
 The following behavior solves the problem.
 
@@ -1197,7 +1643,7 @@ closely follows the one last dispatched from.  Requests are dispatched
 as soon as allowed by that ordering, the concurrency bound in the
 problem statement, and of course not dispatching before arrival.
 
-### More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness
+### More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness and concurrent virtual execution
 
 We consider three issues in turn: (1) computing the max-min fair
 allocation for a given set of demands, (2) scheduling in the virtual
@@ -1205,64 +1651,9 @@ world, and (3) picking the next request to execute in the real world.
 
 #### Computing the max-min fair allocation
 
-A single instance of the problem of finding the max-min fair
-allocations `mu(i,t1)` given capacity `C` and demands `rho(i,t1)`, for
-indices `0 <= i < N`, can be solved in `O(N log N)` time.  This is
-done by first sorting the indices according to increasing `rho`, then
-making one pass over the sorted indices to find the boundary between
-the demands that are fully met and those that are not.
+This is the same as [above](#computing-the-max-min-fair-allocation).
 
-Fair Queuing for Server Requests is an on-line problem, and as such
-presents a series of max-min fair allocation problems --- each
-differing from the previous by a change in the demand of one queue.
-Thus we can use an incremental algorithm to solve each new instance
-based on the previous one, as follows.
-
-- Keep the queues in a data structure sorted by increasing `rho`.  Let
-  us say this is a permutation `RI`.  That is, at any given moment
-  `t`, `rho(RI(j),t) <= rho(RI(k),t)` for every `0 <= j < k < N`.
-  Also maintain the inverse permutation `IR` --- that is, `IR(RI(i)) =
-  i` for every `0 <= i < N`.
-
-- Maintain the sort index `L` of the first sorted queue that is
-  limited (does not get all it demands).  That is, `L` is the smallest
-  non-negative integer with the property that `mu(RI(j),t) <
-  rho(RI(j),t)` for all `j` such that `j >= L` and `j < N`.  Sort
-  index `L` can be as small as 0 (when no queue gets its full demand)
-  and as large as `N` (when every queue gets its full demand).
-
-- Maintain the quantity `CL = Sum[over j < L] rho(RI(j),t) * (N-j)`.
-  This is the capacity usage implied by all the fully granted demands,
-  including the implication that the queues with higher demands get at
-  least the highest fully granted demand.
-
-- The above imply that when `L < N`, `L` has the property that making
-  it one bigger would blow `CL` past the bound `C`: `CL +
-  rho(RI(L),t) * (N-L) > C`.
-
-- Given the above, `mu_fair(t)` is:
-
-  - `C / N` if `L = 0`
-  
-  - `rho(RI(L-1),t) + (C - CL) / (N - L)` if `0 < L < N`
-
-  - `rho(RI(N-1),t)` if `L = N`.
-
-The permutation `RI` and its inverse can be implemented in such a way
-that every operation we invoke on them costs no more than `O(log N)`
-time.  For example, use a [https://github.com/wangjia184/sortedset]
-where the keys are stringified `i` and the scores are `rho(i,t)`,
-making the rank for `i` be `IR(i) + 1` and thus
-`GetByRank(j+1,false).Score()` implements `rho(RI(j),t)`.
-
-With that representation, the time complexity of solving the next
-instance of the max-min fair allocation problem is `O((1 + N_Delta) *
-log N)` where `N_Delta` is the number of queues that cross the
-boundary.  Note that while the system stays out of overload, `N_Delta`
-is zero.  It also stays zero while the system stays overloaded by the
-same set of queues.
-
-#### Scheduling in the virtual world
+#### Concurrent scheduling in the virtual world
 
 Next consider the problem of scheduling in the virtual world.  This is
 a matter of computing the `B` and `E` values in the virtual world.
@@ -1285,7 +1676,7 @@ time when it is not executing in the real world but has already
 started execution in the virtual world.  [TODO: describe how to handle
 this.]
 
-##### Simplest virtual-world scheduling implementation
+##### Simplest virtual-world concurrent scheduling implementation
 
 A request becomes known to the implementation when it arrives, and is
 deleted from the virtual world upon completion in the virtual world
@@ -1304,15 +1695,15 @@ no `O(1)` summary of their implications for future dispatches.
 A queue's requests that are waiting (not executing) in the virtual
 world are held in a FIFO.  This should support efficient removal of
 any given request, if it should happen to be ejected while waiting; a
-linked list supports all the needed operations in `O(1)` coompute
-time.  Whenever a request arrives or completes in the virtual world
---- the latter can happen when the clock reaches the request's `E` ---
-it is time to dispatch waiting requests.  These are pulled out of the
-FIFO, proceeding as long as the queue's number of occupied seats
-before each dispatch is less than `C`.  For each such dispatch, the
-`B` of the dispatched request is set to the current clock reading and
-the `E` can be estimated by assuming that nothing else changes until
-then; these cost `O(1)` compute time.
+linked list supports all the needed operations in `O(1)` compute time.
+Whenever a request arrives or completes in the virtual world --- the
+latter can happen when the clock reaches the request's `E` --- it is
+time to dispatch waiting requests.  These are pulled out of the FIFO,
+proceeding as long as the queue's number of occupied seats before each
+dispatch is less than `C`.  For each such dispatch, the `B` of the
+dispatched request is set to the current clock reading and the `E` can
+be estimated by assuming that nothing else changes until then; these
+cost `O(1)` compute time.
 
 The executing requests of a queue can be held in any data structure
 that supports efficient addition and removal of any given request.  A
@@ -1430,7 +1821,7 @@ the costs to keep the `nextEE` updated.
 In summary, the simplest implementation costs `O((1 + N_Delta) * log
 N + C + N)` compute time per request.
 
-##### Simplest correct virtual-world scheduling implementation
+##### Simplest correct virtual-world concurrent scheduling implementation
 
 However, there is a bug in the above approach to scheduling the
 computations about request completions in the virtual world.  When
@@ -1479,7 +1870,7 @@ Thus we get the same asymptotic summary.  The simplest correct
 implementation's total compute time per request is `O((1 + N_Delta) *
 log N + C + N)`.
 
-##### Sorted executing requests
+##### Sorted concurrent executing requests
 
 The easiest target for improvement is the costs of finding the new
 values for `nextCompletes`, `nextPE`, and `nextEE`.  The simplest
@@ -1494,7 +1885,7 @@ cost `O(log C)` for each.
 In this implementation, the total compute time per request is `O((1 +
 N_Delta) * log N + log C + N)`.
 
-##### Sorted queues
+##### Sorted queues with concurrent executing requests
 
 A more efficient approach is possible, based on using representations
 in which the data structure for a queue does not need to be updated in

--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -31,11 +31,17 @@
     - [More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness and serial virtual execution](#more-or-less-efficient-implementation-of-fair-queuing-for-server-requests-with-max-min-fairness-and-serial-virtual-execution)
       - [Computing the max-min fair allocation](#computing-the-max-min-fair-allocation)
       - [Serial scheduling in the virtual world](#serial-scheduling-in-the-virtual-world)
+      - [Simplest virtual-world serial scheduling implementation](#simplest-virtual-world-serial-scheduling-implementation)
+      - [Sorted queues with serial executing requests](#sorted-queues-with-serial-executing-requests)
   - [Fair Queuing for Server Requests, with max-min fairness and concurrent virtual execution](#fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution)
     - [Fair Queuing for Server Requests, with max-min fairness and concurrent virtual execution, behavior](#fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution-behavior)
     - [More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness and concurrent virtual execution](#more-or-less-efficient-implementation-of-fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution)
       - [Computing the max-min fair allocation](#computing-the-max-min-fair-allocation-1)
       - [Concurrent scheduling in the virtual world](#concurrent-scheduling-in-the-virtual-world)
+      - [Simplest virtual-world concurrent scheduling implementation](#simplest-virtual-world-concurrent-scheduling-implementation)
+      - [Simplest correct virtual-world concurrent scheduling implementation](#simplest-correct-virtual-world-concurrent-scheduling-implementation)
+      - [Sorted concurrent executing requests](#sorted-concurrent-executing-requests)
+      - [Sorted queues with concurrent executing requests](#sorted-queues-with-concurrent-executing-requests)
       - [Picking the next request to dispatch in the real world](#picking-the-next-request-to-dispatch-in-the-real-world)
     - [Derivation of Fair Queuing for Server Requests wit max-min fairness and concurrent virtual execution](#derivation-of-fair-queuing-for-server-requests-wit-max-min-fairness-and-concurrent-virtual-execution)
       - [The original story](#the-original-story)
@@ -1327,7 +1333,10 @@ updated as more information comes in.  Sadly, sometimes relevant
 information comes in after it was first needed.  [TODO: summarize
 coping better.]
 
-###### Simplest virtual-world serial scheduling implementation
+The following subsections cover a progression of solutions for virtual
+world scheduling of one request at a time per queue.
+
+##### Simplest virtual-world serial scheduling implementation
 
 A queue has a linked list of requests.  When a request arrives, it is
 appended to the end of the list.  At some point, that request is
@@ -1428,7 +1437,7 @@ implementation looks through all the queue to find those with minimal
 In summary, the simplest implementation costs `O((1 + N_Delta) * log
 N + N)` compute time per request.
 
-###### Sorted queues with serial executing requests
+##### Sorted queues with serial executing requests
 
 A more efficient approach is possible, based on using representations
 in which the data structure for a queue does not need to be updated in
@@ -1695,7 +1704,10 @@ time when it is not executing in the real world but has already
 started execution in the virtual world.  [TODO: describe how to handle
 this.]
 
-###### Simplest virtual-world concurrent scheduling implementation
+The following subsections cover a progression of solutions for
+scheduling multiple requests at a time per queue in the virtual world.
+
+##### Simplest virtual-world concurrent scheduling implementation
 
 A request becomes known to the implementation when it arrives, and is
 deleted from the virtual world upon completion in the virtual world
@@ -1840,7 +1852,7 @@ the costs to keep the `nextEE` updated.
 In summary, the simplest implementation costs `O((1 + N_Delta) * log
 N + C + N)` compute time per request.
 
-###### Simplest correct virtual-world concurrent scheduling implementation
+##### Simplest correct virtual-world concurrent scheduling implementation
 
 However, there is a bug in the above approach to scheduling the
 computations about request completions in the virtual world.  When
@@ -1889,7 +1901,7 @@ Thus we get the same asymptotic summary.  The simplest correct
 implementation's total compute time per request is `O((1 + N_Delta) *
 log N + C + N)`.
 
-###### Sorted concurrent executing requests
+##### Sorted concurrent executing requests
 
 The easiest target for improvement is the costs of finding the new
 values for `nextCompletes`, `nextPE`, and `nextEE`.  The simplest
@@ -1904,7 +1916,7 @@ cost `O(log C)` for each.
 In this implementation, the total compute time per request is `O((1 +
 N_Delta) * log N + log C + N)`.
 
-###### Sorted queues with concurrent executing requests
+##### Sorted queues with concurrent executing requests
 
 A more efficient approach is possible, based on using representations
 in which the data structure for a queue does not need to be updated in

--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -43,7 +43,7 @@
       - [Sorted concurrent executing requests](#sorted-concurrent-executing-requests)
       - [Sorted queues with concurrent executing requests](#sorted-queues-with-concurrent-executing-requests)
       - [Picking the next request to dispatch in the real world](#picking-the-next-request-to-dispatch-in-the-real-world)
-    - [Derivation of Fair Queuing for Server Requests wit max-min fairness and concurrent virtual execution](#derivation-of-fair-queuing-for-server-requests-wit-max-min-fairness-and-concurrent-virtual-execution)
+    - [Derivation of Fair Queuing for Server Requests with max-min fairness and concurrent virtual execution](#derivation-of-fair-queuing-for-server-requests-with-max-min-fairness-and-concurrent-virtual-execution)
       - [The original story](#the-original-story)
       - [Re-casting the original story](#re-casting-the-original-story)
       - [From one to many](#from-one-to-many)
@@ -2048,7 +2048,7 @@ but maintains its own `nextCompletes`, `nextPE`, and
 This iterator also has the added problem of respecting round-robin
 ordering.  This can be implemented in `O(1)` compute time per request.
 
-#### Derivation of Fair Queuing for Server Requests wit max-min fairness and concurrent virtual execution
+#### Derivation of Fair Queuing for Server Requests with max-min fairness and concurrent virtual execution
 
 Finally, here is an explanation of how this solution was derived.  It
 starts with an old paper from the world of networking and makes a

--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -897,8 +897,13 @@ non-empty queues, as follows.
 mu(i,t) = mu_equal(t)  if rho(i,t) > 0
         = 0            otherwise
 
-mu_equal(t) = min(C, Sum[over i] rho(i,t)) / NEQ(t)
+mu_equal(t) = min(C, Sum[over i] rho(i,t)) / NEQ(t)   if NEQ(t) > 0
+            = 0                                       otherwise
 ```
+
+In this design, a queue executes one request at a time in the virtual
+world.  Thus, `NOS(i,t) = width(i,j)` for that relevant `j` whenever
+there is one.
 
 Each non-empty queue divides its allocated concurrency `mu` evenly
 among the seats it occupies in the virtual world, so that the
@@ -908,10 +913,8 @@ aggregate rate work gets done on all the queue's seats is `mu`.
 rate(i,t) = if NOS(i,t) > 0 then mu_equal(t) / NOS(i,t) else 0
 ```
 
-In this design, a queue executes one request at a time in the virtual
-world.  Thus, `NOS(i,t) = width(i,j)` for that relevant `j` whenever
-there is one.  Since `mu_equal(t)` can be greater or less than
-`width(i,j)`, `rate(i,t)` can be greater or less than 1.
+Since `mu_equal(t)` can be greater or less than `width(i,j)`,
+`rate(i,t)` can be greater or less than 1.
 
 We use the above policy and rate to define the schedule in the virtual
 world.  The scheduling is thus done with almost no interactions
@@ -934,8 +937,10 @@ of the queue's earlier requests finish.  Note that the concurrency
 limit used here is different from the real world: a queue is allowed
 to run one request at a time, regardless of how many it has waiting to
 run and regardless of the server's concurrency limit `C`.  The
-independent virtual-world scheduling for each queue helps enable
-efficient implementations.
+independent virtual-world scheduling for each queue is crucial for
+fairness: a queue's virtual completions depend only on the queue's
+demand and allocated concurrency, not any detailed scheduling
+interaction.  This also helps enable efficient implementations.
 
 The end of a request's virtual execution (`E(i,j)`) is the solution to
 the following equation.

--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -1249,11 +1249,11 @@ based on the previous one, as follows.
   - `rho(RI(N-1),t)` if `L = N`.
 
 The permutation `RI` and its inverse can be implemented in such a way
-that every operation we invoke on them costs no more than `O(N)` time.
-For example, use a [https://github.com/wangjia184/sortedset] where the
-keys are stringified `i` and the scores are `rho(i,t)`, making the
-rank for `i` be `IR(i) + 1` and thus `GetByRank(j+1,false).Score()`
-implements `rho(RI(j),t)`.
+that every operation we invoke on them costs no more than `O(log N)`
+time.  For example, use a [https://github.com/wangjia184/sortedset]
+where the keys are stringified `i` and the scores are `rho(i,t)`,
+making the rank for `i` be `IR(i) + 1` and thus
+`GetByRank(j+1,false).Score()` implements `rho(RI(j),t)`.
 
 With that representation, the time complexity of solving the next
 instance of the max-min fair allocation problem is `O((1 + N_Delta) *

--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -23,11 +23,8 @@
   - [Fair Queuing for Server Requests problem statement](#fair-queuing-for-server-requests-problem-statement)
   - [Fair Queuing for Server Requests, with equal allocations](#fair-queuing-for-server-requests-with-equal-allocations)
     - [Fair Queuing for Server Requests, with equal allocations, initial definition](#fair-queuing-for-server-requests-with-equal-allocations-initial-definition)
-    - [Fair Queuing for Server Requests, with equal allocations and width=1 and Y=0, intended behavior](#fair-queuing-for-server-requests-with-equal-allocations-and-width1-and-y0-intended-behavior)
-    - [Implementation of Fair Queuing for Server Requests with equal allocations and width=1 and Y=0, technique and problems](#implementation-of-fair-queuing-for-server-requests-with-equal-allocations-and-width1-and-y0-technique-and-problems)
-    - [Fair Queuing for Server Requests, with equal allocations and general width and Y, intended behavior](#fair-queuing-for-server-requests-with-equal-allocations-and-general-width-and-y-intended-behavior)
-    - [Implementation of Fair Queuing for Server Requests with equal allocations and general width and Y, technique and problems](#implementation-of-fair-queuing-for-server-requests-with-equal-allocations-and-general-width-and-y-technique-and-problems)
-  - [Problems with initial definition of Fair Queuing for Server Requests](#problems-with-initial-definition-of-fair-queuing-for-server-requests)
+    - [Fair Queuing for Server Requests, with equal allocations, intended behavior](#fair-queuing-for-server-requests-with-equal-allocations-intended-behavior)
+    - [Implementation of Fair Queuing for Server Requests with equal allocations, technique and problems](#implementation-of-fair-queuing-for-server-requests-with-equal-allocations-technique-and-problems)
   - [Fair Queuing for Server Requests, with max-min fairness](#fair-queuing-for-server-requests-with-max-min-fairness)
     - [Fair Queuing for Server Requests, with max-min fairness, behavior](#fair-queuing-for-server-requests-with-max-min-fairness-behavior)
   - [More or less efficient implementation of Fair Queuing for Server Requests with max-min fairness](#more-or-less-efficient-implementation-of-fair-queuing-for-server-requests-with-max-min-fairness)
@@ -716,6 +713,13 @@ The is the technique currently used.  The following subsections cover:
 (b) equations that describe the intended behavior, and (c)
 implementation difficulties (solved and unsolved).
 
+After all that is a presentation of a solution for truly fair queuing,
+with max-min fairness.  There is also a confounding difference: the
+solution with equal allocations uses a virtual schedule with each
+queue running only one request at a time while the max-min fair
+solution allows a queue to run concurrent requests in the virtual
+world.  These are two corners of a quad of possible approaches.
+
 #### Fair Queuing for Server Requests, with equal allocations, initial definition
 
 Following is the design that motivated the code as it existed just
@@ -803,251 +807,26 @@ service the queue’s virtual start time is advanced by G.  When a
 request finishes being served, and the actual service time was S, the
 queue’s virtual start time is decremented by G - S.
 
-#### Fair Queuing for Server Requests, with equal allocations and width=1 and Y=0, intended behavior
+#### Fair Queuing for Server Requests, with equal allocations, intended behavior
 
 Here is a succinct summary of behavior intended to solve the Fair
 Queuing for Server Requests problem but with equal allocations instead
-of max-min fair allocations, with every request occupying one seat and
-having no extra latency.  This summarizes the code as it existed
-before we started generalizing for width and extra latency.
+of max-min fair allocations.  This includes general width and extra
+latency, although their implementation is in progress.
 
 We imagine a virtual world in which request executions are scheduled
 (queued and executed) differently than in the real world.  In the
 virtual world, requests are generally executed with more or less
-concurrency and with infinitesimal interleaving.
+concurrency than in the real world and with infinitesimal
+interleaving.
 
 PLEASE NOTE VERY CAREFULLY: the virtual world uses the same clock as
 the real world.  This is also true in the original Fair Queuing paper.
 Some subsequent authors --- including the authors of the
 implementation outline on Wikipedia and thus the authors of the
 original APF work and thus the current code --- use the term "virtual
-time" to refer to what the original paper, and the discussion below,
-calls `R(t)`.  Where the discussion below refers to "time in the
-virtual world", it means `t` rather than `R(t)`.
-
-Define the following.
-
-- `len(i,j)` is the execution duration for request `(i,j)` in the real
-  world.  At first `len` is only a guess.  When the real execution
-  duration is eventually learned, `len` gets updated with that
-  information.
-
-- `B(i,j)` is the time when request `(i,j)` beings execution in the
-  virtual world.
-
-- `E(i,j)` is the time when request `(i,j)` ends execution in the
-  virtual world.  This is _not_ simply `B` plus `len` because requests
-  generally execute at a different rate in the virtual world.
-
-- `SAQ(t)` is the Set of Active Queues at time `t`: those `i` for
-  which there is a `j` such that `t_arrive(i,j) <= t < E(i,j)`.
-
-- `NEQ(t)` is the number of Non-Empty Queues at time `t`; it is the
-  number of queues in `SAQ(t)`.
-
-At time `t`, queue `i` is requesting `rho(i,t)` (written as
-`reqs(q,t)` in the original KEP language) concurrency in the virtual
-world.  This is the number of the requests that have arrived but not
-yet finished executing.
-
-```
-rho(i,t) = |{j such that t_arrive(i,j) <= t < E(i,j)}|
-```
-
-The allocations of concurrency are written as `mu(i,t)` seats for
-queue `i` at time `t`.  We use allocations that are equal among
-non-empty queues, as follows.
-
-```
-mu(i,t) = mu_equal(t)  if rho(i,t) > 0
-        = 0            otherwise
-
-mu_equal(t) = min(C, Sum[over i] rho(i,t)) / NEQ(t)
-```
-
-Each non-empty queue divides its allocated concurrency `mu` evenly
-among the seats it occupies in the virtual world, so that the
-aggregate rate work gets done on all the queue's seats is `mu`.
-
-In this design a queue executes one request at a time in the virtual
-world, at a rate of `mu` seat-seconds per second.  This rate can be
-greater or less than 1.
-
-We use the above policy and rate and the concurrency limit to define
-the schedule in the virtual world.  The scheduling is thus done with
-almost no interactions between queues.  The interactions are limited
-to updating the `mu` allocations whenever the `rho` requests change.
-
-To make the scheduling technically easy to speccify, we suppose that
-no two requests arrive at the same time.  The implementation will be
-serialized anyway, so this is no real restriction.
-
-```
-B(i,j) = if j = 0 or E(i,j-1) <= t_arrive(i,j)
-         then t_arrive(i,j)
-         else E(i,j-1)
-```
-
-That is, a newly arrived request is dispatched immediately if the
-queue had nothing executing otherwise the new request waits until all
-of the queue's earlier requests finish.  Note that the concurrency
-limit used here is different from the real world: a queue is allowed
-to run one request at a time, regardless of how many it has waiting to
-run and regardless of the server's concurrency limit `C`.  The
-independent virtual-world scheduling for each queue helps enable
-efficient implementations.
-
-The end of a packet's virtual execution (`E(i,j)`) is the solution to
-the following equation.
-
-```
-Integral[from tau=B(i,j) to tau=E(i,j)] mu_equal(i,tau) dtau = len(i,j)
-```
-
-That is, each of a queue's packets is executed in the virtual world at
-the rate `mu_equal(t)`.  Before the real completion, `len` is only a
-guess.
-
-For a given request `(i,j)`, the initial guess at its execution
-duration is what the request context says is the available remaining
-time for serving the request.  If and whenever the passage of time
-later proves the current guessed `len` to be too small then it is
-increased by adding `G` (which is the server's configured default
-request service time limit).
-
-Once a request `(i,j)` finishes executing in the real world, its
-actual execution duration is known and `len` gets set to that.  This
-changes not only `E(i,j)` but also the `B` and `E` of the all the
-queue's requests that arrived between `t_arrive(i,j)` and the next of
-the queue's idle times.  Note that this can change `rho(i,t)` and thus
-`mu_equal(t)` at those intervening times, and thus the subsequent
-scheduling in other queues.  The computation of these changes can not
-happen until `(i,j)` finishes executing in the real world (which is
-`t_arrive(i,j) + len(i,j)`) --- but the request might finish much
-sooner in the virtual world.  We can have `E(i,j) < t_arrive(i,j) +
-len(i,j)` because of `mu_equal` being greater than 1.  An accurate
-implementation would keep track of enough historical information to
-revise all that scheduling.
-
-The order of request dispatches in the real world is taken to be the
-order of request completions in the virtual world.  In the case of
-ties, round robin ordering is used starting from the queue that most
-closely follows the one last dispatched from.  Requests are dispatched
-as soon as allowed by that ordering, the concurrency bound in the
-problem statement, and of course not dispatching before arrival.
-
-
-#### Implementation of Fair Queuing for Server Requests with equal allocations and width=1 and Y=0, technique and problems
-
-One of the key implementation ideas is taken from the original paper.
-Define a global meter of progress named `R`, and characterize each
-request's execution interval in terms of that meter, as follows.
-
-```
-R(t) = Integral[from tau=epoch to tau=t] mu_equal(tau) dtau
-S(i,j) = R(B(i,j))
-F(i,j) = R(E(i,j))
-```
-
-In the current implementation, that global progress meter is called
-"virtual time".
-
-The value of working with `R` values rather than time is that they do
-not vary with `mu_equal`.  Compare the following two equations (one is
-copied from above, the other follows from it and the definitions of
-`R`, `S`, and `F`).
-
-```
-Integral[from tau=B(i,j) to tau=E(i,j)] mu_equal(i,tau) dtau = len(i,j)
-
-F(i,j) = S(i,j) + len(i,j)
-```
-
-The current implementation makes the incorrect assumption that a
-request can be removed from the virtual world when it finishes in the
-real world ("when" is not confusing here because the two worlds use
-the same clock, as noted earlier).  Remember that `E(i,j)` can be
-greater or lesser than `B(i,j) + len(i,j)`.  In terms of the `R`
-meter, `F(i,j)` can be greater or less than `R(B(i,j) + len(i,j))`.
-Removing a request from the virtual world too early or late leads to
-an incorrect calculation of `rho(i,t)` and thus `mu_equal(t)` and thus
-the scheduling in other queues.
-
-Because the implementation considers requests to complete in the
-virtual world when they complete in the real world, dispatches also
-happen in the virtual world at the same time as in the real world.
-Thus, the problem of finding the next request to dispatch in the real
-world is the same as the problem of finding the next request to
-dispatch in the virtual world.  This leads to the following.
-
-The next key idea is that it is not necessary to explicitly represent
-the `B` and `E`, nor even the `S` and `F`, of _every_ request that
-exists in the implementation at a given moment.  For each non-empty
-queue, all that is really needed (to support finding the next request
-to dispatch) is the `F` of the request that is currently executing in
-the virtual world.  This is known in the code as the queue's
-`virtualStart`, because it is the `R` value at which the queue's next
-dispatch will happen (if there is a waiting request by then).  The
-fact that the initial guess is the same `G` for every request implies
-that for any waiting request the `S` and `F` can be calculated in
-`O(1)` time from that request's queue position and the `F` of the
-currently executing request.  And all that is really needed (given the
-incorrect timing of removal of requests from the virtual world) is the
-`F` of the queue's oldest waiting request.
-
-A queue's `virtualStart` gets incrementally updated as follows.  The
-regular case of dispatch is when one request finishes executing and
-another starts.  At that moment, `virtualStart` was `S` of the request
-about to start; to account for the dispatch, the guessed duration `G`
-is added to `virtualStart` because that computes the `S` of the
-request after the one being dispatched.  In the special case of a
-request arriving to an empty queue, the arrival logic sets
-`virtualStart` to the current `R` value --- because that is the `S` of
-the next request to dispatch --- and soon afterward the regular
-dispatch logic does its thing.  When a request finishes execution, the
-difference between its actual duration and `G` is added to
-`virtualStart` because that is the implied change in the `S` of the
-following request.
-
-Using an equal allocation of concurrency rather than a max-min one
-gives, in scenarios where the two allocations are different, some
-queues more concurrency than they can use.
-
-One consequence of this mis-allocation is that while a queue uses less
-than `mu_equal` but is non-empty at every moment when a request could
-be dispatched from it, the equations above say that the queue gets
-work done faster than it actually does.  The equations above assign
-`B` and `E` values that reflect an impossibly high rate of progress
-for such a queue.  That is, these values get progressively more early.
-The queue is effectively building up "credit" in artificially low `B`
-and `E` values, and can build up an arbitrary amount of this credit.
-Then an arbitrarily large amount of work could suddenly arrive to that
-queue and crowd out other queues for an arbitrarily long time.  To
-mitigate this problem, the implementation has a special step that
-effectively prevents `B` of the next request to dispatch from dropping
-below the current time.  But that solves only half of the problem.
-Other queueus may accumulate a corresponding deficit (inappropriately
-large values for `B` and `E`).  Such a queue can have an arbitrarily
-long burst of inappropriate lossage to other queues.
-
-#### Fair Queuing for Server Requests, with equal allocations and general width and Y, intended behavior
-
-Here is a succinct summary of behavior intended to solve the Fair
-Queuing for Server Requests problem but with equal allocations instead
-of max-min fair allocations.
-
-We imagine a virtual world in which request executions are scheduled
-(queued and executed) differently than in the real world.  In the
-virtual world, requests are generally executed with more or less
-concurrency and with infinitesimal interleaving.
-
-PLEASE NOTE VERY CAREFULLY: the virtual world uses the same clock as
-the real world.  This is also true in the original Fair Queuing paper.
-Some subsequent authors --- including the authors of the
-implementation outline on Wikipedia and thus the authors of the
-original APF work and thus the current code --- use the term "virtual
-time" to refer to what the original paper, and the discussion below,
-calls `R(t)`.  Where the discussion below refers to "time in the
+time" to refer to what the original paper and the discussion below
+call `R(t)`.  Where the discussion below refers to "time in the
 virtual world", it means `t` rather than `R(t)`.
 
 Define the following.
@@ -1065,14 +844,8 @@ Define the following.
   simply `B` plus `len` because requests generally execute at a
   different rate in the virtual world.
 
-- `last(i,t)` is the `j` of the latest arrival to queue `i` by time
-  `t`: `max[j such that] t_arrive(i,t) <= t`.
-
-- `SAR(i,t) = {j such that B(i,j) <= t < E(i,j)}` is the Set of Active
-  Requests for queue `i` at time `t`.
-
-- `NOS(i,t) = Sum[over j in SAR(i,t)] width(i,j)` is the Number of
-  Occupied Seats by queue `i` at time `t`.
+- `NOS(i,t)` is the Number of Occupied Seats by queue `i` at time `t`;
+  this is `Sum[over j such that B(i,j) <= t < E(i,j)] width(i,j)`.
 
 - `SAQ(t)` is the Set of Active Queues at time `t`: those `i` for
   which there is a `j` such that `t_arrive(i,j) <= t < E(i,j)`.
@@ -1089,18 +862,14 @@ rho(i,t) = Sum[over j such that t_arrive(i,j) <= t < E(i,j)] width(i,j)
 ```
 
 The allocations of concurrency are written as `mu(i,t)` seats for
-queue `i` at time `t`.  These allocations are equal among non-empty
-queues when
+queue `i` at time `t`.  This design uses allocations are equal among
+non-empty queues, as follows.
 
 ```
-mu(i,t) = mu_equal  if rho(i,t) > 0
-        = 0         otherwise
-```
+mu(i,t) = mu_equal(t)  if rho(i,t) > 0
+        = 0            otherwise
 
-and
-
-```
-mu_equal = min(C, Sum[over i] rho(i,t)) / NEQ(t)
+mu_equal(t) = min(C, Sum[over i] rho(i,t)) / NEQ(t)
 ```
 
 Each non-empty queue divides its allocated concurrency `mu` evenly
@@ -1114,7 +883,7 @@ rate(i,t) = if NOS(i,t) > 0 then mu_equal(t) / NOS(i,t) else 0
 In this design, a queue executes one request at a time in the virtual
 world.  Thus, `NOS(i,t) = width(i,j)` for that relevant `j` whenever
 there is one.  Since `mu_equal(t)` can be greater or less than
-`width(i,j)`, `rate` can be greater or less than 1.
+`width(i,j)`, `rate(i,t)` can be greater or less than 1.
 
 We use the above policy and rate and the concurrency limit to define
 the schedule in the virtual world.  The scheduling is thus done with
@@ -1140,14 +909,14 @@ run and regardless of the server's concurrency limit `C`.  The
 independent virtual-world scheduling for each queue helps enable
 efficient implementations.
 
-The end of a packet's virtual execution (`E(i,j)`) is the solution to
+The end of a request's virtual execution (`E(i,j)`) is the solution to
 the following equation.
 
 ```
 Integral[from tau=B(i,j) to tau=E(i,j)] rate(i,tau) dtau = len(i,j)
 ```
 
-That is, each of a queue's packets is executed in the virtual world at
+That is, each of a queue's requests is executed in the virtual world at
 the aforementioned `rate`.  Before the real completion, `len` is only
 a guess.
 
@@ -1180,7 +949,7 @@ as soon as allowed by that ordering, the concurrency bound in the
 problem statement, and of course not dispatching before arrival.
 
 
-#### Implementation of Fair Queuing for Server Requests with equal allocations and general width and Y, technique and problems
+#### Implementation of Fair Queuing for Server Requests with equal allocations, technique and problems
 
 One of the key implementation ideas is taken from the original paper.
 Define a global meter of progress named `R`, and characterize each
@@ -1207,28 +976,88 @@ Integral[from tau=B(i,j) to tau=E(i,j)] mu_equal(tau) / width(i,j) dtau
 F(i,j) = S(i,j) + len(i,j) * width(i,j)
 ```
 
+The next key idea is that when it comes time to dispatch the next
+request in the real world, (a) it must be drawn from among those that
+have arrived but not yet been dispatched in the real world and (b) it
+must be the next one of those according to the ordering in the
+real-world dispatch rule given in the problem statement --- recall
+that is increasing `E`, with ties broken by round-robin ordering among
+queues.  The implementation maintains a cursor into that order.  The
+cursor is a queue index (for resolving ties according to round-robin)
+plus a bifurcated representation of each queue.  A queue's
+representation consists of two parts: a set of requests that are
+executing in the real world, and a FIFO of requests that are waiting
+in the real world.  When it comes time to advance the cursor, the
+problem is to find --- among the queues with requests waiting in the
+real world --- the one whose oldest real-world-waiting request (the
+one at head of the FIFO) has the lowest `E`, with ties broken
+appropriately.  This is the only place where the `B` and `E` values
+have an effect on the real world, and this fact is used to prune the
+implementation as explained next.
 
-The next key idea is th
+It is not necessary to explicitly represent the `B` and `E`, nor even
+the `S` and `F`, of _every_ request that exists in the implementation
+at a given moment.  For each queue with requests waiting in the real
+world, all that is really needed (to support finding the next request
+to dispatch) is the `F` of the oldest one of those requests.  The
+ordering constraint in the problem statement is in terms of `E`, but
+we can just as well order by `F` because `R(t)` is a monotonically
+non-decreasing --- and strictly increasing where it matters ---
+function of `t`.  The implementation calculates that request's `F` by
+adding its `len * width` to its `S`.  Rather than explicitly represent
+`B` and `E`, or `S` and `F`, on every request, the implementation
+simply represents the `S` of each queue's oldest
+waiting-in-the-real-world request (if any).  In the implementation
+this is a queue field named `virtualStart`.
 
-### Problems with initial definition of Fair Queuing for Server Requests
+A queue's `virtualStart` gets incrementally updated as follows.  The
+regular case of virtual world dispatch is when one request `(i,j-1)`
+finishes executing and the next one starts.  At that moment,
+`virtualStart` was `F(i,j-1) = S(i,j)`.  To account for the dispatch,
+the product `len(i,j) * width(i,j)` is added to `virtualStart` because
+that computes the initial guess at `F(i,j) = S(i,j+1)`.  In the
+special case of a request arriving to an empty queue, the arrival
+logic sets `virtualStart` to the current `R` value --- because that is
+the `S` of the next request to dispatch --- and soon afterward the
+regular dispatch logic does its thing.  When request `(i,j)` finishes
+execution and its actual duration is learned, the queue's
+`virtualStart` is adjusted by adding the product of `width(i,j)` and
+the correction to `len(i,j)`.
 
-One is that it does not actually aim for max-min fairness; rather, it
-aims to give every non-empty queue the same concurrency (regardless of
-whether a given queue can use that much concurrency).  That is [issue
-95979](https://github.com/kubernetes/kubernetes/issues/95979), which
-is partially addressed by a hack that causes a queue's progress
-(`virtualStart`) to advance at the fair rate even when that queue is
-not actually doing that much work/time.
+That is the only adjustment made when the correct value of `len(i,j)`
+is learned.  This ignores other consequences that the equations above
+call for.  Changing `len(i,j)` can change `rho(i,t)` for some times
+`t`.  That can change `mu_equal(t)`, and thus the scheduling in all
+the queues.
 
-Another problem is that the code removes a request from both the real
-and virtual worlds as soon as it completes in the real world.  In the
-original Fair Queuing technique for networking, a packet continues to
-get service (lowering dR/dt) until it completes in the virtual world
---- even though that may be after the packet completes in the real
-world.  That aspect should be retained.  Removing a request before it
-finishes in the virtual world, causes the code to use a higher dR/dt
-than it should.  This looks similar to the previous problem, and is
-partially addressed by the same hack.
+To advance the cursor, the implementation iterates through all the
+queues to find, among those that have requests waiting in the real
+world, the one with minimal next `F` (with tie broken appropriately).
+This costs `O(N)` compute time, where `N` is the number of queues.
+
+Using an equal allocation of concurrency rather than a max-min fair
+one is [issue
+95979](https://github.com/kubernetes/kubernetes/issues/95979).  In
+scenarios where the two allocations are different, equal allocation
+gives some queues more concurrency than they can use and gives other
+queues less than they should get.
+
+One consequence of this mis-allocation is that while a queue uses less
+than `mu_equal` but is non-empty at every moment when a request could
+be dispatched from it, the equations above say that the queue gets
+work done faster than it actually does.  The equations above assign
+`B` and `E` values that reflect an impossibly high rate of progress
+for such a queue.  That is, these values get progressively more early.
+The queue is effectively building up "credit" in artificially low `B`
+and `E` values, and can build up an arbitrary amount of this credit.
+Then an arbitrarily large amount of work could suddenly arrive to that
+queue and crowd out other queues for an arbitrarily long time.  To
+mitigate this problem, the implementation has a special step that
+effectively prevents `B` of the next request to dispatch from dropping
+below the current time.  But that solves only half of the problem.
+Other queueus may accumulate a corresponding deficit (inappropriately
+large values for `B` and `E`).  Such a queue can have an arbitrarily
+long burst of inappropriate lossage to other queues.
 
 ### Fair Queuing for Server Requests, with max-min fairness
 
@@ -1341,18 +1170,18 @@ at which point we do not consider additional dispatches from queue
 `i`).  The independent virtual-world scheduling for each queue also
 helps enable efficient implementations.
 
-The end of a packet's virtual execution (`E(i,j)`) is the solution to
+The end of a request's virtual execution (`E(i,j)`) is the solution to
 the following equation.
 
 ```
 Integral[from tau=B(i,j) to tau=E(i,j)] rate(i,tau) dtau = len(i,j)
 ```
 
-That is, each of a queue's packets is executed in the virtual world at
-the aforementioned `rate`.  Before the real completion, `len` is only
-a guess and the virtual completion is certainly in the future --- and
-so can be updated when the real value of `len` is learned.  The ease
-of this is why we insist on keepting that update out of the past.
+That is, each of a queue's requests is executed in the virtual world
+at the aforementioned `rate`.  Before the real completion, `len` is
+only a guess and the virtual completion is certainly in the future ---
+and so can be updated when the real value of `len` is learned.  The
+ease of this is why we insist on keepting that update out of the past.
 
 For a given request `(i,j)`, the initial guess at its execution
 duration is the sum of `Y(i,j)` and what the request context says is
@@ -1502,7 +1331,7 @@ an executing request's `E` estimate are:
 
 To maintain and incrementally update these estimates in the face of
 `rate` varying over the course of a request's execution, it helps to
-define a notion of the "progresss" `P(i,t)` that queue `i` has made up
+define a notion of the "progress" `P(i,t)` that queue `i` has made up
 to time `t`.
 
 ```


### PR DESCRIPTION
Restore the description of the design that is currently implemented.

Update max-min fairness design for LIST and WATCH.

Also present the derived design first, put derivation in a later
section.

Added subsections about efficient FQ4SR implementation, ordered by
simplicity.