### PR TITLE
kep-1864: promote ServiceLBNodePortControl to GA

### DIFF
--- a/keps/prod-readiness/sig-network/1864.yaml
+++ b/keps/prod-readiness/sig-network/1864.yaml
@@ -1,3 +1,5 @@
 kep-number: 1864
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-network/1864-disable-lb-node-ports/kep.yaml
+++ b/keps/sig-network/1864-disable-lb-node-ports/kep.yaml
@@ -17,12 +17,12 @@ prr-approvers:
   - "@johnbelamaric"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: promote ServiceLBNodePortControl to GA in v1.23

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1864

<!-- other comments or additional information -->
- Other comments: