### PR TITLE
KEP-1645: Update MCS API graduation criteria based on 5/11 SIG-MC discussions

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -870,19 +870,18 @@ when drafting this test plan.
 - A detailed DNS spec for multi-cluster services.
 - NetworkPolicy either solved or explicitly ruled out.
 - API group chosen and approved.
-- Implementation strategy defined and approved.
-- Kube-proxy can consume ServiceImport and EndpointSlice.
 - E2E tests exist for MCS services.
 - Beta -> GA Graduation criteria defined.
 - At least one MCS DNS implementation.
 - A formal plan for a standard Cluster ID.
 - Finalize a name for the "supercluster" concept.
+- [Cluster ID KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid) is in beta
 
 #### Beta -> GA Graduation
 
 - Scalability/performance testing, understanding impact on cluster-local service
   scalability.
-- Cluster ID defined, with at least one other multi-cluster use case.
+- [Cluster ID KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid) is GA, with at least one other multi-cluster use case.
 
 <!--
 **Note:** *Not required until targeted at a release.*

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -285,8 +285,8 @@ be recognized as a single combined service. For example, if 5 clusters export
 all exporting clusters. Properties of the `ServiceImport` (e.g. ports, topology)
 will be derived from a merger of component `Service` properties.
 
-Existing implementations of Kubernetes Service API (e.g. kube-proxy) can be
-extended to present `ServiceImports` alongside traditional `Services`.
+This specification is not prescriptive on exact implementation details. Existing implementations of Kubernetes Service API (e.g. kube-proxy) can be
+extended to present `ServiceImports` alongside traditional `Services`. One often discussed implementation requiring no changes to kube-proxy is to have the mcs-controller maintain ServiceImports and create "dummy" or "shadow" Service objects, named after a mcs-controller managed EndpointSlice that aggregates all cross-cluster backend IPs, so that kube-proxy programs those endpoints like a regular Service. Other implementations are encouraged as long as the properties of the API described in this document are maintained.
 
 ### User Stories
 
@@ -790,6 +790,7 @@ connection with the source cluster is confirmed alive. When a lease expires, the
 cluster name and `multicluster.kubernetes.io/source-cluster` label may be used
 to find and remove all `EndpointSlices` containing endpoints from the
 unreachable cluster.
+
 
 ## Constraints and Conflict Resolution
 


### PR DESCRIPTION
- One-line PR description: Update graduation criteria based on 5/11 SIG-MC discussions

- Issue link: https://github.com/kubernetes/enhancements/issues/1645

- Other comments:
  * Removed kube-proxy implementation related items (now consider these an implementation detail0
  * Explicitly tied MCS API to Cluster ID KEP's maturity level
  * Based on conversation on 5/11 SIG-MC meeting, see [slides](https://docs.google.com/presentation/d/1-zWVm3GplfH0A_4QIxve2rZB6ozc_T2pRTPtXbGgBVM/edit?usp=sharing) (notes in speaker notes) and [meeting recording starting at 7:20](https://youtu.be/bAno54l95VA?t=441)

#### TODO
- [x] mention a few examples of implementations (dummy service, if you made kubeproxy work with it, your own thing)