### PR TITLE
KEP-853: Improvement: Add periodSeconds field and fixed typo.

### DIFF
--- a/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
+++ b/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
@@ -115,10 +115,11 @@ behavior:
   scaleUp:
     policies:
     - type: Percent
-      value: 900%
+      value: 900
+      periodSeconds: 60
 ```
 
-The `900%` implies that 9 times the current number of pods can be added, effectively making the number
+The `900` implies that 9 times the current number of pods can be added, effectively making the number
 of replicas 10 times the current size. All other parameters are not specified (default values are used)
 
 If the application is started with 1 pod, it will scale up with the following number of pods:
@@ -143,7 +144,8 @@ behavior:
   scaleUp:
     policies:
     - type: Percent
-      value: 900%
+      value: 900
+      periodSeconds: 60
   scaleDown:
     policies:
     - type: Pods
@@ -167,6 +169,7 @@ behavior:
     policies:
     - type: Pods
       value: 1
+      periodSeconds: 300
 ```
 
 If the application is started with 1 pod, it will scale up very gradually:
@@ -204,6 +207,7 @@ behavior:
     policies:
     - type: Pods
       value: 5
+      periodSeconds: 600
 ```
 
 i.e., the algorithm will:
@@ -246,6 +250,7 @@ behavior:
     policies:
     - type: Pods
       value: 20
+      periodSeconds: 60
 ```
 
 i.e., the algorithm will:


### PR DESCRIPTION
This PR Added the `periodSecond` field under policies section which we have to mention otherwise it gives the below error on applying hpa.yaml:

> error: error validating "hpa.yaml": error validating data: ValidationError(HorizontalPodAutoscaler.spec.behavior.scaleUp.policies[0]): missing required field "periodSeconds" in io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy; if you choose to ignore these errors, turn validation off with --validate=false

And also removed the` %` sign from the value, it is of int32 not string type. it gives the below error:

>  error: error validating "hpa.yaml": error validating data: [ValidationError(HorizontalPodAutoscaler.spec.behavior.scaleUp.policies[0].value): invalid type for io.k8s.api.autoscaling.v2beta2.HPAScalingPolicy.value: got "string", expected "integer"

It is useful for the Users.