### PR TITLE
Updating Topology Aware Hints KEP for 1.23

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/kep.yaml
+++ b/keps/sig-network/2433-topology-aware-hints/kep.yaml
@@ -30,13 +30,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.21"
-  beta: "v1.22"
-  stable: "v1.24"
+  beta: "v1.23"
+  stable: "v1.25"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: Updates Topology Aware Hints KEP for 1.23 - was already approved for beta, just needed to change target release versions.

- Issue link: #2433

/sig network
/assign @thockin