### PR TITLE
KEP-1669: promote ProxyTerminatingEndpoints to beta in v1.23

### DIFF
--- a/keps/sig-network/1669-proxy-terminating-endpoints/kep.yaml
+++ b/keps/sig-network/1669-proxy-terminating-endpoints/kep.yaml
@@ -1,4 +1,4 @@
-title: Graceful Termination for Local External Traffic Policy
+title: Proxy Terminating Endpoints
 kep-number: 1669
 authors:
   - "@andrewsykim"
@@ -14,7 +14,7 @@ approvers:
 prr-approvers:
   - "@johnbelamaric"
 creation-date: 2020-04-07
-last-updated: 2020-04-07
+last-updated: 2022-01-21
 status: implementable
 see-also:
   - "/keps/sig-network/1672-tracking-terminating-endpoints/README.md"
@@ -26,7 +26,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Promote ProxyTerminatingEndpoints to beta in v1.23

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1669 

<!-- other comments or additional information -->
- Other comments: initial PR was opened in https://github.com/kubernetes/enhancements/pull/2938. Splitting each KEP into it's own PR as requested by @wojtek-t 