### PR TITLE
[KEP-1933] Correct stable version to 1.23, not 1.22

### DIFF
--- a/keps/prod-readiness/sig-security/1933.yaml
+++ b/keps/prod-readiness/sig-security/1933.yaml
@@ -3,4 +3,3 @@ beta:
   approver: "@deads2k"
 stable:
   approver: "@deads2k"
-#

--- a/keps/sig-security/1933-secret-logging-static-analysis/kep.yaml
+++ b/keps/sig-security/1933-secret-logging-static-analysis/kep.yaml
@@ -27,12 +27,12 @@ replaces: []
 
 stage: stable
 
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"
 
 milestone:
   alpha: "v1.20"
   beta: "v1.21"
-  stable: "v1.22"
+  stable: "v1.23"
 
 # This KEP enhances Kubernetes testing.  It does not directly impact any component.
 feature-gates: []


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:  Correct stable version to 1.23, not 1.22.

<!-- link to the k/enhancements issue -->
- Issue link: #1933

<!-- other comments or additional information -->
- Other comments:  This change comes at the recommendation of @gracenng as 1.23 enhancement shadow.  Since we recently merged the "official" stable state in the KEP's YAML, it should be reflected in 1.23 for enhancement tracking, not back-dating 1.22 of when scanning became blocking.
- Also, I noticed I left a trailing, empty comment line.  Trimmed that form the YAML.

/sig security
/cc gracenng
