### PR TITLE
KEP-1487: Target 1.25 for aws csi migration GA

### DIFF
--- a/keps/sig-storage/1487-csi-migration-aws/README.md
+++ b/keps/sig-storage/1487-csi-migration-aws/README.md
@@ -57,5 +57,5 @@ Major milestones for AWS EBS in-tree plugin CSI migration:
 - 1.23
   - AWS EBS CSI migration to Beta, on by default.
 
-- 1.24
+- 1.25
   - AWS EBS CSI migration to Stable

--- a/keps/sig-storage/1487-csi-migration-aws/kep.yaml
+++ b/keps/sig-storage/1487-csi-migration-aws/kep.yaml
@@ -27,13 +27,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.25"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.14"
   beta: "v1.17"
-  stable: "v1.24"
+  stable: "v1.25"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: updating milestone to 1.25

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1487

<!-- other comments or additional information -->
- Other comments: after some internal discussions and such, better to target 1.25!