### PR TITLE
KEP-2876: Core library proposal for CEL

### DIFF
--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -13,7 +13,6 @@
 - [Proposal](#proposal)
     - [Expression lifecycle](#expression-lifecycle)
     - [Function library](#function-library)
-- [CEL <a href="https://github.com/google/cel-go/blob/master/ext/strings.go">extended string function library</a> includes:](#cel-extended-string-function-library-includes)
       - [Function Library Updates](#function-library-updates)
   - [User Stories](#user-stories)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -452,7 +452,6 @@ Some considerations when selecting which of the above we should include in CEL e
 - None of the other policy libraries provide extended math/trig support and I asked Tristan (maintainer of CEL) if
   they are requested and he said "almost never", which he clarified to mean it has been requested exactly one time.
 - Average and quantile (median, 99th percentile, ...) and stddev are, however, often requested by other CEL users
-- `hasPrefix` / `hasSuffix` is useful but can be performed trivially using regex matching
 
 Future work:
 

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -481,9 +481,9 @@ introduced one Kubernetes release prior to when it may be included in create/upd
 The mechanism for this will be:
 
 - All new functions, macros, or overloads of existing functions, will be added to a separate "kubernetes-future-compatibility" CEL extension library. (Better naming suggestions welcome).
-- For create requests, and for any CEL expression that are changed as part of an update, the CEL expression will be 
+- For create requests, and for any CEL expressions that are changed as part of an update, the CEL expression will be 
   compiled **without** the "kubernetes-future-compatibility" CEL extension.
-- For CEL expressions not change in an update, the CEL expression will be compiled **with** the
+- For CEL expressions not changed in an update, the CEL expression will be compiled **with** the
   "kubernetes-future-compatibility" CEL extension. This ensures that persisted fields that already use the change continue
   to compile.
 - The "kubernetes-future-compatibility" CEL extension will always be included when CEL expressions are evaluated.

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -424,9 +424,8 @@ Some considerations when selecting which of the above we should include in CEL e
 - `sort` makes it possible to check if a list is sorted. It can be an expensive operation.
 - `indexOf` / `lastIndexOf` / `split` / `replace` (the string functions) could be overloaded to provide the equivalent list functions?
    Keeping string and list functions consistent seems like a good way to keep the learning curve down.
-- `reduce` is going to non-obvious to anyone that doesn't have a functional programming background?
-  - CEL already provides `map`..
-  - I don't want to ever be expected to expose `fold` (or `zip` either, I think)
+- `reduce` is going to be non-obvious to anyone that doesn't have a functional programming background?
+  - If we provide `reduce` are developers going to also expect to have `fold` or `zip`?
 - "Ability to construct a map using a comprehension": this appears mechanically problematic to support in CEL?
 
 Proposal:
@@ -436,7 +435,6 @@ Proposal:
 - Add `trim` / `trimLeft` / `trimRight` (overloaded to take an optional cutset arg) for strings
 - Add `trimPrefix` / `trimSuffix` for strings
 - Add `sort` for lists with comparable elements
-- Add a `reduce` macro? (I'm on the fence on this one)
 - Add `sum`, `min` and `max` functions for lists of summable/comparable elements
 - Add the core math functions (exp/log/log10/logN/pow/sqrt/abs/cel/floor/round) and trig. Can we put this in a math extension library in cel-go?
   - What types of abuse do we open ourselves up to? What are the mining / code breaking uses that get unlocked?

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -588,7 +588,7 @@ Types:
 | 'object' with AdditionalProperties                 | map                                                                                                                          |
 | 'object' with x-kubernetes-embedded-type           | object / "message type", 'apiVersion', 'kind', 'metadata.name' and 'metadata.generateName' are implicitly included in schema |
 | 'object' with x-kubernetes-preserve-unknown-fields | object / "message type", unknown fields are NOT accessible in CEL expression                                                 |
-| x-kubernetes-int-or-string                         | union of int or string,  `self.intOrString < 100 \|\| self.intOrString == '50%'` evalutes to true for both `50` and `"50%"`  |
+| x-kubernetes-int-or-string                         | union of int or string,  `self.intOrString < 100 \|\| self.intOrString == '50%'` evaluates to true for both `50` and `"50%"`  |
 | 'array                                             | list                                                                                                                         |
 | 'array' with x-kubernetes-list-type=map            | list with map based Equality & unique key guarantees                                                                         |
 | 'array' with x-kubernetes-list-type=set            | list with set based Equality & unique entry guarantees                                                                       |

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -427,7 +427,7 @@ Some considerations when selecting which of the above we should include in CEL e
 - Regex replace is very powerful and useful. It is also potentially dangerous due to its ability to allocate memory.
 - `format`: Since CEL supports string concatenation, the value of having format would only be to do things like format floats.
   Formatting functions are complex and require extensive documentation to teach.
-- `isSorted` makes it possible to check if a list is sorted without the expensive of performing a sort
+- `isSorted` makes it possible to check if a list is sorted without the expense of performing a sort
 - `indexOf` / `lastIndexOf` / `split` / `replace` (the string functions) will be overloaded to provide the equivalent list functions.
 - `reduce` is going to be non-obvious to anyone that doesn't have a functional programming background?
   - If we provide `reduce` are developers going to also expect to have `fold` or `zip`?
@@ -435,7 +435,7 @@ Some considerations when selecting which of the above we should include in CEL e
 - None of the other policy libraries provide extended math/trig support and I asked Tristan (maintainer of CEL) if
   they are requested and he said "almost never", which he clarified to mean it has been requested exactly one time.
 - Average and quantile (median, 99th percentile, ...) and stddev are, however, often requested by other CEL users
-- `hasPrefix` / `hasSuffix` is useful but an be performed trivially using regex matching
+- `hasPrefix` / `hasSuffix` is useful but can be performed trivially using regex matching
 
 Proposal:
 
@@ -445,7 +445,7 @@ Proposal:
   core set of aggregate functions for lists, with CEL they can also be used on scalars by using defining list literals
   inline , e.g. `[self.val1, self.val2].max()`
 - Add `indexOf` / `lastIndexOf` support for lists (overloading the existing string functions), this can be useful for
-- validating partial order (i.e. the tasks of a workflow)
+  validating partial order (i.e. the tasks of a workflow)
 
 The function libraries we need can be added using [extension
 functions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#extension-functions) to either cel-go (if they accept our proposals)
@@ -453,7 +453,7 @@ or directly to the Kubernetes codebase.
 
 Future work:
 
-We've NOT to add the following functions. They may be useful for mutation, in which case we will consider adding them as part
+We've decided NOT to add the following functions. They may be useful for mutation, in which case we will consider adding them as part
 of any future work done involving CEL and mutating admission control:
 
 - Regex replace

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -465,7 +465,11 @@ of any future work done involving CEL and mutating admission control:
 
 ##### Function Library Updates
 
-Any function library changes must follow the [API Changes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md)
+Any changes to the CEL function library will make it possible for CRD authors to create CRDs that are incompatible with
+all previous Kubernetes releases that supported CEL. Because of this incompatibility, changing the function library
+will need to carefully considered and kept to a minimum. All changes will need to be limited to function additions.
+
+Any function library change must follow the [API Changes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md)
 guidelines. Since a change to the function library is a change to the `x-kubernetes-validations.rule` field, it must be
 introduced one Kubernetes release prior to when it may be included in create/update requests to CRDs. Specifically:
 

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -13,6 +13,7 @@
 - [Proposal](#proposal)
     - [Expression lifecycle](#expression-lifecycle)
     - [Function library](#function-library)
+- [CEL <a href="https://github.com/google/cel-go/blob/master/ext/strings.go">extended string function library</a> includes:](#cel-extended-string-function-library-includes)
   - [User Stories](#user-stories)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -366,6 +366,11 @@ Proposal:
     inline , e.g. `[self.val1, self.val2].max()`. Overflow will raise the same error raised by arithmetic operation [overflow](https://github.com/google/cel-spec/blob/master/doc/langdef.md#overflow).
   - Add `indexOf` / `lastIndexOf` support for lists (overloading the existing string functions), this can be useful for
     validating partial order (i.e. the tasks of a workflow)
+  - Add URL parsing: `url(string) URL`, `string(URL) string` (conversion), `getScheme(URL) string`, `getUserInfo(URL) string`,
+    `getHost(URL) string`, `getPort(URL) string`, `getPath(URL) string`, `getQuery(URL) string`, `getFragment(URL) string`. This is
+    useful for validating URLs. The go URL parser implements all the functionality.
+  - Add regex `find(string) string` and `findAll(string) []string`. This makes it possible to parse out parts of string
+    formats (we only provide timestamp, duration and url support directly).
 
 The function libraries we need can be added using [extension
 functions](https://github.com/google/cel-spec/blob/master/doc/langdef.md#extension-functions) to either cel-go (if they accept our proposals)
@@ -432,6 +437,9 @@ Numbers:
 Formats:
 
 - semver: compare (xref [Kyverno function library](https://github.com/kyverno/kyverno/blob/main/pkg/engine/jmespath/functions.go))
+- urls: parsing out {scheme, userInfo, host, port, path, query, fragment}. This is [hard](https://community.helpsystems.com/forums/intermapper/miscellaneous-topics/5acc4fcf-fa83-e511-80cf-0050568460e4?_ga=2.113564423.1432958022.1523882681-2146416484.1523557976)
+  to get right with regex, particularly with ipv6.
+- images: parsing out {name, tag, digest} as well as {host, port} from name and algorithm, hex} from digest. (xref: [grammar](https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go#L4-L24)).
 
 Maps:
 
@@ -468,7 +476,7 @@ of any future work done involving CEL and mutating admission control:
 Any changes to the CEL function library will make it possible for CRD authors to create CRDs that are incompatible with
 all previous Kubernetes releases that supported CEL. Because of this incompatibility, changing the function library
 will need to carefully considered and kept to a minimum. All changes will need to be limited to function additions.
-We will not add functions to do things that can already be accomplished with existing functions. Improving ease-of-use
+We will not add functions to do things that can already be reasonably accomplished with existing functions Improving ease-of-use
 at the cost of fragmentation / incompatibility with older servers is not a good trade-off.
 
 Any function library change must follow the [API Changes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md)

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
@@ -6,7 +6,7 @@ authors:
   - "@DangerOnTheRanger"
   - "@leilajal"
 owning-sig: sig-api-machinery
-status: implemented
+status: implementable
 creation-date: 2021-05-26
 reviewers:
   - "@deads2k"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Propose what core library of functions we will make available to CEL for Beta

Proposed additions are:

- `isSorted` for lists with comparable elements. This is useful for ensuring that a list is kept in-order.
- `sum`, `min` and `max` functions for lists of summable/comparable elements. This is the
  core set of aggregate functions for lists, with CEL they can also be used on scalars by using defining list literals
  inline , e.g. `[self.val1, self.val2].max()`
- `indexOf` / `lastIndexOf` for lists (overloading the existing string functions), this can be useful for
- validating partial order (i.e. the tasks of a workflow)

Also:
- Explain mechanism to make post-alpha library updates (which will need to be done with great care given that they will make CRDs incompatible with older Kubernetes versions)
- Update KEP to reflect that numerical comparisons will be fully supported in Beta
- Update KEP to reflect that int-or-string will be typesafe in Beta

<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/2876
<!-- other comments or additional information -->
- Other comments:

/sig api-machinery