### PR TITLE
KEP-2876: CEL expression language: Clarify escaping, root field access, int-or-string/embedded/unknown types

### DIFF
--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -605,6 +605,8 @@ developers to test their validation rules.
 - Understanding of upper bounds of CPU/memory usage and appropriate limits set to prevent abuse.
 - Build-in macro/function library is comprehensive and stable (any changes to this will be a breaking change)
 - CEL numeric comparison issue is resolved (e.g. ability to compare ints to doubles)
+- [Reduce noise of invalid data messages reported from cel.UnstructuredToVal](https://github.com/kubernetes/kubernetes/issues/106440)
+- [Benchmark cel.UnstructuredToVal and optimize away repeated wrapper object construction](https://github.com/kubernetes/kubernetes/issues/106438)
 
 ## Production Readiness Review Questionnaire
 

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -311,11 +311,11 @@ like the `all` macro, e.g. `self.all(listItem, <predicate>)` or `self.all(mapKey
 
 - Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible and are escaped
   according to the following rules when accessed in the expression:
-	- '__' escapes to '__underscores__'
-	- '.' escapes to '__dot__'
-	- '-' escapes to '__dash__'
-	- '/' escapes to '__slash__'
-	- Property names that match a CEL RESERVED keyword exactly escape to '__{keyword}__'. The
+	- `__` escapes to `__underscores__`
+	- `.` escapes to `__dot__`
+	- `-` escapes to `__dash__`
+	- `/` escapes to `__slash__`
+	- Property names that match a CEL RESERVED keyword exactly escape to `__{keyword}__`. The
 	keywords are: "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for",
 	"function", "if", "import", "let", "loop", "package", "namespace", "return".
 

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -506,7 +506,7 @@ Types:
 | 'object' with AdditionalProperties                 | map                                                                                                            |
 | 'object' with x-kubernetes-embedded-type           | <treatment is the same as 'object' more details below>                                                         |
 | 'object' with x-kubernetes-preserve-unknown-fields | <treatment is the same as 'object', more details below>                                                        |
-| x-kubernetes-embedded-int-or-string                | object with 'intVal' (type: int) and 'strVal' (type: string) fields                                            |
+| x-kubernetes-int-or-string                | object with 'intVal' (type: int) and 'strVal' (type: string) fields                                            |
 | 'array                                             | list                                                                                                           |
 | 'array' with x-kubernetes-list-type=map            | list with map based Equality & unique key guarantees                                                           |
 | 'array' with x-kubernetes-list-type=set            | list with set based Equality & unique entry guarantees                                                         |

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -297,11 +297,16 @@ like the `all` macro, e.g. `self.all(listItem, <predicate>)` or `self.all(mapKey
   identifiers](https://github.com/google/cel-spec/blob/master/doc/langdef.md#values)) it is not
   accessible as a root variable and must be accessed via `self`, .e.g. `self.int`.
 
-- If a object property name contains characters not allowed in CEL identifiers it is escaped using these rules:
-  - `.` (period) is escaped as `__dot__`
-  - `-` (slash) is escaped as `__slash__`
-  - ` ` (space) is escaped as `__space__`
-  - `__` (2 underscores) is escaped as `__underscores__`
+- If a object property name contains characters not allowed in CEL identifiers (`[a-zA-Z_][a-zA-Z0-9_]*`) it is escaped using these rules:
+  - Property names starting with a number are prefixed by `_`. Property names prefixed with `_`
+    followed by a number are prefixed with `__` and the number.
+  - `__` (2 underscores) is escaped as `__underscores__` (and is used as the escape char for the below rules)
+  - All characters except `[a-zA-Z0-9]` are escaped either as `__{symbolName}__` or `__0x{unicodeHex}__`, the recognized symbol names are:
+    - `dot` (`.`)
+	- `dash` (`-`)
+	- `space` (` `)
+	- `dollar` (`$`)
+	- `slash` (`/`)
 
 - Rules may be written at the root of an object, and may make field selection into any fields
   declared in the OpenAPIv3 schema of the CRD as well as `apiVersion`, `kind`, `metadata.name` and

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -295,7 +295,7 @@ like the `all` macro, e.g. `self.all(listItem, <predicate>)` or `self.all(mapKey
 - If a object property name is a CEL language identifier (`int`, `uint`, `double`, `bool`, `string`,
   `bytes`, `list`, `map`, `null_type`, `type`, see [CEL language
   identifiers](https://github.com/google/cel-spec/blob/master/doc/langdef.md#values)) it is not
-  accessible as a root variable and must be accessed via `self`, .e.g. `seft.int`.
+  accessible as a root variable and must be accessed via `self`, .e.g. `self.int`.
 
 - Rules may be written at the root of an object, and may make field selection into any fields
   declared in the OpenAPIv3 schema of the CRD. This includes selection of fields in both the `spec`

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -236,7 +236,7 @@ extension in the schema. In the above example, the validator is scoped to the
 `spec` field. `self` will be used to represent the name of the field which the validator
 is scoped to.
 
-  - Consideration under adding the representative of scoped filed name: There would be composition
+  - Consideration under adding the representative of scoped field name: There would be composition
     problem while generating CRD with tools like `controller-gen`.  When trying to add validation as
     a marker comment to a field, the validation rule will be hard to define without the actual field
     name. As the example showing below. When we want to put cel validation on ToySpec, the field

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -232,12 +232,13 @@ Example Validation Rules:
 | `self.minReplicas <= self.replicas <= self.maxReplicas`                          | Validate that the three fields defining replicas are ordered appropriately        |
 | `'Available' in self.stateCounts`                                                | Validate that an entry with the 'Available' key exists in a map                   |
 | `(size(self.list1) == 0) != (size(self.list2) == 0)`                             | Validate that one of two lists is non-empty, but not both                         |
-| `!('MY_ENV' in self.envars) || self['MY_ENV'].matches('^[a-zA-Z]*$')`            | Validate the value of a map for a specific key, if it is in the map               |
+| `!('MY_KEY' in self.map1) || self['MY_KEY].matches('^[a-zA-Z]*$')`               | Validate the value of a map for a specific key, if it is in the map               |
+| `self.envars.filter(e, e.name = 'MY_ENV').all(e, e.value.matches('^[a-zA-Z]*$')` | Validate the 'value' field of a listMap entry where key field 'name' is 'MY_ENV'  |
 | `has(self.expired) && self.created + self.ttl < self.expired`                    | Validate that 'expired' date is after a 'create' date plus a 'ttl' duration       |
 | `self.health.startsWith('ok')`                                                   | Validate a 'health' string field has the prefix 'ok'                              |
 | `self.widgets.exists(w, w.key == 'x' && w.foo < 10)`                             | Validate that the 'foo' property of a listMap item with a key 'x' is less than 10 |
-| `type(self) == string ? self == '100%' : self == 1000`         | Validate an int-or-string field for both the the int and string cases             |
-| `self.metadata.name == 'singleton'`                                               | Validate that an object's name matches a specific value (making it a singleton)   |
+| `type(self) == string ? self == '100%' : self == 1000`                           | Validate an int-or-string field for both the the int and string cases             |
+| `self.metadata.name == 'singleton'`                                              | Validate that an object's name matches a specific value (making it a singleton)   |
 | `self.set1.all(e, !(e in self.set2))`                                            | Validate that two listSets are disjoint                                           |
 | `size(self.names) == size(self.details) && self.names.all(n, n in self.details)` | Validate the 'details' map is keyed by the items in the 'names' listSet           |
 

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -235,8 +235,8 @@ Example Validation Rules:
 | `has(self.expired) && self.created + self.ttl < self.expired`                    | Validate that 'expired' date is after a 'create' date plus a 'ttl' duration       |
 | `self.health.startsWith('ok')`                                                   | Validate a 'health' string field has the prefix 'ok'                              |
 | `self.widgets.exists(w, w.key == 'x' && w.foo < 10)`                             | Validate that the 'foo' property of a listMap item with a key 'x' is less than 10 |
-| `type(self.limit) == string ? self.limit == '100%' : self.limit == 1000`         | Validate an int-or-string field for both the the int and string cases             |
-| `self.metadata.name == 'singleton`                                               | Validate that an object's name matches a specific value (making it a singleton)   |
+| `type(self) == string ? self == '100%' : self == 1000`         | Validate an int-or-string field for both the the int and string cases             |
+| `self.metadata.name == 'singleton'`                                               | Validate that an object's name matches a specific value (making it a singleton)   |
 | `self.set1.all(e, !(e in self.set2))`                                            | Validate that two listSets are disjoint                                           |
 | `size(self.names) == size(self.details) && self.names.all(n, n in self.details)` | Validate the 'details' map is keyed by the items in the 'names' listSet           |
 
@@ -575,7 +575,7 @@ So instead of treating "associative lists" as maps in CEL, we will continue to t
 Looking up entiries by keys is available primarily via the `exists_one` and `filter` macros. Examples:
 
 ```
-// exists_one() and exists() behave similarly if all map keys are checked, but exsists_one() has slightly stricter
+// exists_one() and exists() behave similarly if all map keys are checked, but exists_one() has slightly stricter
 // semantics, which make it preferable
 
 // To check if the map contains a entry with a particular key:

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
@@ -6,7 +6,7 @@ authors:
   - "@DangerOnTheRanger"
   - "@leilajal"
 owning-sig: sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2021-05-26
 reviewers:
   - "@deads2k"
@@ -16,6 +16,7 @@ reviewers:
 approvers:
   - "@deads2k"
   - "@lavalamp"
+  - "@liggitt"
 
 ##### WARNING !!! ######
 # prr-approvers has been moved to its own location


### PR DESCRIPTION
We've dug into some important details of CEL during implementation. This PR aims to update the KEP to keep it accurate and in-sync, and enable discussion of the decisions before we merge the implementation.

The main points are:
- escaping details
- Validator field access to metadata, and more generally how validation rules defined on the root of the object behave
- handling of int-or-string, embedded and unknown data

@cici37 @sttts @alculquicondor @liggitt @deads2k 