### PR TITLE
KEP-1739: retro-update the customization with patches to Beta

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches/README.md
@@ -857,6 +857,8 @@ Major milestones might include
 
 - 2020-05-04: initial provisional KEP created
 - 2020-05-14: addressed feedback, filled PRR questionnaire, KEP marked as implementable
+- 2021-09-09: marked the feature as graduated to Beta. This was done as part of
+the kubeadm v1beta3 API work. The actions under "Alpha -> Beta" are completed.
 
 ## Drawbacks
 

--- a/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/1739-customization-with-patches/kep.yaml
@@ -18,15 +18,16 @@ replaces:
   - "/keps/sig-cluster-lifecycle/kubeadm/20190722-Advanced-configurations-with-kubeadm-(Kustomize).md"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.19"
+# NOTE: keeping this at v1.0 to avoid PRR. See milestones bellow.
+latest-milestone: "v1.0"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.19"
-  beta: "v1.20"
-  stable: "v1.22"
+  beta: "v1.22"
+  stable: "TODO"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

The customization with patches graduated to Beta as part of the
the work in the KEP 970 (added in the kubeadm v1beta3 API) during
the 1.22 release cycle.
https://github.com/kubernetes/enhancements/issues/970

Retroactively update the KEP for customization with patches to Beta
as the related actions were completed.

<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/1739

<!-- other comments or additional information -->
- Other comments:
NONE
