### PR TITLE
keps: centralize yaml calls, use UnmarshalStrict

### DIFF
--- a/api/approval.go
+++ b/api/approval.go
@@ -23,7 +23,8 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
+
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 type PRRApprovals []*PRRApproval
@@ -108,7 +109,7 @@ func (p *PRRHandler) Parse(in io.Reader) (*PRRApproval, error) {
 		return approval, errors.Wrap(err, "reading file")
 	}
 
-	if err := yaml.Unmarshal(body.Bytes(), &approval); err != nil {
+	if err := yaml.UnmarshalStrict(body.Bytes(), &approval); err != nil {
 		p.Errors = append(p.Errors, errors.Wrap(err, "error unmarshalling YAML"))
 		return approval, errors.Wrap(err, "unmarshalling YAML")
 	}

--- a/api/groups.go
+++ b/api/groups.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"sigs.k8s.io/yaml"
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 // GroupFetcher is responsible for getting informationg about groups in the
@@ -147,9 +147,10 @@ func (f *RemoteGroupFetcher) FetchPRRApprovers() ([]string, error) {
 	}
 
 	config := &struct {
-		Data map[string][]string `json:"aliases,omitempty"`
+		Data map[string][]string `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 	}{}
-	if err := yaml.Unmarshal(body, config); err != nil {
+
+	if err := yaml.UnmarshalStrict(body, config); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling owners aliases")
 	}
 

--- a/api/proposal.go
+++ b/api/proposal.go
@@ -26,7 +26,8 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
+
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 var ValidStages = []string{
@@ -119,7 +120,7 @@ func (k *KEPHandler) Parse(in io.Reader) (*Proposal, error) {
 		kep.Contents = ""
 	}
 
-	if err := yaml.Unmarshal(metadata, &kep); err != nil {
+	if err := yaml.UnmarshalStrict(metadata, &kep); err != nil {
 		k.Errors = append(k.Errors, errors.Wrap(err, "error unmarshalling YAML"))
 		return kep, errors.Wrap(err, "unmarshalling YAML")
 	}
@@ -194,9 +195,11 @@ func (k *KEPHandler) Validate(p *Proposal) []error {
 }
 
 type Milestone struct {
-	Alpha  string `json:"alpha" yaml:"alpha"`
-	Beta   string `json:"beta" yaml:"beta"`
-	Stable string `json:"stable" yaml:"stable"`
+	Alpha      string `json:"alpha" yaml:"alpha"`
+	Beta       string `json:"beta" yaml:"beta"`
+	Stable     string `json:"stable" yaml:"stable"`
+	Deprecated string `json:"deprecated" yaml:"deprecated,omitempty"`
+	Removed    string `json:"removed" yaml:"removed,omitempty"`
 }
 
 type FeatureGate struct {

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/release v0.7.1-0.20210218090651-d71805402dab
 	k8s.io/test-infra v0.0.0-20200813194141-e9678d500461
-	sigs.k8s.io/yaml v1.2.0
 )

--- a/keps/sig-network/2595-expanded-dns-config/kep.yaml
+++ b/keps/sig-network/2595-expanded-dns-config/kep.yaml
@@ -31,7 +31,7 @@ latest-milestone: "v1.22"
 milestone:
   alpha: "v1.22"
   beta: "x.y"
-  GA: "x.y"
+  stable: "x.y"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-node/2727-grpc-probe/kep.yaml
+++ b/keps/sig-node/2727-grpc-probe/kep.yaml
@@ -9,7 +9,7 @@ participating-sigs:
   - sig-network
 status: implementable
 creation-date: 2020-04-04
-modified-date: 2021-05-12
+last-updated: 2021-05-12
 reviewers:
   - "@thockin"
   - "@mrunalp"

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
-	"gopkg.in/yaml.v3"
 
 	"k8s.io/enhancements/api"
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 const (

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -30,12 +30,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
-	"gopkg.in/yaml.v3"
+
+	krgh "k8s.io/release/pkg/github"
+	"k8s.io/test-infra/prow/git"
 
 	"k8s.io/enhancements/api"
 	"k8s.io/enhancements/pkg/kepval"
-	krgh "k8s.io/release/pkg/github"
-	"k8s.io/test-infra/prow/git"
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 const (
@@ -439,7 +440,7 @@ func (r *Repo) loadKEPFromYaml(kepPath string) (*api.Proposal, error) {
 	}
 
 	var p api.Proposal
-	err = yaml.Unmarshal(b, &p)
+	err = yaml.UnmarshalStrict(b, &p)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load KEP metadata: %s", err)
 	}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"k8s.io/release/pkg/log"
 
 	"k8s.io/enhancements/api"
 	"k8s.io/enhancements/pkg/repo"
-	"k8s.io/release/pkg/log"
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 var fixture = struct {
@@ -91,7 +91,7 @@ func TestProposalValidate(t *testing.T) {
 			require.NoError(t, err)
 
 			var p api.Proposal
-			err = yaml.Unmarshal(b, &p)
+			err = yaml.UnmarshalStrict(b, &p)
 			require.NoError(t, err)
 
 			errs := parser.Validate(&p)

--- a/pkg/repo/write.go
+++ b/pkg/repo/write.go
@@ -24,8 +24,9 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 	"k8s.io/enhancements/api"
+
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 func (r *Repo) WriteKEP(kep *api.Proposal) error {

--- a/pkg/repo/write_test.go
+++ b/pkg/repo/write_test.go
@@ -27,7 +27,8 @@ import (
 
 	"k8s.io/enhancements/api"
 	"k8s.io/enhancements/pkg/repo"
-	"sigs.k8s.io/yaml"
+
+	"k8s.io/enhancements/pkg/yaml"
 )
 
 // TODO: Consider using afero to mock the filesystem here
@@ -126,7 +127,7 @@ func TestWriteKep(t *testing.T) {
 			require.NoError(t, err)
 
 			var p api.Proposal
-			err = yaml.Unmarshal(b, &p)
+			err = yaml.UnmarshalStrict(b, &p)
 			require.NoError(t, err)
 
 			p.OwningSIG = tc.sig

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yaml
+
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UnmarshalStrict unmarshals the contents of body into the given interface,
+// and returns an error if any duplicate or unknown fields are encountered
+func UnmarshalStrict(body []byte, v interface{}) error {
+	r := bytes.NewReader(body)
+	d := yaml.NewDecoder(r)
+	d.KnownFields(true)
+	err := d.Decode(v)
+	return err
+}
+
+// Marshal returns a byte array containing a YAML representation of the
+// given interface, and a non-nil error if there was an error
+func Marhsal(v interface{}) ([]byte, error) {
+	return yaml.Marshal(v)
+}

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -34,6 +34,6 @@ func UnmarshalStrict(body []byte, v interface{}) error {
 
 // Marshal returns a byte array containing a YAML representation of the
 // given interface, and a non-nil error if there was an error
-func Marhsal(v interface{}) ([]byte, error) {
+func Marshal(v interface{}) ([]byte, error) {
 	return yaml.Marshal(v)
 }


### PR DESCRIPTION
Prompted by
https://github.com/kubernetes/enhancements/pull/2867#issuecomment-899887426
I decided it would be worth having tests enforce that fields in
KEP-related yaml are well known (vs. allowing addition of unknown
fields)

This codebase largely used `gopkg.in/yaml.v3` but also `sigs.k8s.io/yaml` in
some places, which each have different ways of accomplishing "return
error if there are unknown or duplicate fields" functionality.  I opted
to pull calls to `yaml.Unmarshal` and `yaml.Marshal` into a helper
package, `k8s.io/enhancements/pkg/yaml`, so there's only one place to
change for yaml-related changes.

I then converged on a `gopkg.in/yaml.v3` implementation of
`yaml.UnmarshalStrict` to accomplish erroring on unknown fields, and
corrected the KEPs that failed tests as a result. The reasoning for
choice of library was: most everything already used it, and it supports
preserving comments (not that the code as-written does). I don't feel
strongly about switching it back to sigs.k8s.io/yaml though if that's
the preference

The ony controversial change was to support the KEP that added
"deprecated" and "removed" milestones. I opted to add those to the API
but am open to suggestion on how that could be better encoded in the
`Proposal` struct that we have today.