### PR TITLE
KEP-2365: Mark as stable for v1.23

### DIFF
--- a/keps/prod-readiness/sig-network/2365.yaml
+++ b/keps/prod-readiness/sig-network/2365.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-network/2365-ingressclass-namespaced-params/kep.yaml
+++ b/keps/sig-network/2365-ingressclass-namespaced-params/kep.yaml
@@ -18,12 +18,12 @@ see-also:
   - "/keps/sig-network/1453-ingress-api"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2365

<!-- other comments or additional information -->
- Other comments:
Marking the enhancement as stable for v1.23 cycle as it meets graduation criteria.