### PR TITLE
pkg/repo: only parse kep.yaml files as KEPs

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -242,8 +242,6 @@ func (r *Repo) findLocalKEPMeta(sig string) ([]string, error) {
 				return nil
 			}
 
-			logrus.Debugf("adding %s as KEP metadata", info.Name())
-			keps = append(keps, path)
 			return nil
 		},
 	)


### PR DESCRIPTION
`kepctl query` was attempting to parse non-kep.yaml files as KEPs and
erroring out before loading all KEPs.

I opted to filter out non-kep.yaml files from the loading code rather
than allow kepctl to continue loading files, so as to incentivize
fixing kep.yaml files to be valid ASAP