### PR TITLE
Stephen & Lauri to Emeritus, Nabarun to KEP tools approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,6 @@ approvers:
   - sig-architecture-leads
 reviewers:
   - enhancements-reviewers
+emeritus_approvers:
+  - justaugustus    # 2021-11-11
+  - LappleApple     # 2021-04-13: https://kubernetes.slack.com/archives/C1L57L91V/p1618348221078400

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,7 +6,6 @@ aliases:
   sig-apps-leads:
     - janetkuo
     - kow3ns
-    - mattfarina
     - soltysh
   sig-architecture-leads:
     - derekwaynecarr
@@ -22,8 +21,8 @@ aliases:
     - gjtempleton
     - mwielgus
   sig-cli-leads:
-    - eddiezane
     - KnVerey
+    - eddiezane
     - seans3
     - soltysh
   sig-cloud-provider-leads:
@@ -33,15 +32,15 @@ aliases:
     - fabriziopandini
     - justinsb
     - neolit123
-    - timothysc
+    - vincepri
   sig-contributor-experience-leads:
     - alisondy
     - cblecker
     - mrbobbytables
     - nikhita
   sig-docs-leads:
-    - jimangel
     - divya-mohan0209
+    - jimangel
     - kbhawkey
     - onlydole
     - sftim
@@ -66,9 +65,10 @@ aliases:
     - dchen1107
     - derekwaynecarr
   sig-release-leads:
-    - alejandrox1
-    - hasheddan
+    - cpanato
+    - jeremyrickard
     - justaugustus
+    - puerco
     - saschagrunert
   sig-scalability-leads:
     - mm4tt
@@ -77,6 +77,7 @@ aliases:
   sig-scheduling-leads:
     - Huang-Wei
     - ahg-g
+    - alculquicondor
   sig-security-leads:
     - IanColdwater
     - tabbysable
@@ -100,6 +101,7 @@ aliases:
     - shu-mutou
   sig-usability-leads:
     - hpandeycodeit
+    - morengab
     - tashimi
   sig-windows-leads:
     - claudiubelu
@@ -109,9 +111,6 @@ aliases:
   wg-api-expression-leads:
     - apelisse
     - kwiesmueller
-  wg-component-standard-leads:
-    - mtaufen
-    - stealthybox
   wg-data-protection-leads:
     - xing-yang
     - yuxiangqian
@@ -122,17 +121,16 @@ aliases:
   wg-multitenancy-leads:
     - srampal
     - tashimi
-  wg-naming-leads:
-    - celestehorgan
-    - jdumars
-    - justaugustus
   wg-policy-leads:
-    - ericavonb
-    - hannibalhuang
+    - JimBugwadia
+    - rficcaglia
   wg-reliability-leads:
     - deads2k
     - stevekuznetsov
     - wojtek-t
+  wg-structured-logging-leads:
+    - pohly
+    - serathius
   ug-big-data-leads:
     - erikerlandson
     - foxish
@@ -143,27 +141,27 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - AevaOnline
     - celestehorgan
     - karenhchu
-    - tashimi
+    - palnabarun
     - tpepper
-  committee-product-security:
+    - vllry
+  committee-security-response:
     - cjcullen
-    - cji
     - joelsmith
     - lukehinds
     - micahhausler
     - swamymsft
+    - tabbysable
     - tallclair
   committee-steering:
     - cblecker
-    - derekwaynecarr
     - dims
+    - justaugustus
     - liggitt
     - mrbobbytables
-    - nikhita
     - parispittman
+    - tpepper
 ## BEGIN CUSTOM CONTENT
   enhancements-approvers:
     - jeremyrickard
@@ -198,12 +196,11 @@ aliases:
     - wojtek-t
     - ehashman
   provider-aws:
-    - d-nishi
     - justinsb
-    - kris-nova
+    - nckturner
+    - wongma7
   provider-azure:
     - craiglpeters
-    - justaugustus
     - feiskyer
     - khenidak
   provider-gcp:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -180,6 +180,7 @@ aliases:
     - johnbelamaric
     - justaugustus
     - mrbobbytables
+    - palnabarun
   kep-tools-reviewers:
     - jeremyrickard
     - johnbelamaric

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -166,17 +166,13 @@ aliases:
   enhancements-approvers:
     - jeremyrickard
     - johnbelamaric
-    - justaugustus
     - kikisdeliveryservice
-    - LappleApple
     - mrbobbytables
   enhancements-reviewers:
     - annajung
     - jeremyrickard
     - johnbelamaric
-    - justaugustus
     - kikisdeliveryservice
-    - LappleApple
     - mrbobbytables
     - palnabarun
   kep-tools-approvers:


### PR DESCRIPTION
- OWNERS_ALIASES: Sync with k/community
- OWNERS: @justaugustus and @LappleApple are now Emeritus subproject owners
- OWNERS_ALIASES: Promote @palnabarun to `kep-tools-approvers`

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Announcement to follow.
Thnks fr th Mmrs!

/assign @mrbobbytables @kikisdeliveryservice @dims 
cc: @kubernetes/enhancements @kubernetes/sig-architecture-leads 