### PR TITLE
fix the example output for kepctl

### DIFF
--- a/pkg/kepctl/commands/create.go
+++ b/pkg/kepctl/commands/create.go
@@ -32,7 +32,7 @@ func addCreate(topLevel *cobra.Command) {
 		Use:           "create",
 		Short:         "Create a new KEP",
 		Long:          "Create a new KEP using the current KEP template for the given type",
-		Example:       `  kepctl create --name a-path --title "My KEP" --number 123 --owning-sig sig-foo`,
+		Example:       `  kepctl create --name a-path --title "My KEP" --number 123 --owning-sig sig-foo --approvers someapprover --authors githubhandle`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -92,6 +92,20 @@ func addCreate(topLevel *cobra.Command) {
 		"s",
 		string(api.ProvisionalStatus),
 		"KEP State",
+	)
+
+	cmd.PersistentFlags().StringArrayVar(
+		&co.Approvers,
+		"approvers",
+		[]string{},
+		"Approvers",
+	)
+
+	cmd.PersistentFlags().StringVar(
+		&co.Stage,
+		"stage",
+		string(api.AlphaStage),
+		"KEP Stage",
 	)
 
 	cmd.PersistentFlags().StringVar(

--- a/pkg/proposal/create.go
+++ b/pkg/proposal/create.go
@@ -47,6 +47,7 @@ type CreateOpts struct {
 	Reviewers         []string
 	Type              string
 	State             string
+	Stage             string
 	ParticipatingSIGs []string
 	PRRApprovers      []string
 }
@@ -162,6 +163,7 @@ func populateProposal(p *api.Proposal, opts *CreateOpts) {
 	p.ParticipatingSIGs = append(opts.ParticipatingSIGs, opts.SIG)
 	p.Filename = opts.Name
 	p.LastUpdated = "v1.19"
+	p.Stage = api.Stage(opts.Stage)
 
 	if len(opts.PRRApprovers) > 0 {
 		p.PRRApprovers = updatePersonReference(opts.PRRApprovers)


### PR DESCRIPTION
so that it outputs the necessary fields for kep creation
also fix the flags so that we can pass along the required
fields for validation, otherwise KEP creation will simply
not work.

- One-line PR description:

`kepctl create` does not work and it should work if you use the example output command. This fixes that.