### PR TITLE
keps/sig-release: mv wg-k8s-infra sig-k8s-infra

### DIFF
--- a/keps/sig-release/1734-k8s-image-promoter/kep.yaml
+++ b/keps/sig-release/1734-k8s-image-promoter/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@javier-b-perez"
 owning-sig: sig-release
 participating-sigs:
-  - wg-k8s-infra
+  - sig-k8s-infra
 reviewers:
   - "@AishSundar"
   - "@BenTheElder"


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/community/issues/6036
- Part of: https://github.com/kubernetes/enhancements/issues/1734

Follow the rename of wg-k8s-infra to sig-k8s-infra

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update stakeholder sig

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1734

<!-- other comments or additional information -->
- Other comments: