### PR TITLE
Mark TTL-after-finish KEP-592 to implemented

### DIFF
--- a/keps/sig-apps/592-ttl-after-finish/kep.yaml
+++ b/keps/sig-apps/592-ttl-after-finish/kep.yaml
@@ -7,7 +7,7 @@ authors:
 owning-sig: sig-apps
 participating-sigs:
   - sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2018-08-16
 reviewers:
   - "@enisoc"


### PR DESCRIPTION
  - One-line PR description:
This PR updates the status to `implemented` for KEP-592 (TTL-after-finish) which recently moved to stable state in 1.23 release.

- Issue link:
https://github.com/kubernetes/enhancements/issues/592

- Other comments: