### PR TITLE
KEP-2625: Update CPU Manager Policy Options 1.23 Beta

### DIFF
--- a/keps/prod-readiness/sig-node/2625.yaml
+++ b/keps/prod-readiness/sig-node/2625.yaml
@@ -1,3 +1,5 @@
 kep-number: 2625
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
@@ -7,14 +7,15 @@ owning-sig: sig-node
 participating-sigs: []
 status: implementable
 creation-date: "2021-04-14"
-last-updated: "2021-09-02"
+last-updated: "2021-09-08"
 reviewers:
   - "@klueska"
 approvers:
   - "@sig-node-leads"
 prr-approvers:
   - "@johnbelamaric"
-see-also: []
+see-also:
+- "keps/sig-node/2902-cpumanager-distribute-cpus-policy-option/"
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
@@ -35,6 +36,7 @@ milestone:
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: "CPUManagerPolicyOptions"
+  - name: "CPUManagerPolicyExperimentalOptions"
     components:
       - kubelet
 disable-supported: true

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
@@ -7,6 +7,7 @@ owning-sig: sig-node
 participating-sigs: []
 status: implementable
 creation-date: "2021-04-14"
+last-updated: "2021-09-02"
 reviewers:
   - "@klueska"
 approvers:
@@ -17,12 +18,12 @@ see-also: []
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
One-line PR description: Update CPU Manager Policy Options 1.23 Beta
Issue link: https://github.com/kubernetes/enhancements/issues/2625

- Introduced as an alpha feature in 1.22 https://github.com/kubernetes/kubernetes/pull/101432

Other comments:  
- This PR updates the KEP to capture the policy name `full-pcpus-only`
  based on the implementation merged in 1.22.
- Explains the use of this feature for introduction another policy option
- Changes pertaining to promotion to Beta

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>