### PR TITLE
OWNERS_ALIASES: update sig-testing-leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -90,6 +90,8 @@ aliases:
     - xing-yang
   sig-testing-leads:
     - BenTheElder
+    - alvaroaleman
+    - cjwagner
     - spiffxp
     - stevekuznetsov
   sig-ui-leads:


### PR DESCRIPTION
Related:
- Followup to: https://github.com/kubernetes/community/pull/6069

- One-line PR description: OWNERS_ALIASES: update sig-testing-leads

- Issue link: n/a

- Other comments: n/a