### PR TITLE
KEP-2371: clarify plan for cAdvisor and target at Beta for 1.24

### DIFF
--- a/keps/prod-readiness/sig-node/2371.yaml
+++ b/keps/prod-readiness/sig-node/2371.yaml
@@ -1,3 +1,5 @@
 kep-number: 2371
 alpha:
   approver: "@ehashman"
+beta:
+  approver: "@ehashman"

--- a/keps/sig-node/2371-cri-pod-container-stats/README.md
+++ b/keps/sig-node/2371-cri-pod-container-stats/README.md
@@ -515,13 +515,11 @@ Each compliant CRI implementation must:
 
 Below is the proposed strategy for doing so:
 
-1. The Alpha release will strictly cover research, performance testing and the creation of conformance tests.
+1. The Alpha release will focus solely on `/stats/summary` endpoint, and `/metrics/cadvisor` support will follow in Beta.
+2. For the Beta release, add initial support for CRI implementations to report these metrics
     - Initial research on the set of metrics required should be done. This will, possibly, allow the community to declare metrics that are not required to be moved to the CRI implementations.
     - Testing on how performant cAdvisor+Kubelet are today should be done, to find a target, acceptable threshold of performance for the CRI implementations
     - Creation of tests verifying the metrics are reported correctly should be created and verified with the existing cAdvisor implementation.
-2. For the Beta release, add initial support for CRI implementations to report these metrics
-    - This set of metrics will be based on the research done in alpha
-    - Each will be validated against the conformance and performance tests created in alpha.
 3. For the GA release, the CRI implementation should be the source of truth for all pod and container level metrics that external parties rely on (no matter how many endpoints the Kubelet advertises).
 
 #### cAdvisor
@@ -540,19 +538,19 @@ As a requirement for the Beta stage, cAdvisor must support optionally collecting
 
 - CRI should be extended to provide required stats for `/stats/summary`
 - Kubelet should be extended to provide the required stats from CRI implementation for `/stats/summary`.
-- cAdvisor should be updated to support no longer collecting stats that are duplicated with CRI implementation.
 - This new behavior will be gated by a feature gate to prevent regressions for users that rely on the old behavior.
-- Conduct research to find the set of metrics from `/metrics/cadvisor` that compliant CRI implementations must expose.
-- Conformance tests for the fields in `/metrics/cadvisor` should be created
-- Performance tests for CPU/memory usage between Kubelet/cAdvisor/CRI implementation should be added.
+
 #### Alpha -> Beta Graduation
 
-- CRI implementations should report any difficulties collecting the stats, and by Beta the CRI stats implementation should perform better than they did with CRI+cAdvisor.
-- CRI implementations should support their equivalent of `/metrics/cadvisor`, passing the performance and conformance suite created in Alpha.
+- Conduct research to find the set of metrics from `/metrics/cadvisor` that compliant CRI implementations must expose.
+- Conformance tests for the fields in `/metrics/cadvisor` should be created.
+- Performance tests for CPU/memory usage between Kubelet/cAdvisor/CRI implementation should be added.
+	- The CRI stats implementation should perform better than they did with CRI+cAdvisor.
 - cAdvisor stats provider may be marked as deprecated (depending on stability of new CRI based implementations).
 - cAdvisor should be able to optionally not report the metrics needed for both summary API and `/metrics/cadvisor`. This behavior will be toggled by the Kubelet feature gate.
 
 #### Beta -> GA Graduation
+
 - The CRI stats provider in the Kubelet should be fully formed, and able to satisfy all the needs of downstream consumers
 - cAdvisor stats provider will likely be marked as deprecated (depending on dockershim deprecation).
 - Feature gate removed and the CRI stats provider will no longer rely on cAdvisor for container/pod level metrics.
@@ -562,7 +560,7 @@ As a requirement for the Beta stage, cAdvisor must support optionally collecting
 - There needs to be a way for the Kubelet to verify the CRI provider is capable of providing the correct metrics.
   Upon upgrading to a version that relies on this new behavior (assuming the feature gate is enabled),
   Kubelet should fail early if the CRI implementation won't report the expected metrics.
