### PR TITLE
KEP-2485: Scheduler changes for beta graduation criteria

### DIFF
--- a/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/README.md
+++ b/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/README.md
@@ -376,9 +376,9 @@ proposal will be implemented, this is the place to discuss them.
 
 In Kubernetes, we should add a new ReadWriteOncePod persistent volume access
 mode to PersistentVolumes and PersistentVolumeClaims. This change will require
-adding a feature gate to the kube-apiserver, kube-controller-manager,
-kube-scheduler, and kubelet. Validation logic will need updating to accept this
-access mode type if the feature gate is enabled.
+adding a feature gate to the kube-apiserver, kube-scheduler, and kubelet.
+Validation logic will need updating to accept this access mode type if the
+feature gate is enabled.
 
 ```golang
        // can be mounted read/write mode to exactly 1 pod
@@ -627,10 +627,9 @@ enhancement:
 -->
 
 In order to upgrade a cluster to use this feature, the user will need to restart
-the kube-apiserver, kube-controller-manager, kube-scheduler, and kubelet with
-the ReadWriteOncePod feature gate enabled.  Additionally they will need to
-update their CSI drivers and sidecars to versions that depend on the new
-Kubernetes API and CSI spec.
+the kube-apiserver, kube-scheduler, and kubelet with the ReadWriteOncePod
+feature gate enabled.  Additionally they will need to update their CSI drivers
+and sidecars to versions that depend on the new Kubernetes API and CSI spec.
 
 When downgrading a cluster to disable this feature, the user will need to
 restart the kube-apiserver with the ReadWriteOncePod feature gate disabled. When
@@ -755,7 +754,6 @@ Pick one of these and delete the rest.
   - Feature gate name: ReadWriteOncePod
   - Components depending on the feature gate:
     - kube-apiserver
-    - kube-controller-manager
     - kube-scheduler
     - kubelet
 

--- a/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/README.md
+++ b/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/README.md
@@ -391,7 +391,7 @@ This access mode will be enforced in two places:
 
 First is at the time a pod is scheduled. When scheduling a pod, if another pod
 is found using the same PVC and the PVC uses ReadWriteOncePod, then scheduling
-will fail and the pod will be considered unresolvable.
+will fail and the pod will be considered UnschedulableAndUnresolvable.
 
 In order to determine if a pod using a ReadWriteOncePod PVC can be scheduled, we
 need to enumerate all pods and check if any are already consuming this PVC. This
@@ -402,7 +402,7 @@ The [node info cache] will be extended to map the PVC name to a reference count
 for the PVC. In the PreFilter extension point, if the pod's PVC is using
 ReadWriteOncePod, we will query this map for each node checking for references
 to the scheduled pod's PVC. If one is found the pod will fail scheduling and be
-marked unresolvable.
+marked UnschedulableAndUnresolvable.
 
 [volume restrictions plugin]: https://github.com/kubernetes/kubernetes/blob/v1.21.0/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go#L29
 [node info cache]: https://github.com/kubernetes/kubernetes/blob/v1.21.0/pkg/scheduler/framework/types.go#L357
@@ -601,6 +601,8 @@ in back-to-back releases.
 
 #### Beta
 
+- Scheduler enforces ReadWriteOncePod access mode by marking pods as
+  Unschedulable, preemption logic added
 - ReadWriteOncePod access mode has end to end test coverage
 - Mock CSI driver supports `SINGLE_NODE_*_WRITER` access modes, relevant end to
   end tests updated to use this driver

--- a/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/kep.yaml
+++ b/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/kep.yaml
@@ -41,7 +41,6 @@ feature-gates:
   - name: ReadWriteOncePod
     components:
       - kube-apiserver
-      - kube-controller-manager
       - kube-scheduler
       - kubelet
 disable-supported: true


### PR DESCRIPTION
- One-line PR description: Scheduler changes for beta graduation criteria, remove kube-controller-manager from feature gate consumers
- Issue link: https://github.com/kubernetes/enhancements/issues/2485
- Other comments: Included is a small change to remove the kube-controller-manager from the feature gate consumer list, it is not required for adding the feature

/assign @alculquicondor 
/assign @ahg-g 