### PR TITLE
kubeadm: retroactively update old KEPs

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/2500-kubeadm-join-control-plane-workflow/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2500-kubeadm-join-control-plane-workflow/README.md
@@ -370,6 +370,7 @@ one control plane instances, but with a new sub-step to be executed on secondary
 - v1.13 support for local/stacked etcd
 - v1.14 implementation of automatic certificates copy
   (see KEP [Certificates copy for join --control-plane](20190122-Certificates-copy-for-kubeadm-join--control-plane.md)).
+- v1.24 retroactively promoted to GA
 
 ## Drawbacks
 

--- a/keps/sig-cluster-lifecycle/kubeadm/2500-kubeadm-join-control-plane-workflow/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2500-kubeadm-join-control-plane-workflow/kep.yaml
@@ -12,7 +12,10 @@ approvers:
   - "@timothysc"
 editor: "@fabriziopandini"
 creation-date: 2018-01-28
-last-updated: 2019-04-18
-status: provisional
+last-updated: 2022-01-17
+status: implemented
 see-also:
   - KEP 0004
+
+latest-milestone: "0.0"
+stage: "stable"

--- a/keps/sig-cluster-lifecycle/kubeadm/2501-kubeadm-phases-to-beta/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2501-kubeadm-phases-to-beta/README.md
@@ -139,6 +139,7 @@ workflows e.g. reuse of phase `certs` in both `kubeadm init` and `kubeadm join` 
 * v1.14 implementation of phases in the `kubeadm join` workflow
 * v1.15 implementation of phases in the `kubeadm upgrade node` workflow
 * v1.17 implementation of phases in the `kubeadm upgrade apply` workflow (planned)
+- v1.24 retroactively promoted to Beta. `upgrade apply` might need a separate KEP.
 
 ## Drawbacks
 

--- a/keps/sig-cluster-lifecycle/kubeadm/2501-kubeadm-phases-to-beta/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2501-kubeadm-phases-to-beta/kep.yaml
@@ -13,7 +13,10 @@ approvers:
   - "@timothysc"
 editor: "@fabriziopandini"
 creation-date: 2018-03-16
-last-updated: 2019-01-22
-status: provisional
+last-updated: 2022-01-17
+status: implemented
 see-also:
   - KEP 0008
+
+latest-milestone: "0.0"
+stage: "beta"

--- a/keps/sig-cluster-lifecycle/kubeadm/2502-Certificates-copy-for-join-control-plane/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2502-Certificates-copy-for-join-control-plane/README.md
@@ -309,6 +309,7 @@ affect component version or version skew policy)
   - Extension of the kubeadm config file for allowing usage of pre-generated certificate keys
   - TokenCleaner enforcement
   - E2E tests
+- v1.24 retroactively promoted to GA
 
 ## Alternatives
 

--- a/keps/sig-cluster-lifecycle/kubeadm/2502-Certificates-copy-for-join-control-plane/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2502-Certificates-copy-for-join-control-plane/kep.yaml
@@ -15,12 +15,12 @@ approvers:
   - "@luxas"
 editor: TBD
 creation-date: 2019-01-22
-last-updated: 2019-04-18
-status: implementable
+last-updated: 2022-01-17
+status: implemented
 see-also:
   - KEP-0015
 replaces:
 superseded-by:
 
 latest-milestone: "0.0"
-stage: "alpha"
+stage: "stable"

--- a/keps/sig-cluster-lifecycle/kubeadm/2506-Remove-ClusterStatus-from-kubeadm-config/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2506-Remove-ClusterStatus-from-kubeadm-config/README.md
@@ -123,3 +123,4 @@ NA
 - the `Summary` and `Motivation` sections being merged signaling SIG acceptance
 - the `Proposal` section being merged signaling agreement on a proposed design
 - the date implementation started
+- v1.24 retroactively promoted to GA

--- a/keps/sig-cluster-lifecycle/kubeadm/2506-Remove-ClusterStatus-from-kubeadm-config/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2506-Remove-ClusterStatus-from-kubeadm-config/kep.yaml
@@ -14,8 +14,8 @@ approvers:
   - "@timothysc"
 editor: "@fabriziopandini"
 creation-date: 2019-11-25
-last-updated: 2019-11-25
-status: implementable
+last-updated: 2022-01-17
+status: implemented
 
 latest-milestone: "0.0"
-stage: "alpha"
+stage: "stable"


### PR DESCRIPTION
The work on some of the these enhancements completed a long
time ago. Perform the following cleanup:

- 2500, 2502 (HA features) have been in beta for ~7 releases
and can be considered GA without much changes other than bug fixes.
Separate tracking is already done for future improvements
that may need separate KEPs (e.g. learner mode for etcd). Promote them to GA and close.
- 2051 was about moving the kubeadm phases to beta. "upgrade apply"
still does not have phases, so a separate KEP might be required TBD. Promote the old KEP as Beta / implemented.
- 2506 the work completed in 1.22, when ClusterStatus was removed
from v1beta3. Promote to GA.

clusterstatus: https://github.com/kubernetes/kubeadm/issues/2290
phases for "apply": https://github.com/kubernetes/kubeadm/issues/1318

ha issues:
learner mode: https://github.com/kubernetes/kubeadm/issues/1793
closes https://github.com/kubernetes/kubeadm/issues/2081
closes https://github.com/kubernetes/enhancements/issues/357
closes https://github.com/kubernetes/enhancements/issues/2500
closes https://github.com/kubernetes/enhancements/issues/2502
