### PR TITLE
Remove SIG Service Catalog

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -81,9 +81,6 @@ aliases:
   sig-security-leads:
     - IanColdwater
     - tabbysable
-  sig-service-catalog-leads:
-    - jberkhahn
-    - jhvhs
   sig-storage-leads:
     - jsafrane
     - msau42


### PR DESCRIPTION
SIG Service Catalog was retired, for more information see:
https://github.com/kubernetes/community/pull/6632