-- For Beta/GA releases, components that rely on `/metrics/cadvisor` should take the decided action (use `/stats/summary`, or use the Kubelet provided `/metrics/cadvisor`).
+- For Beta/GA releases, components that rely on `/metrics/cadvisor` should take the decided action (use `/stats/summary`, or use the CRI provided `/metrics/cadvisor`).
 
 ### Version Skew Strategy
 
@@ -735,7 +733,7 @@ operations covered by [existing SLIs/SLOs]?**
 resource usage (CPU, RAM, disk, IO, ...) in any components?**
   - It most likely will reduce resource utilization. Right now, there is duplicate work being done between CRI and cAdvisor.
     This will not happen anymore.
-  - The CRI implementation may scrape the metrics less efficiently than cAdvisor currently does. This should be measured and evaluated before Beta.
+  - The CRI implementation may scrape the metrics less efficiently than cAdvisor currently does. This should be measured and evaluated as a requirement of Beta.
 
 ### Troubleshooting
 

--- a/keps/sig-node/2371-cri-pod-container-stats/README.md
+++ b/keps/sig-node/2371-cri-pod-container-stats/README.md
@@ -225,7 +225,7 @@ As such, this proposal will be broken up into what needs to be done for each of 
 2. Add CRI Pod Level Stats message to CRI protobuf that includes all [Pod Level Stats](#summary-pod-stats-object) metrics from Summary API.
 3. Add support for the new CRI additions in supported container runtimes (CRI-O and containerd).
 4. Switch Kubelet's CRI stats provider from querying container and pod level stats from cAdvisor to newly added CRI pod and container level stats
-5. cAdvisor should stop collecting container and pod level stats. If any other components need container or pod level stats from cAdvisor, the CRI implementation should be queried instead.
+5. cAdvisor should be updated to support no longer collecting stats that are duplicated with CRI implementation. Any client that requires the metrics that are reported by the CRI should gather them from the CRI instead of cAdvisor.
 
 This will be described in more detail in the [design details section](#design-details)
 
@@ -234,7 +234,7 @@ This will be described in more detail in the [design details section](#design-de
 ### /metrics/cadvisor
 
 1. Expose the metric fields provided in `/metrics/cadvisor` in an analogous Prometheus endpoint directly from the CRI implementation.
-2. cAdvisor should stop collecting container and pod level stats, as well as stop broadcasting from `/metrics/cadvisor`.
+5. cAdvisor should be updated to support no longer collecting stats that are duplicated with CRI implementation, and omit them from the report sent to `/metrics/cadvisor`.
 3. The precise endpoint can change, but all the fields should be duplicated (so custom rules can be maintained).
 4. Kubelet does not collect nor expose pod and container level metrics that were formally collected for and exposed by `/metrics/cadvisor`.
 

--- a/keps/sig-node/2371-cri-pod-container-stats/README.md
+++ b/keps/sig-node/2371-cri-pod-container-stats/README.md
@@ -756,6 +756,10 @@ _This section must be completed when targeting beta graduation to a release._
 ## Implementation History
 
 2021-1-27: KEP opened
+2021-5-12: KEP merged, targeted at Alpha in 1.22
+2021-7-8: KEP deemed not ready for Alpha in 1.22
+2021-12-07: KEP successfully implemented at Alpha in 1.23
+2022-1-25: KEP targeted at Beta in 1.24
 
 ## Drawbacks
 

--- a/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
+++ b/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
@@ -16,7 +16,7 @@ approvers:
 prr-approvers:
   - "@ehashman"
 creation-date: 2021-01-27
-last-updated: 2021-09-08
+last-updated: 2022-01-25
 status: implementable
 stage: beta
 latest-milestone: "v1.24"

--- a/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
+++ b/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
@@ -18,8 +18,11 @@ prr-approvers:
 creation-date: 2021-01-27
 last-updated: 2021-09-08
 status: implementable
-stage: alpha
-latest-milestone: "v1.23"
+stage: beta
+latest-milestone: "v1.24"
+milestone:
+  alpha: "v1.23"
+  beta: "v1.24"
 see-also:
   - N/A
 replaces:


### PR DESCRIPTION
Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
addressing comments in https://github.com/kubernetes/enhancements/pull/2364#discussion_r716697783
<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: