### PR TITLE
Update KEP for Scheduler CC in beta

### DIFF
--- a/keps/prod-readiness/sig-scheduling/785.yaml
+++ b/keps/prod-readiness/sig-scheduling/785.yaml
@@ -1,0 +1,3 @@
+kep-number: 785
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/785-scheduler-component-config-api/README.md
+++ b/keps/sig-scheduling/785-scheduler-component-config-api/README.md
@@ -8,9 +8,13 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
+    - [Beta -&gt; GA Graduation](#beta---ga-graduation)
+  - [Upgrade/Downgrade Strategy](#upgradedowngrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
   - [Feature enablement and rollback](#feature-enablement-and-rollback)
   - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
@@ -29,8 +33,8 @@
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [x] (R) Graduation criteria is in place
 - [x] (R) Production readiness review completed
-- [ ] Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
+- [x] Production readiness review approved
+- [x] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
@@ -41,9 +45,9 @@
 
 ## Summary
 
-The kube-scheduler configuration API `kubescheduler.config.k8s.io` is currently
-in version `v1alpha2`. We propose its graduation to `v1beta1` in order to
-promote its wider use.
+The kube-scheduler configuration API `kubescheduler.config.k8s.io` was in alpha
+for several releases. We graduated it to beta in 1.19 as `v1beta1`. In 1.22,
+we introduced `v1beta2`.
 
 ## Motivation
 
@@ -66,8 +70,8 @@ usage.
 
 - Introduce `kubescheduler.config.k8s.io/v1beta1` as a copy of
 `kubescheduler.config.k8s.io/v1alpha2` with minimal cleanup changes.
+- Iterate the API in `kubescheduler.config.k8s.io/v1beta2`, based on learnings.
 - Use the newly created API objects to build the default configuration for kube-scheduler.
-- Remove support for `kubescheduler.config.k8s.io/v1alpha2`
 
 ### Non-Goals
 
@@ -82,6 +86,16 @@ For the most part, `kubescheduler.config.k8s.io/v1beta1` will be a copy of
 - [ ] `.profiles[*].plugins.unreserve` will be removed.
 - [ ] Embedded types of `RequestedToCapacityRatio` will include missing json tags
   and will be decoded with a case-sensitive decoder.
+  
+The second iteration, `kubescheduler.config.k8s.io/v1beta2`, includes the following changes:
+  - Plugin removals:
+    - `NodeLabel` (in favor of `NodeAffinity`)
+    - `ServiceAffinity` (in favor of `NodeAffinity`)
+    - `NodePreferAvoidPods` (in favor of `TaintToleration`)
+    - `NodeResourcesLeastAllocated` (in favor of `NodeResourcesFit` plugin with a `LeastAllocated` scoring strategy)
+    - `NodeResourcesMostAllocated` (in favor of `NodeResourcesFit` plugin with a `MostAllocated` scoring strategy)
+    - `RequestedToCapacityRatio` (in favor of `NodeResourcesFit` plugin with a `RequestedToCapacityRatio` scoring strategy)
+  - Cleanup of validation hacks.
 
 ### Risks and Mitigations
 
@@ -98,12 +112,15 @@ updated to comply with the modified `Reserve` interface, otherwise scheduler
 startup will fail. Plugins can choose to provide empty implementations.
 This will be documented in https://kubernetes.io/docs/reference/scheduling/profiles/
 
+## Design Details
+
 ### Test Plan
 
-- [ ] Compatibility tests for defaults and overrides of `.bindTimeoutSeconds`
+- [x] Compatibility tests for defaults and overrides of `.bindTimeoutSeconds`
   in `VolumeBindingArgs` type.
-- [ ] Tests for `RequestedToCapacityRatioArgs` that: (1) fail to pass with
+- [x] Tests for `RequestedToCapacityRatioArgs` that: (1) fail to pass with
   bad casing and (2) get encoded with lower case.
+- [x] Tests for parsing, conversion, defaulting and validation.
 
 ### Graduation Criteria
 
@@ -111,6 +128,22 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 
 - Complete features listed in [proposal][#proposal].
 - Tests in [test plan](#test-plan)
+
+#### Beta -> GA Graduation
+
+- Deprecation of legacy plugins.
+- Minimal changes in the last beta iteration of the API.
+
+### Upgrade/Downgrade Strategy
+
+Users are able to use the `v1beta1` or `v1beta2` APIs. Since they only affect
+the configuration of the scheduler, there is no impact to running workloads.
+
+The default configurations preserve the behavior of the scheduler.
+
+### Version Skew Strategy
+
+N/A
 
 ## Production Readiness Review Questionnaire
 
@@ -129,7 +162,7 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 * **Can the feature be disabled once it has been enabled (i.e. can we rollback
   the enablement)?**
 
-  By removing `--config` command line flag for `kube-scheduler`.
+  Yes, by removing `--config` command line flag for `kube-scheduler`.
 
 * **What happens if we reenable the feature if it was previously rolled back?**
 
@@ -138,6 +171,8 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 * **Are there any tests for feature enablement/disablement?**
 
   The e2e framework does not currently support changing configuration files.
+  
+  There are intensive unit tests for both API versions.
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -148,7 +183,11 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 
 * **What specific metrics should inform a rollback?**
 
-  Metric "schedule_attempts_total" remaining at zero when new pods are added.
+  - Metric "schedule_attempts_total" remaining at zero when new pods are added.
+  - Latency changes in the metrics:
+    - `e2e_scheduling_duration_seconds`
+    - `scheduling_algorithm_duration_seconds`
+    - `framework_extension_point_duration_seconds`
 
 * **Were upgrade and rollback tested? Was upgrade->downgrade->upgrade path tested?**
 
@@ -157,11 +196,20 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 * **Is the rollout accompanied by any deprecations and/or removals of features,
   APIs, fields of API types, flags, etc.?**
   
-  Configuration API `kubescheduler.config.k8s.io/v1alpha2` is removed.
+  When `v1beta1` was introduced:
+  - Configuration API `kubescheduler.config.k8s.io/v1alpha2` is removed.
+  
+  When `v1beta2` was introduced:
+  - Some plugins are disabled. They continue to work in `v1beta1`; if used,
+    kube-scheduler logs a Warning.
 
 ### Monitoring requirements
 
 * **How can an operator determine if the feature is in use by workloads?**
+
+  N/A.
+
+* **How can someone using this feature know that it is working for their instance?**
 
   N/A.
 
@@ -194,7 +242,7 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 
 * **Will enabling / using this feature result in introducing new API types?**
 
-  No.
+  No REST API changes.
 
 * **Will enabling / using this feature result in any new calls to cloud
   provider?**
@@ -235,3 +283,4 @@ This will be documented in https://kubernetes.io/docs/reference/scheduling/profi
 - 2020-05-08: KEP for beta graduation sent for review, including motivation,
   proposal, risks, test plan and graduation criteria.
 - 2020-05-13: KEP updated to remove v1alpha2 support.
+- 2021-07-08: Introducing `v1beta2`

--- a/keps/sig-scheduling/785-scheduler-component-config-api/kep.yaml
+++ b/keps/sig-scheduling/785-scheduler-component-config-api/kep.yaml
@@ -16,8 +16,8 @@ prr-approvers:
   - "@wojtek-t"
 see-also:
   - "/keps/sig-scheduling/1451-multi-scheduling-profiles"
+  - "/keps/sig-scheduling/2458-node-resource-score-strategy"
 stage: beta
-latest-milestone: "v1.19"
+latest-milestone: "v1.22"
 milestone:
   beta: "v1.19"
-  stable: "v1.22"


### PR DESCRIPTION
Add notes for v1beta2.
Remove target milestone for GA.

Note that PRR was completed for 1.19, even though it was optional.

/sig scheduling

Ref kubernetes/enhancements#785