### PR TITLE
KEP-2149: Cluster id api review request

### DIFF
--- a/keps/sig-multicluster/2149-clusterid/README.md
+++ b/keps/sig-multicluster/2149-clusterid/README.md
@@ -378,7 +378,7 @@ Contains an identifier that relates the containing cluster to the ClusterSet in 
 
 ### Additional Properties
 
-Implementers are free to add additional properties as they see fit, so long as they do not conflict with the well known properties and utilize a suffix. "Bare name" properties with no suffix, and properties using the suffixes `*.k8s.io`, `*.kubernetes.io`, and `*.sigs.k8s.io` are reserved for Kubernetes and related projects. For example, an implementation may utilize the `Kind` `ClusterProperty` to store objects with the name `fingerprint.coolmcsimplementation.com` but not `fingerprint.k8s.io` and not simply `fingerprint`.
+Implementers are free to add additional properties as they see fit, so long as they do not conflict with the well known properties _and_ utilize a suffix. The following suffixes are reserved for Kubernetes and related projects: `.k8s.io`, `.kubernetes.io`. For example, an implementation may utilize the `Kind` `ClusterProperty` to store objects with the name `fingerprint.coolmcsimplementation.com` but not `fingerprint.k8s.io` and not simply `fingerprint`.
 
 
 ### Notes/Constraints/Caveats (Optional)

--- a/keps/sig-multicluster/2149-clusterid/README.md
+++ b/keps/sig-multicluster/2149-clusterid/README.md
@@ -300,9 +300,11 @@ _For example, [CAPN's virtualcluster project](https://github.com/kubernetes-sigs
 The `ClusterProperty` resource provides a way to store identification related, cluster scoped information for multi-cluster tools while creating flexibility for implementations. A cluster may have multiple `ClusterProperty`s, each holding a different identification related value. Each property contains the following information:
 
 *   **Name** - a well known or custom name to identify the property.
-*   **Value** - a property-dependent string, up to 128 KB.
+*   **Value** - a property-dependent string, up 128k Unicode code points (see _Note_).
 
 The schema for `ClusterProperty` is intentionally loose to support multiple forms of information, including arbitrary additional identification related properties described by users (see "Additional Properties", below), but certain well-known properties will add additional schema constraints, such as those described in the next section.
+
+_Note: While prior Kubernetes API constructs containing arbitrary string values, such as annotations, are limited by a byte length, the OpenAPI validation this CRD depends on defines string length as Unicode code points at validation time. The encoded length of the string in bytes as observed on input or output by the user may vary depending on which of the valid JSON encodings are used (UTF-8, UTF-16, or UTF-32). Therefore, the value limit of 128k code points could take up to 512KB using the least space efficient allowable encoding, UTF-32, which uses 4 bytes per code point._
 
 
 ### Well known properties

--- a/keps/sig-multicluster/2149-clusterid/README.md
+++ b/keps/sig-multicluster/2149-clusterid/README.md
@@ -378,7 +378,7 @@ Contains an identifier that relates the containing cluster to the ClusterSet in 
 
 ### Additional Properties
 
-Implementers are free to add additional properties as they see fit, so long as they do not conflict with the well known properties. `*.k8s.io`, `*.kubernetes.io`, and `sigs.k8s.io` properties are reserved for Kubernetes and related projects.
+Implementers are free to add additional properties as they see fit, so long as they do not conflict with the well known properties and utilize a suffix. "Bare name" properties with no suffix, and properties using the suffixes `*.k8s.io`, `*.kubernetes.io`, and `*.sigs.k8s.io` are reserved for Kubernetes and related projects. For example, an implementation may utilize the `Kind` `ClusterProperty` to store objects with the name `fingerprint.coolmcsimplementation.com` but not `fingerprint.k8s.io` and not simply `fingerprint`.
 
 
 ### Notes/Constraints/Caveats (Optional)


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Requesting API review for proposed apiGroup `about.k8s.io`, containing Kind `ClusterProperty` in [KEP-2149: ClusterID for ClusterSet Identificiation](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid)

<!-- link to the k/enhancements issue -->
- Issue link: #2149

<!-- other comments or additional information -->
- Other comments:
1. This KEP proposes an out-of-tree CRD to be hosted at (provisionally named) [kubernetes-sigs/about-api](https://github.com/kubernetes-sigs/about-api). The names selected in this proposal (`about.k8s.io` API group; `ClusterProperty` kind name; `id.k8s.io` and `clusterset.k8s.io` well-known CRs) were voted on by surveys sent to the SIG-Multicluster mailing list:
   - CR name announcement with data is in [this email](https://groups.google.com/g/kubernetes-sig-multicluster/c/90VOAKEMRKQ/m/EYb3eThvCgAJ).
   - API name announcement with data in it is in [this email](https://groups.google.com/g/kubernetes-sig-multicluster/c/KsCecfPE0zY/m/obz49m5qAwAJ).
2. Another well-known CR is under discussion right now in https://github.com/kubernetes/enhancements/pull/3045. I'm interested to know if additions like these need to undergo their own API review if/when they are included in the base KEP.
3. If I understand from the directions correctly API review starts with the KEP, but let me know if you need an implementation to go with it