### PR TITLE
KEP-277: Update for beta in 1.23

### DIFF
--- a/keps/prod-readiness/sig-node/277.yaml
+++ b/keps/prod-readiness/sig-node/277.yaml
@@ -1,3 +1,5 @@
 kep-number: 277
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/277-ephemeral-containers/kep.yaml
+++ b/keps/sig-node/277-ephemeral-containers/kep.yaml
@@ -9,7 +9,7 @@ participating-sigs:
 status: implementable
 creation-date: 2019-02-12
 reviewers:
-  - "@yujuhong"
+  - "@dchen1107"
 approvers:
   - "@dchen1107"
   - "@liggitt"
@@ -19,12 +19,12 @@ see-also:
   - "/keps/sig-cli/1441-kubectl-debug"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -43,4 +43,6 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - kubelet_container_errors_total
+  - kubelet_started_containers_total
+  - kubelet_started_containers_errors_total
+  - kubelet_managed_ephemeral_containers


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Updating ephemeral containers KEP for beta in 1.23

<!-- link to the k/enhancements issue -->
- Issue link: #277

<!-- other comments or additional information -->
- Other comments: This KEP was approved for beta for 1.21 in #2244 but then reverted to alpha in order to make an API change that landed in 1.22.
- Changes to the KEP in this PR include:
  - Placing the removal of ephemeral containers out of scope for this KEP. It will be addressed in a future proposal.
  - Updating PRR questions for names that changed during implementation