### PR TITLE
KEP-563 - Moving IPv4/IPv6 dual-stack networking to stable in 1.23

### DIFF
--- a/keps/sig-network/563-dual-stack/README.md
+++ b/keps/sig-network/563-dual-stack/README.md
@@ -1379,9 +1379,9 @@ This capability will move to beta when the following criteria have been met.
 
 This capability will move to stable when the following criteria have been met.
 
-* Support of at least one CNI plugin to provide multi-IP
+* Support of at least one CNI plugin to provide multi-IP ([Cilium](https://cilium.io/blog/2021/05/20/cilium-110) and [Calico](https://www.tigera.io/blog/dual-stack-operation-with-calico-on-kubernetes/))
 * e2e test successfully running on two platforms (Azure and kind)
-* testing ingress controller infrastructure with updated dual-stack services
+* dual-stack service object is backwards-compatible with existing ingress controllers, so ingress controller infrastructure remains the same with updated dual-stack services
 * dual-stack tests always run as pre-submit (non-blocking) for PRs
 
 

--- a/keps/sig-network/563-dual-stack/README.md
+++ b/keps/sig-network/563-dual-stack/README.md
@@ -1380,9 +1380,9 @@ This capability will move to beta when the following criteria have been met.
 This capability will move to stable when the following criteria have been met.
 
 * Support of at least one CNI plugin to provide multi-IP
-* e2e test successfully running on two platforms
+* e2e test successfully running on two platforms (Azure and kind)
 * testing ingress controller infrastructure with updated dual-stack services
-* dual-stack tests run as pre-submit blocking for PRs
+* dual-stack tests always run as pre-submit (non-blocking) for PRs
 
 
 ## Production Readiness Review Questionnaire

--- a/keps/sig-network/563-dual-stack/README.md
+++ b/keps/sig-network/563-dual-stack/README.md
@@ -1243,7 +1243,7 @@ v1.21: Moved from `Alpha` to `Beta`
 
 v1.22: Gathering beta user feedback and making bugfixes as needed.
 
-v1.23: Planning to move from `Beta` to `Stable`
+v1.23: Moved from `Beta` to `Stable`
 
 ## Alternatives
 

--- a/keps/sig-network/563-dual-stack/kep.yaml
+++ b/keps/sig-network/563-dual-stack/kep.yaml
@@ -19,10 +19,10 @@ prr-approvers:
   - "@johnbelamaric"
 editor: TBD
 creation-date: "2018-05-21"
-last-updated: "2021-05-03"
-status: implementable
-stage: beta
-latest-milestone: v1.22
+last-updated: "2021-08-13"
+status: implemented
+stage: stable
+latest-milestone: v1.23
 milestone:
   alpha: "v1.20"
   beta: "v1.21"


### PR DESCRIPTION
- One-line PR description:

We anticipate moving IPv4/IPv6 dual-stack networking to stable in 1.23.

- Issue link:

https://github.com/kubernetes/enhancements/issues/563

- This PR contains:

KEP updates for https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/563-dual-stack  

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
