### PR TITLE
hack/verify-toc.sh: Use `go install` instead of `go get`

### DIFF
--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -38,7 +38,7 @@ trap exitHandler EXIT
 # perform go get in a temp dir as we are not tracking this version in a go module
 # if we do the go get in the repo, it will create / update a go.mod and go.sum
 cd "${TMP_DIR}"
-GO111MODULE=on GOBIN="${TMP_DIR}" go get "sigs.k8s.io/mdtoc@${TOOL_VERSION}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go install "sigs.k8s.io/mdtoc@${TOOL_VERSION}"
 export PATH="${TMP_DIR}:${PATH}"
 cd "${ROOT}"
 


### PR DESCRIPTION
## What

Use `go install` instead of `go get`

## Why 

> installing executables with 'go get' in module mode is deprecated.

```
(*'-') < make verify-toc               
/Users/kenseinakada/workspace/enhancements/hack/verify-toc.sh
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
Checking table of contents are up to date...
Cleaning up...
```

This is the same change as https://github.com/kubernetes/enhancements/pull/2817/commits/da2dac0b6aa5600c99dec19839dd2c8d610c05e1.

/cc @justaugustus
/kind cleanup