### PR TITLE
Replace go get with go install in verify shell scripts

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -34,10 +34,10 @@ exitHandler() (
 )
 trap exitHandler EXIT
 
-# perform go get in a temp dir as we are not tracking this version in a go module
-# if we do the go get in the repo, it will create / update a go.mod and go.sum
+# perform go install in a temp dir as we are not tracking this version in a go module
+# if we do the go install in the repo, it will create / update a go.mod and go.sum
 cd "${TMP_DIR}"
-GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go install "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
 export PATH="${TMP_DIR}:${PATH}"
 cd "${ROOT}"
 

--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -35,8 +35,8 @@ exitHandler() (
 )
 trap exitHandler EXIT
 
-# perform go get in a temp dir as we are not tracking this version in a go module
-# if we do the go get in the repo, it will create / update a go.mod and go.sum
+# perform go install in a temp dir as we are not tracking this version in a go module
+# if we do the go install in the repo, it will create / update a go.mod and go.sum
 cd "${TMP_DIR}"
 GO111MODULE=on GOBIN="${TMP_DIR}" go install "sigs.k8s.io/mdtoc@${TOOL_VERSION}"
 export PATH="${TMP_DIR}:${PATH}"


### PR DESCRIPTION
This is _not_ a PR for a KEP.

Fixes this warning for hack scripts and updates a stale comment:
```
pjoglekar@pjoglekar-a01 enhancements % hack/verify-spelling.sh 
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```