### PR TITLE
KEP-2845: klog deprecation: beta in 1.24

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/2845.yaml
+++ b/keps/prod-readiness/sig-instrumentation/2845.yaml
@@ -1,3 +1,5 @@
 kep-number: 2845
 alpha:
   approver: "@ehashman"
+beta:
+  approver: "@ehashman"

--- a/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
+++ b/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/kep.yaml
@@ -16,8 +16,8 @@ approvers:
 see-also:
   - "/keps/sig-instrumentation/1602-structured-logging"
 replaces: []
-stage: alpha
-latest-milestone: "v1.23"
+stage: beta
+latest-milestone: "v1.24"
 milestone:
   alpha: "v1.23"
   beta: "v1.24"


### PR DESCRIPTION
- One-line PR description: describe goal for 1.24
- Issue link: https://github.com/kubernetes/enhancements/issues/2845
