### PR TITLE
exclude kubeadm from PRR

### DIFF
--- a/keps/prod-readiness/README.md
+++ b/keps/prod-readiness/README.md
@@ -19,4 +19,8 @@ items.
 Full documentation on the production readiness review process can be found on
 the SIG Architecture page [here][prod-readiness].
 
+**Note:** The kubeadm tool is considered out-of-tree and does not fall under PRR.
+If the kubeadm maintainers have to, they could still ask the PRR team for advisory on
+a particular production related topic.
+
 [prod-readiness]: https://git.k8s.io/community/sig-architecture/production-readiness.md

--- a/keps/prod-readiness/sig-cluster-lifecycle/2568.yaml
+++ b/keps/prod-readiness/sig-cluster-lifecycle/2568.yaml
@@ -1,3 +1,0 @@
-kep-number: 2568
-alpha:
-  approver: "@ehashman"

--- a/keps/prod-readiness/sig-cluster-lifecycle/2915.yaml
+++ b/keps/prod-readiness/sig-cluster-lifecycle/2915.yaml
@@ -1,3 +1,0 @@
-kep-number: 2915
-alpha:
-  approver: "@johnbelamaric"

--- a/pkg/kepval/approval.go
+++ b/pkg/kepval/approval.go
@@ -100,6 +100,12 @@ func ValidatePRR(kep *api.Proposal, h *api.PRRHandler, prrDir string) error {
 func isPRRRequired(kep *api.Proposal) (required, missingMilestone, missingStage bool, err error) {
 	logrus.Debug("checking if PRR is required")
 
+	// kubeadm is considered out-of-tree. Skip PRR checks for KEPs in the kubeadm directory.
+	kubeadmPath := "keps/sig-cluster-lifecycle/kubeadm/"
+	if strings.Contains(kep.Filename, kubeadmPath) {
+		return required, missingMilestone, missingStage, nil
+	}
+
 	required = kep.Status == api.ImplementableStatus || kep.Status == api.ImplementedStatus
 	missingMilestone = kep.IsMissingMilestone()
 	missingStage = kep.IsMissingStage()


### PR DESCRIPTION
- Update the PRR readme with a note that kubeadm is out of scope.
- Remove existing PRR approvals for kubeadm in
keps/prod-readiness/sig-cluster-lifecycle. These were rubberstamps and the KEPs do not contain an actual PRR.
- Update kepval/approval.go to skip kubeadm KEP paths.

some context on why this change is being proposed:
https://github.com/kubernetes/enhancements/issues/2067#issuecomment-1018408831

> this has been a recurring topic every release

role book PR:
https://github.com/kubernetes/sig-release/pull/1831