### PR TITLE
KEP-592: Graduate TTL after finish to stable

### DIFF
--- a/keps/prod-readiness/sig-apps/592.yaml
+++ b/keps/prod-readiness/sig-apps/592.yaml
@@ -1,3 +1,5 @@
 kep-number: 592
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/592-ttl-after-finish/README.md
+++ b/keps/sig-apps/592-ttl-after-finish/README.md
@@ -237,7 +237,7 @@ Mitigations:
 
 ### Beta -> GA
 
-- Make a decision on wehther or not the feature should be extended to pods
+- TTL controller will be GA'ed without handling pods. The ability to extend TTL controller to work with pods can be introduced via a feature gate so that we can collect feedback and improve.
 - Enabled in Beta for at least two releases without complaints
 
 [umbrella issues]: https://github.com/kubernetes/kubernetes/issues/42752
@@ -427,3 +427,6 @@ When a Pod is created or updated:
   - indicate that the feature will be graduated for Jobs, and that Pods will be done as future work under a separate flag
   - add production readiness questionnaire
   - mark the feature for Beta graduation for jobs.
+- 2021-07-27: KEP updated to
+  - indicate that the feature will be graduated to stable for Jobs
+  - Pods will be done as future work if the need arises

--- a/keps/sig-apps/592-ttl-after-finish/kep.yaml
+++ b/keps/sig-apps/592-ttl-after-finish/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 592
 authors:
   - "@janetkuo"
   - "@ahg-g"
+  - "@sahilvv"
 owning-sig: sig-apps
 participating-sigs:
   - sig-api-machinery
@@ -23,12 +24,12 @@ superseded-by:
   - n/a
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.23"
   
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: This PR graduates TTL for completed jobs to stable in 1.23

- Issue link: Enhancement issue: #592[https://github.com/kubernetes/enhancements/issues/592]

- Other comments: This was spoken about in the sig-apps meeting on 7/26.