### PR TITLE
KEP 3140: Add LoadLocation on MacOS issue for beta promotion for CronJob TZ

### DIFF
--- a/keps/sig-apps/3140-TimeZone-support-in-CronJob/README.md
+++ b/keps/sig-apps/3140-TimeZone-support-in-CronJob/README.md
@@ -178,7 +178,11 @@ Additionally, all of tests will be performed with feature gate enabled and disab
 
 #### Beta
 
-TBD
+- Solve issue with case insensitive location loading:
+  - Test skipped on MacOS (https://github.com/kubernetes/kubernetes/pull/109218)
+  - Golang issue (https://github.com/golang/go/issues/21512)
+
+More TBD
 
 #### GA
 


### PR DESCRIPTION
- One-line PR description: adds beta promotion requirement 

- Issue link: https://github.com/kubernetes/enhancements/issues/3140

This was discovered in https://github.com/kubernetes/kubernetes/issues/109220 with a temporary fix skipping the test on MacOS in https://github.com/kubernetes/kubernetes/pull/109218