### PR TITLE
keps/sig-testing: refresh KEP status

### DIFF
--- a/keps/sig-testing/2290-new-label-for-trusted-PR-identification/README.md
+++ b/keps/sig-testing/2290-new-label-for-trusted-PR-identification/README.md
@@ -88,7 +88,15 @@ N/A
 
 ## Graduation Criteria
 
-N/A
+Alpha:
+* `/ok-to-test` workflow live
+
+Beta:
+* `/ok-to-test` workflow fully documented
+* Comment parsing for `/ok-to-test` removed in favor of `ok-to-test` label presence
+
+Stable:
+* `/ok-to-test` workflow used without incident for more than 6 months
 
 ## Future evolutions
 
@@ -100,9 +108,13 @@ This would require adding automatically the `ok-to-test` label to member authore
 
 ## References
 
-* https://github.com/kubernetes/test-infra/issues/3827
-* https://github.com/kubernetes/test-infra/issues/7801
-* https://github.com/kubernetes/test-infra/pull/5246
+* Issues
+  * https://github.com/kubernetes/test-infra/issues/3827
+  * https://github.com/kubernetes/test-infra/issues/7801
+  * https://github.com/kubernetes/test-infra/issues/9754
+* PRs
+  * https://github.com/kubernetes/test-infra/pull/5246
+  * https://github.com/kubernetes/test-infra/pull/10991
 
 ## Implementation History
 
@@ -114,3 +126,4 @@ This would require adding automatically the `ok-to-test` label to member authore
 * 2018-10-08: start of implementation
 * 2018-10-10: `ok-to-test` label added
 * 2019-01-29: remove comment parsing code for PR trust
+* 2021-08-16: Retroactive stable declaration

--- a/keps/sig-testing/2290-new-label-for-trusted-PR-identification/kep.yaml
+++ b/keps/sig-testing/2290-new-label-for-trusted-PR-identification/kep.yaml
@@ -1,19 +1,25 @@
 title: New label for trusted PR identification
 kep-number: 2290
 authors:
-  - "@matthyx"
+  - matthyx
 owning-sig: sig-testing
 participating-sigs:
   - sig-contributor-experience
 reviewers:
-  - "@fejta"
-  - "@cjwagner"
-  - "@BenTheElder"
-  - "@cblecker"
-  - "@stevekuznetsov"
+  - fejta
+  - cjwagner
+  - BenTheElder
+  - cblecker
+  - stevekuznetsov
 approvers:
-  - TBD
-editor: TBD
+  - spiffxp
+editor: spiffxp
 creation-date: 2018-06-25
-last-updated: 2019-01-30
+last-updated: 2021-08-16
 status: implemented
+stage: stable
+latest-milestone: v1.13
+milestone:
+  alpha: v1.13
+  beta: v1.13
+  stable: v1.14

