### PR TITLE
KEP-563: dual-stack IPv4/IPv6 enhancement is implemented

### DIFF
--- a/keps/sig-network/563-dual-stack/kep.yaml
+++ b/keps/sig-network/563-dual-stack/kep.yaml
@@ -19,8 +19,8 @@ prr-approvers:
   - "@johnbelamaric"
 editor: TBD
 creation-date: "2018-05-21"
-last-updated: "2021-09-08"
-status: implementable
+last-updated: "2022-01-03"
+status: implemented
 stage: stable
 latest-milestone: v1.23
 milestone:


### PR DESCRIPTION
* One-line PR description: Dual-stack IPv4/IPv6 Enhancement has graduated to `stable` and can be considered implemented.

* Issue link: [Add IPv4/IPv6 dual-stack support #563](https://github.com/kubernetes/enhancements/issues/563)

* Other comments: 

Fixes https://github.com/kubernetes/enhancements/issues/563

/assign @thockin 
/cc @aojea @caseydavenport @danwinship @dcbw @khenidak @lachie83 
