### PR TITLE
Promote Portworx CSI migration to Beta in v1.24

### DIFF
--- a/keps/prod-readiness/sig-storage/2589.yaml
+++ b/keps/prod-readiness/sig-storage/2589.yaml
@@ -1,3 +1,5 @@
 kep-number: 2589
 alpha:
   approver: "@ehashman"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-storage/2589-csi-migration-portworx/README.md
+++ b/keps/sig-storage/2589-csi-migration-portworx/README.md
@@ -16,14 +16,14 @@ This document present as a vendor specific KEP for the parent KEP
 [CSI Migration](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/625-csi-migration)
 
 This inherits all the contents from its parent KEP. It will introduce two new feature gates to be 
-used as as described in its parent KEP. For all other contents, please refer to the parent KEP.
+used as described in its parent KEP. For all other contents, please refer to the parent KEP.
 
 ### New Feature Gates
 
 - CSIMigrationPortworx
   - As describe in [CSI Migration](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/625-csi-migration), 
   when this feature flag && the `CSIMigration` is enabled at the same time, the in-tree volume 
-  plugin `kubernetes.io/portworx-volume` will be redirect to use the corresponding CSI driver. From a 
+  plugin `kubernetes.io/portworx-volume` will be redirected to use the corresponding CSI driver. From a 
   user perspective, nothing will be noticed.
 - InTreePluginPortworxUnregister
   - This flag technically is not part of CSI Migration design. But it happens to be related and helps with 
@@ -50,4 +50,6 @@ Major milestones for Portworx in-tree plugin CSI migration:
 
 - 1.23
   - Portworx CSI migration to Alpha
+- 1.24
+  - Portworx CSI migration to Beta, off by default
 

--- a/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
+++ b/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
@@ -22,12 +22,12 @@ prr-approvers:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This commit adds the details to the KEP for promoting Portworx CSI migration from alpha to beta in v1.24

One-line PR description: Update KEP for Portworx CSI Migration

Issue link: Portworx file in-tree to CSI driver migration  #[2589](https://github.com/kubernetes/enhancements/issues/2589)

Other comments: 

/sig storage
/cc @msau42