### PR TITLE
kepctl query: fix remote KEP loading

### DIFF
--- a/pkg/proposal/promote.go
+++ b/pkg/proposal/promote.go
@@ -51,7 +51,7 @@ func Promote(opts *PromoteOpts) error {
 
 	logrus.Infof("Updating KEP %s/%s", opts.SIG, opts.Name)
 
-	p, err := r.ReadKEP(opts.SIG, opts.Name)
+	p, err := r.LoadLocalKEP(opts.SIG, opts.Name)
 	if err != nil {
 		return fmt.Errorf("unable to load KEP for promotion: %s", err)
 	}

--- a/pkg/repo/query.go
+++ b/pkg/repo/query.go
@@ -99,7 +99,7 @@ func (r *Repo) Query(opts *QueryOpts) ([]*api.Proposal, error) {
 		}
 	}
 
-	allKEPs := make([]*api.Proposal, 0, 10)
+	allKEPs := []*api.Proposal{}
 	// load the KEPs for each listed SIG
 	for _, sig := range opts.Groups {
 		// KEPs in the local filesystem
@@ -132,7 +132,7 @@ func (r *Repo) Query(opts *QueryOpts) ([]*api.Proposal, error) {
 	allowedApprover := sliceToMap(opts.Approver)
 	allowedParticipant := sliceToMap(opts.Participant)
 
-	results := make([]*api.Proposal, 0, 10)
+	results := []*api.Proposal{}
 	for _, k := range allKEPs {
 		if k == nil {
 			return nil, errors.New("one of the KEPs in query was nil")

--- a/pkg/repo/query.go
+++ b/pkg/repo/query.go
@@ -112,7 +112,7 @@ func (r *Repo) Query(opts *QueryOpts) ([]*api.Proposal, error) {
 
 		// Open PRs; existing KEPs with open PRs will be shown twice
 		if opts.IncludePRs {
-			prKeps, err := r.loadKEPPullRequests(sig)
+			prKeps, err := r.LoadPullRequestKEPs(sig)
 			if err != nil {
 				logrus.Warnf("error searching for KEP PRs from %s: %s", sig, err)
 			}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -509,7 +509,7 @@ func (r *Repo) loadKEPFromYaml(repoPath, kepPath string) (*api.Proposal, error) 
 		if err != nil {
 			logrus.Errorf(
 				"%v",
-				errors.Wrapf(err, "getting PRR approver for %s stage", p.Stage),
+				fmt.Errorf("getting PRR approver for stage '%s' for kep %s: %w", p.Stage, fullKEPPath, err),
 			)
 		}
 

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -331,7 +331,7 @@ func (r *Repo) loadKEPPullRequests(sig string) ([]*api.Proposal, error) {
 		}
 	}
 
-	kepPRs := make([]*github.PullRequest, 10)
+	kepPRs := []*github.PullRequest{}
 	sigLabel := strings.Replace(sig, "-", "/", 1)
 	logrus.Debugf("Searching list of %v PRs for %v/%v with labels: [%v, %v]", len(r.allPRs), remoteOrg, remoteRepo, sigLabel, proposalLabel)
 	for _, pr := range r.allPRs {


### PR DESCRIPTION
Related:
- Followup to https://github.com/kubernetes/enhancements/pull/2927
- Based on trying to run https://github.com/kubernetes/community/blob/master/sig-architecture/production-readiness.md#finding-keps-needing-prod-readiness-review

I wanted to run the same command a PRR approver is going to run to see
if my KEP PR would show up in their query. I discovered that:
- remote KEP PR loading was slow
- remote KEP PR loading was broken

See commits for details, but tl;dr:
- remote KEP PR loading works now (I'm not sure when it broke or if it ever worked) and has debug logging
- the command in question is faster now (took ~1m40s locally)
- PRR error messages reference the KEP in question for easier diagnosis