### PR TITLE
KEP-2579: PodSecurity beta / 1.23 updates

### DIFF
--- a/keps/prod-readiness/sig-auth/2579.yaml
+++ b/keps/prod-readiness/sig-auth/2579.yaml
@@ -1,3 +1,5 @@
 kep-number: 2579
 alpha:
   approver: "@deads2k"
+beta:
+  approver: "@deads2k"

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -426,11 +426,18 @@ This means that an existing pod which is not valid according to the current
 
 #### Other Pod Subresources
 
-Aside from ephemeral containers, the policy is not checked for any other Pod subresources (status,
-bind, logs, exec, attach, port-forward).
+The policy is not checked for the following Pod subresources:
+- attach
+- binding
+- eviction
+- exec
+- log
+- portforward
+- proxy
+- status
 
 Although annotations can be updated through the status subresource, the apparmor annotations are
-immutable and the seccomp annotations are deprecated and slated for removal in v1.23.
+immutable and the seccomp annotations are validated to match the `seccompProfile` field present in the pod spec.
 
 ### Pod Security Standards
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -561,16 +561,14 @@ _Note: These fields should be unconditionally restricted, regardless of targeted
 
 ### Windows Support
 
-In the initial alpha implementation, Windows pods will be supported by both the `privileged` and
-`baseline` profiles. Windows pods _may_ be broken by the restricted field, which requires setting
-linux-specific settings (such as seccomp profile, run as non root, and disallow privilege
-escalation). If the Kubelet and/or container runtime choose to ignore these linux-specific values at
-runtime, then windows pods should still be allowed under the restricted profile, although the
-profile will not add additional enforcement over baseline (for Windows).
+The `privileged` and `baseline` levels do not require any OS-specific fields to be set.
 
