### PR TITLE
KEP-2043: [podresources] KEP updates for introducing cpu_affinity in ContainerResources

### DIFF
--- a/keps/prod-readiness/sig-node/2043.yaml
+++ b/keps/prod-readiness/sig-node/2043.yaml
@@ -1,0 +1,3 @@
+kep-number: 2043
+alpha:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/2043-pod-resource-concrete-assigments/README.md
+++ b/keps/sig-node/2043-pod-resource-concrete-assigments/README.md
@@ -171,6 +171,8 @@ message ContainerResources {
     string name = 1;
     repeated ContainerDevices devices = 2;
     repeated int64 cpu_ids = 3;
+    repeated ContainerMemory memory = 4;
+    repeated int64 cpu_affinity = 5
 }
 
 // Topology describes hardware topology of the resource
@@ -243,6 +245,19 @@ compute resources.
 Applications are expected to run `GetAlloctableResources` each time they expect a change in the resources
 availability (e.g. CPUs onlined/offlined, devices added/removed). We anticipate these changes to happen very rarely.
 Client applications should not expect any ordering in the return value.
+
+NOTE: cpu_ids field in the `ContainerResources` returns only exclusively allocated CPUs in the list endpoint of Podresource API.
+
+Though this is useful in proper resource accounting and determining the remaining CPUs on a node,
+there is no easy way to know the taskset associated with a container.
+Currently, in order to determine the taskset the client had to:
+
+1. Call GetAllocatableResources gRPC endpoint to get a list of all the allocatable CPUs
+1. Call GetCpuIds on all ContainerResources in the system
+1. Subtract out all of the CPUs from the GetCpuIds calls from the GetAllocatableResources call
+
+To determine the tasket of a container in a more user friendly way, the client can use the cpu_affinity
+field in the ContainerResources.
 
 ### Test Plan
 
@@ -358,6 +373,7 @@ Feature only collects data when requests comes in, data is then garbage collecte
 - 2020-09-02: Add the GetAllocatableResources endpoint
 - 2020-10-01: KEP extended with Watch API
 - 2020-11-02: Agreement in sig-node to implement Watch API in the 1.21 cycle
+- 2021-10-15: Add cpu_affinity in ContainerResources to obtain taskset of a container in 1.24 cycle
 
 ## Alternatives
 

--- a/keps/sig-node/2043-pod-resource-concrete-assigments/kep.yaml
+++ b/keps/sig-node/2043-pod-resource-concrete-assigments/kep.yaml
@@ -6,10 +6,12 @@ authors:
   - "@renaudwastaken"
   - "@fromanirh"
   - "@alexeyperevalov"
+  - "swatisehgal"
 owning-sig: sig-node
 participating-sigs: []
 status: implementable
 creation-date: "2018-07-19"
+last-updated: "2021-10-15"
 reviewers:
   - "@derekwaynecarr"
   - "@renaudwastaken"
@@ -28,7 +30,7 @@ stage: stable
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
 # latest-milestone: "v1.21"
-latest-milestone: "0.0"
+latest-milestone: "1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -40,6 +42,7 @@ milestone:
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: "KubeletPodResources"
+  - name: "KubeletPodResourcesGetCPUAffinity"
     components:
       - kubelet
 disable-supported: false


### PR DESCRIPTION
The enhancement improves the overall user experience and enables the client to determine the taskset of a container.

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Enable Kubelet podresources API client to provide a user-friendly way to determine taskset of a container

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2043
- Related k/k issue: https://github.com/kubernetes/kubernetes/issues/105698

<!-- other comments or additional information 
- Other comments:
- -->

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>