### PR TITLE
KEP-1495: bump beta version from 1.23 to 1.24

### DIFF
--- a/keps/sig-storage/1495-volume-populators/README.md
+++ b/keps/sig-storage/1495-volume-populators/README.md
@@ -590,6 +590,7 @@ resource usage (CPU, RAM, disk, IO, ...) in any components?**
 - KEP updated Feb 2021 for v1.21
 - Redesign with new `DataSourceRef` field in May 2021 for v1.22, still alpha
 - Added metrics, troubleshooting, move to beta in Sep 2021 for v1.23.
+- Jan 2021, bump beta release to v1.24.
 
 ## Alternatives
 

--- a/keps/sig-storage/1495-volume-populators/kep.yaml
+++ b/keps/sig-storage/1495-volume-populators/kep.yaml
@@ -7,7 +7,7 @@ participating-sigs:
   - sig-api-machinery
 status: implementable
 creation-date: 2019-12-03
-last-updated: 2021-09-02
+last-updated: 2022-01-31
 reviewers:
   - "@thockin"
   - "@saad-ali"
@@ -24,8 +24,8 @@ stage: beta
 latest-milestone: "v1.23"
 milestone:
   alpha: "v1.18"
-  beta: "v1.23"
-  stable: "v1.24"
+  beta: "v1.24"
+  stable: "v1.25"
 feature-gates:
   - name: AnyVolumeDataSource
     components:


### PR DESCRIPTION
- One-line PR description: update version for move to beta

- Issue link: https://github.com/kubernetes/enhancements/issues/1495

- Other comments: n/a