-Windows support will be reevaluated prior to this policy feature going to beta, or if/when
-Kubernetes adds support to definitively distinguish between Windows and Linux workloads. See
-[Windows restricted profile support](#windows-restricted-profile-support) for more details.
+The `restricted` level currently requires fields that are Linux-specific, which may prevent
+Windows pods from running or require Windows kubelets to ignore those fields.
+
+A mechanism for Windows-specific exemptions or requirements in the `restricted` profile is
+described in the ["future work" section](#windows-restricted-profile-support) and addressed by
+[KEP-2802](https://github.com/kubernetes/enhancements/issues/2802).
 
 ### Flexible Extension Support
 
@@ -1041,6 +1039,14 @@ Risk: If a Windows RuntimeClass uses a runtime handler that is also configured o
 a user can just create a linux pod with the Windows RuntimeClass and manually schedule it to a linux
 node to bypass the policy checks. For example, this would be the case if the cluster was exclusively
 using the dockershim runtime, which requires the hardcoded `docker` runtime handler to be set.
+
+[KEP-2802](https://github.com/kubernetes/enhancements/issues/2802) proposes allowing a Pod to indicate its OS.
+As part of that KEP:
+* Pod validation will be adjusted to ensure values are not required
+  for OS-specific fields that are irrelevant to the Pod's OS.
+* Pod Security Standards will be reviewed and updated to indicate which Pod OSes they apply to
+* The `restricted` Pod Security Standard will be reviewed to see if there are Windows-specific requirements that should be added
+* The PodSecurity admission implementation will be updated to skip checks which do not apply to the Pod's OS.
 
 ### Offline Policy Checking
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -43,11 +43,9 @@
 - [Optional Future Extensions](#optional-future-extensions)
   - [Automated PSP migration tooling](#automated-psp-migration-tooling)
   - [Rollout of baseline-by-default for unlabeled namespaces](#rollout-of-baseline-by-default-for-unlabeled-namespaces)
-  - [Custom Profiles](#custom-profiles)
   - [Custom Warning Messages](#custom-warning-messages)
   - [Windows restricted profile support](#windows-restricted-profile-support)
   - [Offline Policy Checking](#offline-policy-checking)
-  - [Event recording](#event-recording)
   - [Conformance](#conformance)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
@@ -976,13 +974,6 @@ or combined for a more aggressive rollout:
 
 Each step in the rollout could be overridden with a flag (e.g. force the admission plugin to step N)
 
-### Custom Profiles
-
-Allow custom profile levels to be statically configured. E.g.
-`--extra-pod-security-levels=host-network`. Custom profiles are ignored by the built-in admission
-plugin, and must be handled completely by a 3rd party webhook (including the dry-run implementation,
-if desired).
-
 ### Custom Warning Messages
 
 An optional `pod-security.kubernetes.io/warn-message` annotation can be used to return a custom
@@ -1017,10 +1008,6 @@ As part of that KEP:
 We could provide a standalone tool that is capable of checking the policies against resource files
 or through stdin. It should be capable of evaluating `AdmissionReview` resources, but also pod and
 templated pod resources. This could be useful in CI/CD pipelines and tests.
-
-### Event recording
-
-Allow recording an event in response to a pod creation attempt that exceeds a given level.
 
 ### Conformance
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -419,33 +419,10 @@ against audit & warn policies, independent of which fields are being modified.
 
 #### Ephemeral Containers
 
-In the initial implementation, ephemeral containers will be subject to the same policy restrictions,
+Ephemeral containers will be subject to the same policy restrictions,
 and adding or updating ephemeral containers will require a full policy check.
-
-<<[UNRESOLVED]>>
-
-_Non-blocking for alpha. This should be resolved for beta._
-
-Once ephemeral containers allow [custom security contexts], it may be desirable to run an ephemeral
-container with higher privileges for debugging purposes. For example, CAP_SYS_PTRACE is forbidden by
-the baseline policy but can be useful in debugging. We could introduce yet-another-mode-label that
-only applies enforcement to ephemeral containers (defaults to the enforce policy).
-
-[custom security contexts]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/277-ephemeral-containers#configurable-security-policy
-
-One way this could be handled under the current model is:
-1. Exempt a special username (not one that can be authenticated directly) from policy enforcement,
-   e.g. `ops:privileged-debugger`
-2. Grant the special user permission to ONLY operate on the ephemeral containers subresource (it is
-   critical that they cannot create or update pods directly).
-3. Grant (real) users that should have privileged debug capability the ability to impersonate the
-   exempt user.
-
-We could consider ways to streamline the user experience of this, for instance adding a special RBAC
-binding that exempts users when operating on the ephemeral containers subresource (e.g. an
-`escalate-privilege` verb on the ephemeral containers subresource).
-
-<<[/UNRESOLVED]>>
+This means that an existing pod which is not valid according to the current
+`enforce` policy will not be permitted to add or modify ephemeral containers.
 
 #### Other Pod Subresources
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -225,13 +225,7 @@ field wasn't added until Kubernetes v1.8, and all containers prior to v1.8 impli
 - `true` (equal in privilege to a v1.7 pod that didn't set the field)
 - `false` (strictly less privileged than other allowed values)
 
-<<[UNRESOLVED]>>
-
-_Blocking for Beta._
-
-How long will old profiles be kept for? What is the removal policy?
-
-<<[/UNRESOLVED]>>
+Definitions of policy levels for previous versions will be kept in place indefinitely.
 
 ### PodTemplate Resources
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -630,22 +630,21 @@ The metric will use the following labels:
 
 The following audit annotations will be added:
 
-1. `pod-security.kubernetes.io/enforce-policy = <policy_level>:<resolved_version>` Record which policy was evaluated
+1. `pod-security.kubernetes.io/enforce-policy = "<policy_level>:<version>"` - Record which policy was evaluated
    for enforcing mode.
-    - Resolved version is the actual version of the policy that was evaluated, so in the case of
-      `latest` or future versions, it will be `latest@<version>` where `<version>` is the tagged
-      version of the apiserver or webhook (e.g. `latest@v1.22.5-build.8`).
+    - version is `latest` or a specific version in the form `v1.x`
     - This annotation is only recorded when a policy is enforced. Specifically, it will not be
       recorded for irrelevant updates or exempt requests.
-2. `pod-security.kubernetes.io/audit-policy = <policy_level>:<resolved_version>` Same as `enforce-policy`, but for
-   audit mode policies (only included when an audit policy is set).
-3. `pod-security.kubernetes.io/enforce-violations = <policy violations>` When an enforcing policy is violated, record
-   the violations here.
-4. `pod-security.kubernetes.io/audit-violations = <policy violations>` When an audit mode policy is violated, record
-   the violations here.
-5. `pod-security.kubernetes.io/exempt = [user, namespace, runtimeClass]` For exempt requests, record the parameters
-   that triggered the exemption here.
+2. `pod-security.kubernetes.io/audit-violations = "<policy violations>"` - When an audit mode policy is violated, record
+   the violation messages here.
+3. `pod-security.kubernetes.io/exempt = "namespace" | "user" | "runtimeClass"` - For exempt requests, record the parameter
+   that triggered the exemption here. If multiple parameters are exempt, the first in this ordered list will be returned:
+   - namespace
+   - user
+   - runtimeClass
+4. `pod-security.kubernetes.io/error = "<evaluation errors>"` - Errors evaluating policies are recorded here
 
+Violation messages returned by enforcing policies are included in the `responseStatus` portion of audit events in the `ResponseComplete` stage.
 
 ### PodSecurityPolicy Migration
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -609,38 +609,22 @@ pod_security_evaluations_total
 
 The metric will use the following labels:
 
-1. `decision {allow, deny, exempt, error}` - The policy decision. Error is reserved for panics or
+1. `decision {exempt, allow, deny, error}` - The policy decision. Error is reserved for panics or
    other errors in policy evaluation. Update requests that are out of scope (see [Updates](#updates)
    above) are not counted.
 3. `policy_level {privileged, baseline, restricted}` - The policy level that the request was
    evaluated against.
-4. `policy_version {latest, v1.YY, >v1.ZZ}` - The policy version that was used for the evaluation.
-   How to constrain cardinality is unresolved (see below).
+4. `policy_version {v1.X, v1.Y, latest, future}` - The policy version that was used for the evaluation.
+   Explicit versions less than or equal to the build of the API server or webhook are recorded in the form `v1.x` (e.g. `v1.22`).
+   Explicit versions greater than the build of the API server or webhook (which are evaluated as `latest`) are recorded as `future`.
+   Explicit use of the `latest` version or implicit use by omitting a version or specifying an unparseable version will be recorded as `latest`.
 5. `mode {enforce, warn, audit}` - The type of evaluation mode being recorded. Note that a single
    request can increment this metric 3 times, once for each mode. If this admission controller is
    enabled, every every create request and in-scope update request will at least increment the
-   `enforce` total.
+   `enforce` total. Privileged evaluations for warn and audit modes are not counted.
 6. `request_operation {create, update}` - The operation of the request being checked.
 7. `resource {pod, controller}` - Whether the request object is a Pod, or a [templated
    pod](#podtemplate-resources) resource.
-
-<<[UNRESOLVED]>>
-
-_Non-blocking: can be decided on the implementing PR_
-
-How should policy version labels be handled, to control cardinality? Specifically:
-- How should future versions be labeled?
-- How should (very old) past versions be labeled?
-
-Ideas:
-- If the version is set higher than `v{latest+1}`, then `>v{latest+1}`
-  will be used. In other words, if the current version of the admission controller is v1.22, then a
-  version of `v1.23` would be unchanged, but `v1.24` would be recorded as `>v1.23`.
-    - Concern that the sliding-window approach will cause issues with historical data.
-- If the version is set higher than latest, simply record it as `future`. Allow recording of all
-  past versions.
-
-<<[/UNRESOLVED]>>
 
 ### Audit Annotations
 

--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -692,10 +692,10 @@ The initial alpha implementation targeting v1.22 includes:
 We are targeting Beta in v1.23.
 
 1. Resolve the following sections:
-    - [ ] [Restricted policy support for Windows pods](#windows-restricted-profile-support)
-    - [ ] [Deprecation / removal policy for old profile versions](#versioning)
-    - [ ] [Ephemeral containers support](#ephemeral-containers)
-    - [ ] [PSP migration workflow & support](#podsecuritypolicy-migration)
+    - [x] [Restricted policy support for Windows pods](#windows-restricted-profile-support)
+    - [x] [Deprecation / removal policy for old profile versions](#versioning)
+    - [x] [Ephemeral containers support](#ephemeral-containers)
+    - [x] [PSP migration workflow & support](#podsecuritypolicy-migration)
 2. Collect feedback from the alpha, analyze usage of the webhook implementation. In particular, re-assess these API decisions:
     - Distinct `audit` and `warn` modes
     - Whether `enforce` should warn on templated pod resources
@@ -1023,6 +1023,8 @@ As this feature progresses towards GA, we should think more about how it interac
 
 - 2021-03-16: [Initial proposal](https://docs.google.com/document/d/1dpfDF3Dk4HhbQe74AyCpzUYMjp4ZhiEgGXSMpVWLlqQ/edit?ts=604b85df#)
               provisionally accepted.
+- 2021-08-04: v1.22 Alpha version released
+- 2021-08-24: v1.23 Beta KEP updates
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.
 Major milestones might include:

--- a/keps/sig-auth/2579-psp-replacement/kep.yaml
+++ b/keps/sig-auth/2579-psp-replacement/kep.yaml
@@ -29,17 +29,17 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
-  beta: TBD
+  beta: "v1.23"
   stable: TBD
 
 # The following PRR answers are required at alpha release

--- a/keps/sig-auth/2579-psp-replacement/kep.yaml
+++ b/keps/sig-auth/2579-psp-replacement/kep.yaml
@@ -52,4 +52,4 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - TBD
+  - pod_security_evaluations_total

--- a/keps/sig-auth/2579-psp-replacement/kep.yaml
+++ b/keps/sig-auth/2579-psp-replacement/kep.yaml
@@ -24,7 +24,8 @@ approvers:
   - "@tabbysable"
 prr-approvers:
   - "@deads2k"
-see-also: []
+see-also:
+  - https://github.com/kubernetes/enhancements/issues/2802
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.


### PR DESCRIPTION
- One-line PR description: beta updates for PodSecurity

- Issue link: #2579 

- Best reviewed commit-by-commit (for most reviewers, there's only a single relevant commit)

/sig auth
