### PR TITLE
KEP: 961: Updating release info maxUnavailable for StatefulSet

### DIFF
--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -13,7 +13,7 @@ approvers:
   - "@kow3ns"
 editor: TBD
 creation-date: 2018-12-29
-last-updated: 2021-05-06
+last-updated: 2021-08-22
 status: implementable
 see-also:
   - n/a
@@ -24,8 +24,8 @@ superseded-by:
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.22"
-  beta: "v1.23"
-  stable: "v1.24"
-latest-milestone: "v1.22"
+  alpha: "v1.23"
+  beta: "v1.24"
+  stable: "v1.25"
+latest-milestone: "v1.23"
 stage: "alpha"


### PR DESCRIPTION
/sig apps