### PR TITLE
KEP-2086: updates for v1.24

### DIFF
--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -167,6 +167,10 @@ Beta:
 * feature gate `ServiceInternalTrafficPolicy` is enabled by default.
 * consensus on how internalTrafficPolicy overlaps with topology-aware routing.
 
+GA:
+* metrics for if a Service is dropping local traffic due to no endpoints (a.k.a black hole)
+* consensus on whether or not "PreferLocal" should be included as a new policy type
+
 ### Upgrade / Downgrade Strategy
 
 * The `trafficPolicy` field will be off by default during the alpha stage but can handle any existing Services that has the field already set.

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -209,6 +209,11 @@ New Services should be able to set the `internalTrafficPolicy` field. Existing S
 
 There will be unit tests to verify that apiserver will drop the field when the `ServiceInternalTrafficPolicy` feature gate is disabled.
 
+Tests added so far:
+* https://github.com/kubernetes/kubernetes/blob/0038bcfad495a0458372867a77c8ca646f361c40pkg/registry/core/service/strategy_test.go#L368-L390
+* https://github.com/kubernetes/kubernetes/blob/0038bcfad495a0458372867a77c8ca646f361c40/pkg/registry/core/service/storage/storage_test.go#L682-L684
+* https://github.com/kubernetes/kubernetes/blob/0038bcfad495a0458372867a77c8ca646f361c40/test/integration/service/service_test.go
+
 ### Rollout, Upgrade and Rollback Planning
 
 _This section must be completed when targeting beta graduation to a release._

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -168,7 +168,7 @@ Beta:
 * consensus on how internalTrafficPolicy overlaps with topology-aware routing.
 
 GA:
-* metrics for if a Service is dropping local traffic due to no endpoints (a.k.a black hole)
+* metrics for total number of Services that are dropping local traffic (kubeproxy/sync_proxy_rules_blackhole_total) due to no endpoints (a.k.a black hole).
 * consensus on whether or not "PreferLocal" should be included as a new policy type
 
 ### Upgrade / Downgrade Strategy
@@ -242,9 +242,7 @@ _This section must be completed when targeting beta graduation to a release._
 * **How can an operator determine if the feature is in use by workloads?**
 
 * Check Service to see if `internalTrafficPolicy` is set to `Local`.
-* A per-node "blackhole" metric will be added to kube-proxy which represent Services that are being intentionally dropped (internalTrafficPolicy=Local and no endpoints).
-
-TODO: add metric name once it's decided
+* A per-node "blackhole" metric will be added to kube-proxy which represent Services that are being intentionally dropped (internalTrafficPolicy=Local and no endpoints). The metric will be named `kubeproxy/sync_proxy_rules/blackhole_total` (subject to rename).
 
 * **What are the SLIs (Service Level Indicators) an operator can use to determine
 the health of the service?**

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -168,7 +168,7 @@ Beta:
 * consensus on how internalTrafficPolicy overlaps with topology-aware routing.
 
 GA:
-* metrics for total number of Services that are dropping local traffic (kubeproxy/sync_proxy_rules_blackhole_total) due to no endpoints (a.k.a black hole).
+* metrics for total number of Services that have no endpoints (kubeproxy/sync_proxy_rules_no_endpoints_total) with additional labels for internal/external and local/cluster policies.
 * consensus on whether or not "PreferLocal" should be included as a new policy type
 
 ### Upgrade / Downgrade Strategy

--- a/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
+++ b/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
@@ -41,4 +41,4 @@ feature-gates:
 disable-supported: true
 
 metrics:
-  - kubeproxy/sync_proxy_rules_blackhole_total
+  - kubeproxy/sync_proxy_rules_local_no_endpoints

--- a/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
+++ b/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
@@ -39,3 +39,6 @@ feature-gates:
       - kube-apiserver
       - kube-proxy
 disable-supported: true
+
+metrics:
+  - kubeproxy/sync_proxy_rules_blackhole_total

--- a/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
+++ b/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
@@ -23,13 +23,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.21"
   beta: "v1.22"
-  stable: "v1.23"
+  stable: "v1.25"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: v1.24 updates for KEP-2086: Service Internal Traffic Policy

<!-- link to the k/enhancements issue -->
- Issue link: #2086 

<!-- other comments or additional information -->
- Other comments:

Adding work towards GA in v1.24, but not planning to actually GA until v1.25