### PR TITLE
KEP-2438: dual-stack-apiserver updates / clarifications

### DIFF
--- a/keps/prod-readiness/sig-network/2438.yaml
+++ b/keps/prod-readiness/sig-network/2438.yaml
@@ -1,0 +1,6 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 2438
+alpha:
+  approver: "@johnbelamaric"

--- a/keps/sig-network/2438-dual-stack-apiserver/kep.yaml
+++ b/keps/sig-network/2438-dual-stack-apiserver/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
 approvers:
   - "@thockin"
   - TBD
-prr-approvers:
-  - TBD
 see-also:
   - "/keps/sig-network/563-dual-stack"
 
@@ -25,13 +23,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.22"
-  beta: "v1.23"
-  stable: "v1.24"
+  alpha: "v1.24"
+  beta: "v1.26"
+  stable: "v1.27"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- Issue link: https://github.com/kubernetes/enhancements/issues/2438

updates based on the comments in #2622

/assign @thockin @khenidak 
(not urgent at this point, but since it's in response to comments made a few days ago I figure you might want to look at it sooner rather than later)