### PR TITLE
OWNERS: Update SIG Docs Chairs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -40,9 +40,7 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
-    - irvifa
     - jimangel
-    - kbarnard10
     - kbhawkey
     - onlydole
     - sftim


### PR DESCRIPTION
Updating SIG Docs chairs.

Ref: https://github.com/kubernetes/website/issues/29354

/cc @parispittman @sftim 