### PR TITLE
KEP-2091: Update Release Signoff Checklist

### DIFF
--- a/keps/sig-network/2091-admin-network-policy/README.md
+++ b/keps/sig-network/2091-admin-network-policy/README.md
@@ -62,14 +62,14 @@
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
-- [ ] (R) Graduation criteria is in place
-- [ ] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [x] (R) Graduation criteria is in place
+- [x] (R) Production readiness review completed
+- [x] (R) Production readiness review approved
+- [x] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 

--- a/keps/sig-network/2091-admin-network-policy/kep.yaml
+++ b/keps/sig-network/2091-admin-network-policy/kep.yaml
@@ -9,7 +9,7 @@ authors:
   - "@vbannai"
   - "@gjsj"
 owning-sig: sig-network
-status: provisional
+status: implementable
 creation-date: 2021-02-18
 reviewers:
   - "@thockin"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Kep incorrectly merged without updating of release signoff Checklist,  resulted in the KEP being incorrectly booted from 1.24. 

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2091

<!-- other comments or additional information -->
- Other comments: This was a naive mistake, sorry about that!