### PR TITLE
KEP-2258: Update milestones to 1.24

### DIFF
--- a/keps/sig-windows/2258-node-service-log-viewer/kep.yaml
+++ b/keps/sig-windows/2258-node-service-log-viewer/kep.yaml
@@ -24,13 +24,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.23"
-  beta: "v1.24"
-  stable: "v1.25"
+  alpha: "v1.24"
+  beta: "v1.25"
+  stable: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
Update the milestones on the KEP for node service log viewer to 1.24.

- Issue link: https://github.com/kubernetes/enhancements/issues/2258