### PR TITLE
KEP-1591: Fix default values for MaxUnavailable and MaxSurge

### DIFF
--- a/keps/sig-apps/1591-daemonset-surge/README.md
+++ b/keps/sig-apps/1591-daemonset-surge/README.md
@@ -52,7 +52,7 @@ type RollingUpdateDaemonSet struct {
 	// The maximum number of DaemonSet pods that can be unavailable during the
 	// update. Value can be an absolute number (ex: 5) or a percentage of total
 	// number of DaemonSet pods at the start of the update (ex: 10%). Absolute
-	// number is calculated from percentage by rounding down to a minimum of one.
+	// number is calculated from percentage by rounding up.
 	// This cannot be 0 if MaxSurge is 0
 	// Default value is 1.
 	// Example: when this is set to 30%, at most 30% of the total number of nodes
@@ -71,15 +71,15 @@ type RollingUpdateDaemonSet struct {
 	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 	// This can not be 0 if MaxUnavailable is 0.
 	// Absolute number is calculated from percentage by rounding up to a minimum of 1.
-	// Defaults to 25%.
+	// Default value is 0.
 	// Example: when this is set to 30%, at most 30% of the total number of nodes
 	// that should be running the daemon pod (i.e. status.desiredNumberScheduled)
 	// can have their a new pod created before the old pod is marked as deleted.
-  // The update starts by launching new pods on 30% of nodes. Once an updated
-  // pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
-  // on that node is marked deleted. If the old pod becomes unavailable for any
-  // reason (Ready transitions to false, is evicted, or is drained) an updated
-  // pod is immediatedly created on that node without considering surge limits.
+	// The update starts by launching new pods on 30% of nodes. Once an updated
+	// pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+	// on that node is marked deleted. If the old pod becomes unavailable for any
+	// reason (Ready transitions to false, is evicted, or is drained) an updated
+	// pod is immediately created on that node without considering surge limits.
 	// Allowing surge implies the possibility that the resources consumed by the
 	// daemonset on any given node can double if the readiness check fails, and
 	// so resource intensive daemonsets should take into account that they may


### PR DESCRIPTION
The implementation defines the default value for MaxSurge being 0, as to
preserve the current behavior of rolling updates in DaemonSets. Also,
for MaxUnavailable, the rounding is up.

This change is just a copy-paste of the docblock defined in the types.go
file.

See:
- https://github.com/kubernetes/kubernetes/blob/10a3cc815bea73f78f7126cab5df95233da96e1b/pkg/apis/apps/types.go
- https://github.com/kubernetes/kubernetes/blob/10a3cc815bea73f78f7126cab5df95233da96e1b/pkg/apis/apps/v1/defaults.go#L87-L91