--- a/keps/sig-testing/2291-presubmit-config-inside-the-tested-repo/README.md
+++ b/keps/sig-testing/2291-presubmit-config-inside-the-tested-repo/README.md
@@ -13,35 +13,17 @@
   - [Risks and Mitigations](#risks-and-mitigations)
     - [Security](#security)
     - [Components that need the <code>Presubmit</code> configuration but do not have a <code>git ref</code> to work on](#components-that-need-the--configuration-but-do-not-have-a--to-work-on)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
+    - [Beta -&gt; Stable Graduation](#beta---stable-graduation)
 - [Implementation History](#implementation-history)
 <!-- /toc -->
 
 ## Release Signoff Checklist
 
-**ACTION REQUIRED:** In order to merge code into a release, there must be an issue in [kubernetes/enhancements] referencing this KEP and targeting a release milestone **before [Enhancement Freeze](https://github.com/kubernetes/sig-release/tree/master/releases)
-of the targeted release**.
-
-For enhancements that make changes to code or processes/procedures in core Kubernetes i.e., [kubernetes/kubernetes], we require the following Release Signoff checklist to be completed.
-
-Check these off as they are completed for the Release Team to track. These checklist items _must_ be updated for the enhancement to be released.
-
-- [ ] kubernetes/enhancements issue in release milestone, which links to KEP (this should be a link to the KEP location in kubernetes/enhancements, not the initial KEP PR)
-- [ ] KEP approvers have set the KEP status to `implementable`
-- [ ] Design details are appropriately documented
-- [ ] Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
-- [ ] Graduation criteria is in place
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
-
-**Note:** Any PRs to move a KEP to `implementable` or significant changes once it is marked `implementable` should be approved by each of the KEP approvers. If any of those approvers is no longer appropriate than changes to that list should be approved by the remaining approvers and/or the owning SIG (or SIG-arch for cross cutting KEPs).
-
-**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
-
-[kubernetes.io]: https://kubernetes.io/
-[kubernetes/enhancements]: https://github.com/kubernetes/enhancements/issues
-[kubernetes/kubernetes]: https://github.com/kubernetes/kubernetes
-[kubernetes/website]: https://github.com/kubernetes/website
+N/A - this KEP is related to code solely in kubernetes/test-infra that is not
+being used as part of the development or release process for
+kubernetes/kubernetes
 
 ## Summary
 
@@ -149,11 +131,24 @@ Components that need the `Presubmit` config but do not have a git reference at h
 can not work as before with `inrepoconfig` because the list of Presubmits depends on
 the `ref`. This limitation will be documented.
 
+### Graduation Criteria
+
+#### Alpha -> Beta Graduation
+
+* Presubmits implemented
+* Actively used in production by at least one prow deployment
+
+#### Beta -> Stable Graduation
+
+* Postsubmits implemeneted
+* Actively used in production by at least one prow deployment for more than six months
+
 ## Implementation History
 
-* A basic but functioning [prototype](https://github.com/kubernetes/test-infra/pull/12836)
-  for this feature was created that served as initial basis for this KEP.
-* A non-working [sketch pull request](https://github.com/kubernetes/test-infra/pull/13342) that shows which parts of Prow need to be touched
-	and how the signatures for the newly-added functions look like was created to
-	be the basis for a discussion on how exactly an implementation could look like
-* Current work is being tracked via a [GitHub tracking issue](https://github.com/kubernetes/test-infra/issues/13370)
+* 2019-06-19 - Created [basic functional prototype](https://github.com/kubernetes/test-infra/pull/12836) as basis for this KEP
+* 2019-07-19 - Created [non-functional sketch PR](https://github.com/kubernetes/test-infra/pull/13342) for discussion on scope and implementation
+* 2019-07-19 - Created [GitHub tracking issue](https://github.com/kubernetes/test-infra/issues/13370)
+* 2019-11-27 - Implemented [Support for in-repo presubmits](https://github.com/kubernetes/test-infra/pull/14866)
+* 2020-01-14 - Implemented [Support for in-repo postsubmits](https://github.com/kubernetes/test-infra/pull/15667)
+* 2020-03-18 - Declared [done](https://github.com/kubernetes/test-infra/issues/13370#issuecomment-600578245)
+* 2021-08-16 - Retroactive stable declaration ([docs](https://github.com/kubernetes/test-infra/blob/master/prow/inrepoconfig.md))

--- a/keps/sig-testing/2291-presubmit-config-inside-the-tested-repo/kep.yaml
+++ b/keps/sig-testing/2291-presubmit-config-inside-the-tested-repo/kep.yaml
@@ -1,20 +1,23 @@
 title: Presubmit config inside the tested repo
 kep-number: 2291
 authors:
-  - "@alvaroaleman"
+  - alvaroaleman
 owning-sig: sig-testing
 participating-sigs:
   - sig-testing
 reviewers:
-  - "@stevekuznetsov"
-  - "@cjwagner"
+  - stevekuznetsov
+  - cjwagner
 approvers:
-  - "@stevekuznetsov"
-  - "@cjwagner"
-editor: TBD
+  - stevekuznetsov
+  - cjwagner
+editor: spiffxp
 creation-date: 2019-06-04
-last-updated: 2019-07-24
-status: implementable
-
-latest-milestone: "0.0"
-stage: "alpha"
+last-updated: 2021-08-16
+status: implemented
+latest-milestone: v1.18
+stage: stable
+milestone:
+  alpha: v1.15
+  beta: v1.16
+  stable: v1.18

--- a/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/README.md
+++ b/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/README.md
@@ -556,6 +556,7 @@ Major milestones might include:
 - 2020-02-08 - KEP Implementable [#2469](https://github.com/kubernetes/enhancements/pull/2469)
 - 2020-04-01 - KEP Alpha, Beta in Kubernetes 1.21
   - There is no distinct alpha/beta for this KEP, only alpha/beta (implemented at HEAD) vs stable (all supported branches)
+- 2020-08-16 - Retroactive implemented declaration
 
 See also PR listing: https://github.com/kubernetes/enhancements/issues/2420#issuecomment-791024902
 

--- a/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/kep.yaml
+++ b/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/kep.yaml
@@ -6,8 +6,9 @@ authors:
 owning-sig: sig-testing
 participating-sigs:
   - sig-release
-status: implementable
+status: implemented
 creation-date: 2021-02-03
+last-updated: 2021-08-16
 reviewers:
   - dims
   - liggitt
@@ -21,18 +22,18 @@ see-also: []
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: v1.21
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.21"
-  beta: "v1.21"
-  stable: "v1.23"
+  alpha: v1.21
+  beta: v1.21
+  stable: v1.23
 
 # these are N/A
 # The following PRR answers are required at alpha release

--- a/keps/sig-testing/2464-kubetest2-ci-migration/kep.yaml
+++ b/keps/sig-testing/2464-kubetest2-ci-migration/kep.yaml
@@ -6,14 +6,14 @@ owning-sig: sig-testing
 participating-sigs:
 - sig-release
 - sig-scalability
-status: implementable
+status: implemented
 creation-date: 2021-02-08
+last-updated: 2021-08-16
 reviewers:
 - BenTheElder
 approvers:
 - spiffxp
 - saschagrunert
-
 # NOTE: there's no production change in this KEP
 prr-approvers:
 - johnbelamaric 
@@ -26,14 +26,14 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: v1.21
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.21"
+  alpha: v1.21
   # TODO: figure out if these are the right milestones for beta/stable.
-  beta: "v1.22"
-  stable: "v1.23"
+  beta: v1.23
+  stable: v1.24
 
 # N/A
 # The following PRR answers are required at alpha release

--- a/keps/sig-testing/2539-continuously-deploy-k8s-prow/README.md
+++ b/keps/sig-testing/2539-continuously-deploy-k8s-prow/README.md
@@ -147,7 +147,10 @@ Before enabling Alpha phase, this will be announced:
 - Via email to the entire kubernetes-dev@googlegroups.com group
 
 ## Implementation History
-
+- 2021-02-23 - KEP [authored](https://github.com/kubernetes/enhancements/pull/2540)
+- 2021-03-31 - KEP [moved to implementable](https://github.com/kubernetes/enhancements/pull/2553)
+- 2021-04-01 - KEP implemented at alpha ([announcement](https://groups.google.com/g/kubernetes-dev/c/nke9PYaGTnY/m/nrQ6hVDfCgAJ))
+- 2021-08-16 - Retroactively declared beta
 
 ## Alternatives
 

--- a/keps/sig-testing/2539-continuously-deploy-k8s-prow/kep.yaml
+++ b/keps/sig-testing/2539-continuously-deploy-k8s-prow/kep.yaml
@@ -1,21 +1,21 @@
 title: Continuously Deploy K8s Prow
 kep-number: 2539
 authors:
-  - "@chaodaiG"
+- chaodaiG
 owning-sig: sig-testing
 participating-sigs:
-  - sig-testing
-  - sig-release
-status: implementable
+- sig-testing
+- sig-release
+status: implemented
 creation-date: 2021-02-23
+last-updated: 2021-08-16
 reviewers:
-  - "@spiffxp" # Sig-testing chair
-  - "@justaugustus" # Sig-release chair
-  - "@alvaroaleman" # Prow approver
+- spiffxp       # sig-testing chair
+- justaugustus  # sig-release chair
+- alvaroaleman  # prow approver
 approvers:
-  - "@spiffxp" # Sig-testing chair
-  - "@justaugustus" # Sig-release chair
-  - "@alvaroaleman" # Prow approver
-
-latest-milestone: "0.0"
-stage: "alpha"
+- spiffxp       # sig-testing chair
+- justaugustus  # sig-release chair
+- alvaroaleman  # prow approver
+latest-milestone: v1.21
+stage: beta

--- a/keps/sig-testing/714-break-test-tarball/README.md
+++ b/keps/sig-testing/714-break-test-tarball/README.md
@@ -276,3 +276,5 @@ Similar discussion and work on the other release tarballs:
   created, deprecation notice included in mondo test tarball
 - 2019-02-22: implementation https://github.com/kubernetes/kubernetes/pull/74065
   merged
+- 2019-09-24: Stop building kubernetes-test.tar.gz: https://github.com/kubernetes/kubernetes/pull/83093
+- 2021-08-16: Retroactive stable declaration

--- a/keps/sig-testing/714-break-test-tarball/kep.yaml
+++ b/keps/sig-testing/714-break-test-tarball/kep.yaml
@@ -1,17 +1,23 @@
 title: Breaking apart the Kubernetes test tarball
 kep-number: 714
 authors:
-  - "@ixdy"
+- ixdy
 owning-sig: sig-testing
 participating-sigs:
-  - sig-release
+- sig-release
 reviewers:
-  - "@akutz"
-  - "@amwat"
+- akutz
+- amwat
 approvers:
-  - "@spiffxp"
-  - "@tpepper"
-editor: TBD
+- spiffxp
+- tpepper
+editor: spiffxp
 creation-date: 2019-01-18
-last-updated: 2019-03-06
+last-updated: 2021-08-16
 status: implemented
+stage: stable
+latest-milestone: v1.17
+milestone:
+  alpha: v1.14
+  beta: v1.14
+  stable: v1.17


### PR DESCRIPTION
If folks would prefer I break this up into a PR-per-KEP I can do that
too...

I wanted to make sure the output of `kepctl query --sig testing`
reflected reality. A number of fields were missing or stale, so I
reconciled:

- if we're aiming for graduation this cycle,the KEP is `status: implementable`
  and `stage: the-target-stage-for-this-release`
- if this is a retroactive change, the KEP is `status: implemented` and
  `stage: whatever-stage-was-reached`
- KEPs done before we had formal graduation criteria or implementation
  history had best guesses added
- a `scope: out-of-tree` field was added to KEPs primarily covering code
  not in kubernetes/kubernetes
- a `scope: in-tree` field was added to KEPs primarily covering code in
  kubernetes/kubernetes, even if it wasn't compiled into a release
  binary used to run a kubernetes cluster
- avoid `@foo` in kep.yaml in favor of `foo` and generally reduce the "amount"
  "of" "things" "wrapped" "in" "quotes"

Broke out proposed v1.23 KEP graduations to https://github.com/kubernetes/enhancements/pull/2871