### PR TITLE
retarget gRPC probes KEP to 1.23

### DIFF
--- a/keps/sig-node/2727-grpc-probe/kep.yaml
+++ b/keps/sig-node/2727-grpc-probe/kep.yaml
@@ -21,4 +21,4 @@ replaces:
 prr-approvers:
   - "@johnbelarmic"
 stage: "alpha"
-latest-milestone: "v1.22"
+latest-milestone: "v1.23"


### PR DESCRIPTION
KEP #2727 

- One-line PR description: Update the milestone for the KEP
- Other comments: This KEP almost made it to 1.22 and now retargeted to 1.23