### PR TITLE
Move KEP-2845 to implementable

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/2845.yaml
+++ b/keps/prod-readiness/sig-instrumentation/2845.yaml
@@ -1,0 +1,3 @@
+kep-number: 2845
+alpha:
+  approver: "@ehashman"

--- a/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
+++ b/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
@@ -347,23 +347,20 @@ k8s binaries, but this can be done one by one independently of other components.
 
 ###### Does enabling the feature change any default behavior?
 
-Yes, this feature will change what flags are available in K8s binaries and how
-logs are written. For flags change will go through K8s flag deprecation policy,
-For logs we will introduce a flag to allow users to rollback the change.
+No, we are not changing the default behavior.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes, there is no impact on cluster state. Logs should also be unaffected as logs
-will be only written to stderr.
+After deprecation period, flags will be removed and users will not be able to re-enable them.
+Only way to re-enable them would be to downgrade the cluster.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
-No impact on cluster.
+Flags cannot be reenabled without downgrading.
 
 ###### Are there any tests for feature enablement/disablement?
 
-New logging configuration will be tested as it will become a default in E2e
-tests. Testing disabled feature will be handled in klog unit tests.
+N/A, we are not introducing any new behavior.
 
 ### Rollout, Upgrade and Rollback Planning
 

--- a/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
+++ b/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md
@@ -36,14 +36,14 @@
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
 - [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
   - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
-- [ ] (R) Graduation criteria is in place
+- [x] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
@@ -313,7 +313,8 @@ N/A
 ## Implementation History
 
 - 20/06/2021 - Original proposal created in https://github.com/kubernetes/kubernetes/issues/99270
-- 30/07/2021 - First KEP draft was created
+- 30/07/2021 - KEP draft was created
+- 26/08/2021 - Merged in provisional state
 
 ## Drawbacks
 

--- a/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
+++ b/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
@@ -8,7 +8,7 @@ participating-sigs:
 status: implementable
 creation-date: 2021-07-30
 reviewers:
-  - TBD
+  - pohly
 approvers:
   - ehashman
 

--- a/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
+++ b/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
@@ -11,6 +11,7 @@ reviewers:
   - pohly
 approvers:
   - ehashman
+  - dims
 
 see-also:
   - "/keps/sig-instrumentation/1602-structured-logging"

--- a/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
+++ b/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-instrumentation
 participating-sigs:
   - sig-arch
-status: provisional
+status: implementable
 creation-date: 2021-07-30
 reviewers:
   - TBD


### PR DESCRIPTION
Sending PR to move KEP-2845 to implementable to start discussion as there is not a lot of time before code freeze. 
Proposal: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md


Assigning people that already volunteered to review the KEP. Thanks for offering help!
/assign @ehashman @pohly 

Still looking for approver from SIG-Arch side:

@dims, @thockin, @liggitt, @johnbelamaric
Could one of you become KEP approver?