### PR TITLE
#2535:ensure secret pulled images - bump targets by one

### DIFF
--- a/keps/sig-node/2535-ensure-secret-pulled-images/kep.yaml
+++ b/keps/sig-node/2535-ensure-secret-pulled-images/kep.yaml
@@ -18,11 +18,11 @@ approvers:
 prr-approvers:
   - "@johnbelarmic"
 stage: alpha
-latest-milestone: "v1.23"
+latest-milestone: "v1.24"
 milestone:
-  alpha: "v1.23"
-  beta: "v1.24"
-  stable: "v1.26"
+  alpha: "v1.24"
+  beta: "v1.25"
+  stable: "v1.27"
 feature-gates:
   - name: KubeletEnsureSecretPulledImages
     components:


### PR DESCRIPTION
Signed-off-by: Mike Brown <brownwm@us.ibm.com>

- One-line PR description: bump kep release targets by one since the PR for the approved kep did not merge in time...
https://github.com/kubernetes/kubernetes/pull/94899

- Issue link: https://github.com/kubernetes/enhancements/issues/2535

- Other comments:
Merged kep.. https://github.com/kubernetes/enhancements/pull/1608