### PR TITLE
Updating Topology Hints to exclude Control Plane Nodes

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/README.md
+++ b/keps/sig-network/2433-topology-aware-hints/README.md
@@ -10,6 +10,7 @@
 - [Design Details](#design-details)
   - [Assumptions](#assumptions)
   - [Identifying Zones](#identifying-zones)
+  - [Excluding Control Plane Nodes](#excluding-control-plane-nodes)
   - [Configuration](#configuration)
     - [Interoperability](#interoperability)
     - [Feature Gate](#feature-gate)
@@ -187,6 +188,14 @@ with a new Service annotation.
 The EndpointSlice controller reads the standard `topology.kubernetes.io/zone`
 label on Nodes to determine which zone a Pod is running in. Kube-Proxy would be
 updated to read the same information to identify which zone it is running in.
+
+### Excluding Control Plane Nodes
+
+Any Nodes with the following labels (set to any value) will be excluded when
+calculating allocatable cores in a zone:
+
+* `node-role.kubernetes.io/control-plane`
+* `node-role.kubernetes.io/master`
 
 ### Configuration
 


### PR DESCRIPTION
- One-line PR description: This updates the Topology Hints KEP to exclude Control Plane Nodes

- Issue link: #2433

- Other comments: As suggested by @aojea in https://github.com/kubernetes/kubernetes/pull/104744

/cc @aojea @bowei 
/assign @thockin 