### PR TITLE
keps/sig-testing: propose v1.23 graduations

### DIFF
--- a/keps/prod-readiness/sig-testing/2420.yaml
+++ b/keps/prod-readiness/sig-testing/2420.yaml
@@ -1,3 +1,5 @@
 kep-number: 2420
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/prod-readiness/sig-testing/2464.yaml
+++ b/keps/prod-readiness/sig-testing/2464.yaml
@@ -1,3 +1,5 @@
 kep-number: 2464
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/kep.yaml
+++ b/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/kep.yaml
@@ -6,7 +6,7 @@ authors:
 owning-sig: sig-testing
 participating-sigs:
   - sig-release
-status: implemented
+status: implementable
 creation-date: 2021-02-03
 last-updated: 2021-08-16
 reviewers:
@@ -27,7 +27,7 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: v1.21
+latest-milestone: v1.23
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/keps/sig-testing/2464-kubetest2-ci-migration/kep.yaml
+++ b/keps/sig-testing/2464-kubetest2-ci-migration/kep.yaml
@@ -6,7 +6,7 @@ owning-sig: sig-testing
 participating-sigs:
 - sig-release
 - sig-scalability
-status: implemented
+status: implementable
 creation-date: 2021-02-08
 last-updated: 2021-08-16
 reviewers:
@@ -21,7 +21,7 @@ see-also: []
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively


### PR DESCRIPTION
Broken out of https://github.com/kubernetes/enhancements/pull/2867

KEPs this proposes for graduation in v1.23:
- graduate to stable: https://github.com/kubernetes/enhancements/issues/2420
- graduate to beta: https://github.com/kubernetes/enhancements/issues/2464

/hold
For https://github.com/kubernetes/enhancements/pull/2867 to merge