### PR TITLE
KEP-2238: Update implementation history and milestones

### DIFF
--- a/keps/sig-node/2238-liveness-probe-grace-period/README.md
+++ b/keps/sig-node/2238-liveness-probe-grace-period/README.md
@@ -529,6 +529,9 @@ _This section must be completed when targeting beta graduation to a release._
 - 2021-01-07: Initial draft KEP
 - 2021-03-11: Alpha implementation
   ([kubernetes/kubernetes#99375](https://github.com/kubernetes/kubernetes/pull/99375))
+- 2021-07-13: Beta updates ([k/k#103168](https://github.com/kubernetes/kubernetes/pull/103168))
+- 2021-07-13: Add validation ([k/k#103245](https://github.com/kubernetes/kubernetes/pull/103245))
+- 1.25 cycle: default feature flag to true ([k/k#108541](https://github.com/kubernetes/kubernetes/pull/108541))
 
 ## Drawbacks
 

--- a/keps/sig-node/2238-liveness-probe-grace-period/kep.yaml
+++ b/keps/sig-node/2238-liveness-probe-grace-period/kep.yaml
@@ -23,13 +23,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.22"
+latest-milestone: "v1.25"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.21"
   beta: "v1.22"
-  stable: "v1.25"
+  stable: "v1.27"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Default beta feature flag to on in 1.25

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2238

<!-- other comments or additional information -->
- Other comments: Beta in 1.22 BUT feature flag defaulted off. Need to set to true before GA.