### PR TITLE
KEP-1441: Include in 1.24 release

### DIFF
--- a/keps/sig-cli/1441-kubectl-debug/kep.yaml
+++ b/keps/sig-cli/1441-kubectl-debug/kep.yaml
@@ -24,13 +24,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.18"
   beta: "v1.20"
-  stable: "v1.25"
+  stable: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update KEP-1441 metadata to reflect that work is planned for 1.24 release

<!-- link to the k/enhancements issue -->
- Issue link: #1441

<!-- other comments or additional information -->
- Other comments: We'll be continuing work on kubectl debug profiles that did not complete in time for 1.23.