### PR TITLE
[1.24] Mark 1558 kep status to implemented

### DIFF
--- a/keps/sig-node/1558-streaming-proxy-redirects/README.md
+++ b/keps/sig-node/1558-streaming-proxy-redirects/README.md
@@ -225,3 +225,8 @@ See [Rollout breakage](#rollout-breakage).
 ## Implementation History
 
 - _2019-12-05_: Published KEP
+- _2020-02-19_: Mark the `--redirect-container-streaming` flag as deprecated. Log a warning on use.
+Mark the `StreamingProxyRedirects` feature as deprecated. Log a warning on use in v1.18.
+- _2020-10-28_: `--redirect-container-streaming` can no longer be enabled in v1.20.
+- _2021-04-30_: Default `StreamingProxyRedirects` to disabled in v1.22.
+- _2021-12-06_: Removed `StreamingProxyRedirects` feature gate in v1.24.

--- a/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
+++ b/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
@@ -14,10 +14,10 @@ approvers:
   - "@Random-Liu"
   - "@derekwaynecarr"
 creation-date: 2019-12-05
-last-updated: 2021-08-19
+last-updated: 2022-07-12
 status: implemented
 replaces:
   - "https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#heading=h.4yfjiw58o8d3"
 
-latest-milestone: "1.22"
+latest-milestone: "1.24"
 stage: "stable"

--- a/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
+++ b/keps/sig-node/1558-streaming-proxy-redirects/kep.yaml
@@ -14,8 +14,8 @@ approvers:
   - "@Random-Liu"
   - "@derekwaynecarr"
 creation-date: 2019-12-05
-last-updated: 2021-05-11
-status: implementable
+last-updated: 2021-08-19
+status: implemented
 replaces:
   - "https://docs.google.com/document/d/1OE_QoInPlVCK9rMAx9aybRmgFiVjHpJCHI9LrfdNM_s/edit#heading=h.4yfjiw58o8d3"
 


### PR DESCRIPTION
the --redirect-container-streaming flag and feature gate will be removed in 1.24

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: update kep status of `Streaming Proxy Redirects [DEPRECATED]`

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1558

<!-- other comments or additional information -->
- Other comments: