### PR TITLE
removing unwanted conditional check: S1017

### DIFF
--- a/pkg/kepval/approval.go
+++ b/pkg/kepval/approval.go
@@ -79,9 +79,7 @@ func ValidatePRR(kep *api.Proposal, h *api.PRRHandler, prrDir string) error {
 		return errors.New("PRR approver cannot be empty")
 	}
 
-	if strings.HasPrefix(stagePRRApprover, "@") {
-		stagePRRApprover = strings.TrimPrefix(stagePRRApprover, "@")
-	}
+	stagePRRApprover = strings.TrimPrefix(stagePRRApprover, "@")
 
 	validApprover := api.IsOneOf(stagePRRApprover, h.PRRApprovers)
 	if !validApprover {


### PR DESCRIPTION
https://staticcheck.io/docs/checks#S1017

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Removing the `strings.HasPrefix(stagePRRApprover, "@")` condition cause the `stagePRRApprover = strings.TrimPrefix(stagePRRApprover, "@")` gives the same output of 
`
if strings.HasPrefix(stagePRRApprover, "@") {
		stagePRRApprover = strings.TrimPrefix(stagePRRApprover, "@")
	}
`

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: