### PR TITLE
PSA GA KEP compliance

### DIFF
--- a/keps/sig-auth/2579-psp-replacement/README.md
+++ b/keps/sig-auth/2579-psp-replacement/README.md
@@ -557,6 +557,10 @@ publish the following tools:
 
 ### Test Plan
 
+[X] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
 ##### Prerequisite testing updates
 
 None.


### PR DESCRIPTION
Adding in the checkbox from the new testing template.

I'm not a fan of cluttering KEPs with boilerplate like this. It makes them less readable as architectural artifacts. IMO if we need things like this it should either go in the tracking issue, or a separate file in the KEP directory.