### PR TITLE
KEP-2433: Removing traffic policy interoperability as beta graduation requirement

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/README.md
+++ b/keps/sig-network/2433-topology-aware-hints/README.md
@@ -460,7 +460,6 @@ EndpointSliceSyncs = metrics.NewCounterVec(
 
 **Beta:**
 - Tests expanded to include e2e coverage described above.
-- Interoperability with Internal and External TrafficPolicy fields.
 
 ### Version Skew Strategy
 This KEP requires updates to both the EndpointSlice Controller and kube-proxy.


### PR DESCRIPTION
- One-line PR description: Removes traffic policy interoperability as beta graduation requirement

- Issue link: #2433

The interoperability between InternalTrafficPolicy, ExternalTrafficPolicy, and Topology are actively being worked on by @danwinship (thanks!!). I think this is an important thing to get right, but I'm not sure it needs to block beta graduation. I expect the vast majority of users will want to user at most one of these features per Service. Open to other input here. This may all be a non-issue if all the kube-proxy updates and fixes manage to make it into 1.23, but I just wanted to start this conversation a bit earlier in case they don't.

/sig network
/cc @aojea @danwinship
/assign @thockin 