### PR TITLE
kubeadm: update 2067-rename-master-label-taint for 1.24

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
@@ -294,8 +294,9 @@ Not applicable.
 ## Implementation History
 
 - 2020-10-03 - initial provisional KEP created
-- 2020-10-05 - KEP marked as implementable
+- 2020-10-05 - KEP marked as implementable for 1.20 (stage 1)
 - 2020-11-09 - added link to "master-control-plane.md" ADR
+- 2022-01-10 - KEP marked as implementable for 1.24 (stage 2)
 
 ## Drawbacks
 

--- a/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/kep.yaml
@@ -7,10 +7,10 @@ participating-sigs:
   - sig-cluster-lifecycle
 status: implementable
 creation-date: 2020-10-03
+last-updated: 2022-01-10
 reviewers:
   - "@fabriziopandini"
 approvers:
   - "@fabriziopandini"
-
-latest-milestone: "v1.20"
+latest-milestone: "0.0"
 stage: "alpha"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:


Mark the 2067-rename-master-label-taint KEP as implementable for 1.24. It is entering
stage 2, as outlined in the proposal.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2067
k/kubeadm: https://github.com/kubernetes/kubeadm/issues/2200

<!-- other comments or additional information -->
- Other comments:
NONE
