### PR TITLE
KEP-2923: adding beta graduation criteria

### DIFF
--- a/keps/prod-readiness/sig-storage/2923.yaml
+++ b/keps/prod-readiness/sig-storage/2923.yaml
@@ -1,3 +1,5 @@
 kep-number: 2923
 alpha:
   approver: "@ehashman"
+beta:
+  approver: "@ehashman"

--- a/keps/sig-storage/2923-csi-migration-ceph-rbd/README.md
+++ b/keps/sig-storage/2923-csi-migration-ceph-rbd/README.md
@@ -16,14 +16,14 @@ This document present as a vendor specific KEP for the parent KEP
 [CSI Migration](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/625-csi-migration)
 
 This inherits all the contents from its parent KEP. It will introduce two new feature gates to be 
-used as as described in its parent KEP. For all other contents, please refer to the parent KEP.
+used as described in its parent KEP. For all other contents, please refer to the parent KEP.
 
 ### New Feature Gates
 
 - CSIMigrationRbd
   - As describe in [CSI Migration](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/625-csi-migration), 
   when this feature flag && the `CSIMigration` is enabled at the same time, all operations related to the 
-  in-tree volume plugin `kubernetes.io/rbd` will be redirect to use the corresponding CSI driver. From a 
+  in-tree volume plugin `kubernetes.io/rbd` will be redirected to use the corresponding CSI driver. From a
   user perspective, nothing will be noticed.
 - InTreePluginRbdUnregister
   - This flag technically is not part of CSI Migration design. But it happens to be related and helps with 
@@ -49,5 +49,7 @@ Major milestones in the life cycle of a KEP should be tracked in `Implementation
 Major milestones for Ceph RBD in-tree plugin CSI migration:
 
 - 1.23
-  - CephRBD CSI migration to Alpha
+  - Ceph RBD CSI migration to Alpha
+- 1.24
+  - Ceph RBD CSI migration to Beta, off by default
 

--- a/keps/sig-storage/2923-csi-migration-ceph-rbd/kep.yaml
+++ b/keps/sig-storage/2923-csi-migration-ceph-rbd/kep.yaml
@@ -22,12 +22,12 @@ prr-approvers:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This commit adds the details to the KEP for promoting Ceph RBD CSI
migration from alpha to beta in v1.24

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


- Issue link:  #2923 

