### PR TITLE
KEP-1435: adding PRR for MixedProtocolLBService feature to move to beta

### DIFF
--- a/keps/prod-readiness/sig-network/1435.yaml
+++ b/keps/prod-readiness/sig-network/1435.yaml
@@ -1,0 +1,3 @@
+kep-number: 1435
+beta:
+  approver: "ehashman"

--- a/keps/sig-network/1435-mixed-protocol-lb/kep.yaml
+++ b/keps/sig-network/1435-mixed-protocol-lb/kep.yaml
@@ -2,6 +2,7 @@ title: Different protocols in the same service definition with type=loadbalancer
 kep-number: 1435
 authors:
   - "@laszlo.janosi1@gmail.com"
+  - "@bridgetkromhout"
 owning-sig: sig-network
 participating-sigs:
   - sig-cloud-provider
@@ -19,18 +20,18 @@ replaces:
   - "/keps/sig-network/ 20200103-mixed-protocol-lb"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.20"
-  beta: "v1.21"
-  stable: "v1.22"
+  beta: "v1.24"
+  stable: "TBD"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: 

Adding Production Readiness Review for Mixed Protocols in Services with type=LoadBalancer

- Issue link: https://github.com/kubernetes/enhancements/issues/1435

- Other comments:

Have discussed with SIG-network and SIG-cloudprovider; see https://github.com/kubernetes/enhancements/issues/1435#issuecomment-969523031 for details.

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
