### PR TITLE
KEP-2579: Pod Security GA plan

### DIFF
--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -735,15 +735,25 @@ We are targeting Beta in v1.23.
 
 #### GA
 
-<<[UNRESOLVED]>>
+Targeting GA in v1.25.
 
-We are targeting GA in v1.24 to allow for migration off PodSecurityPolicy before it is removed in
-v1.25.
+**Conformance:**
+- Enabling the admission controller with the "default-default" enforcing mode of privileged is
+  essentially a no-op without adding namespace labels, so it doesn't have any impact on
+  conformance.
+- E2E framework has been updated to explicitly label test namespaces with the appropriate
+  enforcement level, using the `NamespacePodSecurityEnforceLevel` framework value. For GA,
+  conformance tests should be updated to use the most restrictive level possible.
+- Pod Security Admission is *not* required for conformance.
 
-- Examples of real world usage and positive user feedback.
-- [Conformance test plan](#conformance)
+**User Experience Improvements:**
+- [Warn when labeling exempt namespaces](https://github.com/kubernetes/kubernetes/issues/109549)
+- [Dedupe overlapping forbidden messages](https://github.com/kubernetes/kubernetes/issues/106129)
+- [Aggregate identical warnings for multiple pods in a namespace](https://github.com/kubernetes/kubernetes/issues/103213)
+- [Add context to failure messages](https://github.com/kubernetes/kubernetes/pull/105314)
 
-<<[/UNRESOLVED]>>
+**API Changes:**
+- Add `pod-security.admission.config.k8s.io/v1` with no changes from the `v1beta1` API.
 
 ### Upgrade / Downgrade Strategy
 
@@ -910,6 +920,8 @@ previous answers based on experience in the field._
     There will be a hard cap on the number of pods analyzed, and a timeout for the review of those pods 
     that ensures evaluation does not exceed a percentage of the time allocated to the request.
     See [Namespace policy update warnings](#namespace-policy-update-warnings).
+    - Timeout: minimum of 1 second or (remaining request deadline / 2)
+    - Max pods to check: 3000 ([benchmarks](https://github.com/kubernetes/kubernetes/pull/104588) indicate that 3000 pods should evaluate in under 10ms)
 
 * **Will enabling / using this feature result in introducing new API types?**
   - No.
@@ -1046,13 +1058,10 @@ templated pod resources. This could be useful in CI/CD pipelines and tests.
 
 ### Conformance
 
-As this feature progresses towards GA, we should think more about how it interacts with conformance.
-
-- Enabling the admission controller with the "default-default" enforcing mode of privileged is
-  essentially a no-op without adding namespace labels, so it shouldn't have any impact on
-  conformance.
-- If we want a more restricted version to still be considered conformant, we might need to
-  explicitly label namespaces in the conformance tests with the privilege level the tests require.
+Clusters requiring baseline or restricted Pod Security levels should still be able to pass
+conformance. This might require
+[Conformance Profiles](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1618-conformance-profiles)
+to be feasible.
 
 ## Implementation History
 

--- a/keps/sig-auth/2579-psp-replacement/kep.yaml
+++ b/keps/sig-auth/2579-psp-replacement/kep.yaml
@@ -29,18 +29,18 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.25"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.23"
-  stable: TBD
+  stable: "v1.25"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -48,7 +48,7 @@ feature-gates:
   - name: PodSecurity
     components:
       - kube-apiserver (PodSecurity admission plugin)
-disable-supported: true
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:


### PR DESCRIPTION
- One-line PR description: Pod Security targeting GA in v1.25, update with GA plan.
- Issue link: https://github.com/kubernetes/enhancements/issues/2579
- Other comments: discussed in [2022-04-27 SIG-Auth](https://docs.google.com/document/d/1woLGRoONE3EBVx-wTb4pvp4CI7tmLZ6lS26VTbosLKM/edit#heading=h.iyfydppc7sz6)

/sig auth