### PR TITLE
Fix an issue from golangci-lint

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -267,8 +267,8 @@ func (r *Repo) LoadLocalKEPs(sig string) ([]*api.Proposal, error) {
 
 	logrus.Debugf("loading the following local KEPs: %v", files)
 
-	var allKEPs []*api.Proposal
-	for _, kepYamlPath := range files {
+	allKEPs := make([]*api.Proposal, len(files))
+	for i, kepYamlPath := range files {
 		kep, err := r.loadKEPFromYaml(r.BasePath, kepYamlPath)
 		if err != nil {
 			return nil, errors.Wrapf(
@@ -278,7 +278,7 @@ func (r *Repo) LoadLocalKEPs(sig string) ([]*api.Proposal, error) {
 			)
 		}
 
-		allKEPs = append(allKEPs, kep)
+		allKEPs[i] = kep
 	}
 
 	logrus.Debugf("returning %d local KEPs", len(allKEPs))


### PR DESCRIPTION
This PR fixes an issue from golangci-lint.

```
(*'-') < make verify-golangci-lint

...

pkg/repo/repo.go:270:2: Consider preallocating `allKEPs` (prealloc)
        var allKEPs []*api.Proposal
        ^
make: *** [verify-golangci-lint] Error 1
```

And I think we can enable golangci-lint in prow-job. It's skipped currently.
https://github.com/kubernetes/enhancements/blob/master/hack/verify.sh#L40

/cc @justaugustus