### PR TITLE
kubeadm: update 2915-kubeadm-replace-kubelet-config-x.y for 1.24

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/2915-kubeadm-replace-kubelet-config-x.y/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2915-kubeadm-replace-kubelet-config-x.y/README.md
@@ -591,7 +591,8 @@ Major milestones might include:
 - when the KEP was retired or superseded
 -->
 
-- 2021-08-30: Initial KEP draft.
+- 2021-08-30: Initial KEP draft for 1.23 (Alpha).
+- 2022-01-10: Update KEP for 1.24 (Beta).
 
 ## Drawbacks
 

--- a/keps/sig-cluster-lifecycle/kubeadm/2915-kubeadm-replace-kubelet-config-x.y/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2915-kubeadm-replace-kubelet-config-x.y/kep.yaml
@@ -5,6 +5,7 @@ authors:
 owning-sig: sig-cluster-lifecycle
 status: implementable
 creation-date: 2021-08-30
+last-updated: 2022-01-10
 reviewers:
   - "@fabriziopandini"
   - "@pacoxu"
@@ -14,17 +15,17 @@ approvers:
   - "@SataQiu"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "0.0"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.23"
-  beta: TBD
+  beta: "v1.24"
   stable: TBD
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

The feature is graduating to Beta in 1.24.
Update the KEP files to reflect that.

<!-- link to the k/enhancements issue -->
- Issue link: 
https://github.com/kubernetes/enhancements/issues/2915
https://github.com/kubernetes/kubeadm/issues/1582

<!-- other comments or additional information -->
- Other comments:
NONE
