### PR TITLE
KEP-1864: update to stable for v1.24

### DIFF
--- a/keps/sig-network/1864-disable-lb-node-ports/kep.yaml
+++ b/keps/sig-network/1864-disable-lb-node-ports/kep.yaml
@@ -22,13 +22,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.20"
   beta: "v1.22"
-  stable: "v1.23"
+  stable: "v1.24"
 
 feature-gates:
   - name: ServiceLBNodePortControl


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update KEP-1864 to stable in v1.24

<!-- link to the k/enhancements issue -->
- Issue link: #1864 

<!-- other comments or additional information -->
- Other comments:

Looks like @uablrek already did the work to promote this to GA in v1.24 (https://github.com/kubernetes/kubernetes/pull/107027), this is just offically updating the KEP to reflect what is already done. 