### PR TITLE
Make feature gate for sig-apps/2255-pod-cost consistent with docs

### DIFF
--- a/keps/sig-apps/2255-pod-cost/README.md
+++ b/keps/sig-apps/2255-pod-cost/README.md
@@ -169,7 +169,7 @@ N/A
 
 * **How can this feature be enabled / disabled in a live cluster?**
   - [x] Feature gate (also fill in values in `kep.yaml`)
-    - Feature gate name: ReplicaSetPodDeletionCost
+    - Feature gate name: PodDeletionCost
     - Components depending on the feature gate: kube-controller-manager
   - [ ] Other
     - Describe the mechanism:

--- a/keps/sig-apps/2255-pod-cost/kep.yaml
+++ b/keps/sig-apps/2255-pod-cost/kep.yaml
@@ -38,7 +38,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
- - name: ReplicaSetPodDeletionCost
+ - name: PodDeletionCost
    components:
      - kube-controller-manager
 disable-supported: true


### PR DESCRIPTION
The feature gate name for pod deletion cost was mentioned as `ReplicaSetPodDeletionCost`.
According to the docs and [here](https://github.com/kubernetes/kubernetes/blob/9f7e079a5b0fc689aa7847ec8e5e189cac93c033/pkg/features/kube_features.go#L617) the feature gate name should be `PodDeletionCost`.

Signed-off-by: Madhav Jivrajani <madhav.jiv@gmail.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Edit feature gate name for pod deletion cost

<!-- link to the k/enhancements issue -->
- Issue link: None

<!-- other comments or additional information -->
- Other comments: None