### PR TITLE
KEP-2221: Update dockershim removal KEP to reflect latest changes

### DIFF
--- a/keps/prod-readiness/sig-node/2221.yaml
+++ b/keps/prod-readiness/sig-node/2221.yaml
@@ -1,0 +1,3 @@
+kep-number: 2221
+stable:
+  approver: "@ehashman"

--- a/keps/sig-node/2221-remove-dockershim/README.md
+++ b/keps/sig-node/2221-remove-dockershim/README.md
@@ -40,10 +40,10 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
 - [X] (R) Graduation criteria is in place
 - [X] (R) Production readiness review completed
-- [ ] Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [X] Production readiness review approved
+- [X] "Implementation History" section is up-to-date for milestone
+- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [X] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 ## Terms
 
@@ -286,6 +286,7 @@ Not applicable
 
 ## Implementation History
 
+- 02/03/2022 (v1.24): Update KEP to reflect latest state.
 - 12/02/2020 (v1.20): [Dockershim Deprecation FAQ](https://kubernetes.io/blog/2020/12/02/dockershim-faq/) published.
 - 12/08/2020 (v1.20): dockershim deprecation [warning added to kubelet](https://kubernetes.io/blog/2020/12/08/kubernetes-1-20-release-announcement/#dockershim-deprecation).
 

--- a/keps/sig-node/2221-remove-dockershim/kep.yaml
+++ b/keps/sig-node/2221-remove-dockershim/kep.yaml
@@ -22,12 +22,12 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.20"
+latest-milestone: "v1.24"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This patch updates the dockershim removal KEP to be track-able by SIG Release in the usual enhancements process.

cc @kubernetes/sig-release @kubernetes/sig-node-feature-requests @kubernetes/sig-release-leads 

Refers to https://github.com/kubernetes/enhancements/issues/2221