### PR TITLE
KEP-277: Update milestone metadata for 1.22 cycle

### DIFF
--- a/keps/prod-readiness/sig-node/277.yaml
+++ b/keps/prod-readiness/sig-node/277.yaml
@@ -1,3 +1,3 @@
 kep-number: 277
-beta:
+alpha:
   approver: "@johnbelamaric"

--- a/keps/sig-node/277-ephemeral-containers/kep.yaml
+++ b/keps/sig-node/277-ephemeral-containers/kep.yaml
@@ -19,18 +19,18 @@ see-also:
   - "/keps/sig-cli/1441-kubectl-debug"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: alpha
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.22"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.16"
-  beta: "v1.21"
-  stable: "v1.23"
+  beta: "v1.23"
+  stable: "v1.25"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: updating KEP-277 milestones for 1.22 release

<!-- link to the k/enhancements issue -->
- Issue link: #277 

<!-- other comments or additional information -->
- Other comments: Updating per [exception](https://groups.google.com/g/kubernetes-sig-release/c/1A49p2cGl_4/m/vYS0f46CAAAJ) for 1.22