### PR TITLE
KEP-1682: Move CSIVolumeSupportFSGroup to GA

### DIFF
--- a/keps/prod-readiness/sig-storage/1682.yaml
+++ b/keps/prod-readiness/sig-storage/1682.yaml
@@ -1,0 +1,5 @@
+kep-number: 1682
+beta:
+  approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-storage/1682-csi-driver-skip-permission/kep.yaml
+++ b/keps/sig-storage/1682-csi-driver-skip-permission/kep.yaml
@@ -2,6 +2,7 @@ title: Skip Volume Ownership Change
 kep-number: 1682
 authors:
   - "@huffmanca"
+  - "@dobsonj"
 owning-sig: sig-storage
 participating-sigs:
   - sig-storage
@@ -16,14 +17,13 @@ approvers:
 see-also:
 replaces:
 
-stage: alpha
-
-latest-milestone: "v1.19"
+stage: stable
+latest-milestone: "v1.23"
 
 milestone:
   alpha: "v1.19"
   beta: "v1.20"
-  stable: "v1.21"
+  stable: "v1.23"
 
 feature-gates:
   - name: CSIVolumeSupportFSGroup


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Moving CSIVolumeSupportFSGroup to GA in 1.23

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1682

<!-- other comments or additional information -->
- Other comments: