### PR TITLE
KEP-2067: Fixes broken link

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
@@ -71,7 +71,7 @@ This taint key should also be renamed to "node-role.kubernetes.io/control-plane"
 The Kubernetes project is moving away from wording that is considered offensive.
 A new working group [WG Naming](https://git.k8s.io/community/archive/wg-naming) was created
 to track this work, and the word "master" was declared as offensive.
-[A proposal](http://git.k8s.io/community/wg-naming/recommendations/001-master-control-plane.md)
+[A proposal](http://git.k8s.io/community/sig-architecture/naming/recommendations/001-master-control-plane.md)
 was formalized for replacing the word "master" with "control plane".
 This means it should be removed from source code, documentation, and user-facing
 configuration from Kubernetes and its sub-projects.

--- a/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md
@@ -69,7 +69,7 @@ This taint key should also be renamed to "node-role.kubernetes.io/control-plane"
 ## Motivation
 
 The Kubernetes project is moving away from wording that is considered offensive.
-A new working group [WG Naming](https://git.k8s.io/community/wg-naming) was created
+A new working group [WG Naming](https://git.k8s.io/community/archive/wg-naming) was created
 to track this work, and the word "master" was declared as offensive.
 [A proposal](http://git.k8s.io/community/wg-naming/recommendations/001-master-control-plane.md)
 was formalized for replacing the word "master" with "control plane".


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:  [`wg-naming`](https://github.com/kubernetes/community/tree/master/archive/wg-naming) is now archived and its recommendation moved. That resulted in some broken links which this PR fixes for the future readers of this KEP.


<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint

<!-- other comments or additional information -->
- Other comments: My first contrib here.