### PR TITLE
Promote Portworx CSI migration to Beta in v1.25

### DIFF
--- a/keps/sig-storage/2589-csi-migration-portworx/README.md
+++ b/keps/sig-storage/2589-csi-migration-portworx/README.md
@@ -7,6 +7,12 @@
   - [New Feature Gates](#new-feature-gates)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
 - [Implementation History](#implementation-history)
+- [Design details](#design-details)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
 <!-- /toc -->
 
 
@@ -50,6 +56,33 @@ Major milestones for Portworx in-tree plugin CSI migration:
 
 - 1.23
   - Portworx CSI migration to Alpha
-- 1.24
+- 1.25
   - Portworx CSI migration to Beta, off by default
 
+## Design details
+
+### Test Plan
+
+ I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+No additional tests are needed, rather the issue is orchestrating CSI driver
+deployment for prow jobs. This has been complicated by the storage provider
+extraction work, which no longer permits storage provider specific orchestration
+in the k/k repository. This means that it is not possible to run any test for
+portworx-volume in k/k.
+
+##### Unit tests
+
+See tests in the [https://github.com/kubernetes/csi-translation-lib/blob/master/plugins/portworx_test.go](https://github.com/kubernetes/csi-translation-lib/blob/master/plugins/portworx_test.go)
+
+##### Integration tests
+
+N/A
+
+##### e2e tests
+
+To ensure the implementation correctness, I/we have manually run the e2e tests, [located in the main k8s repository](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/storage/drivers/in_tree.go). Test results are attached to the pull requests 

--- a/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
+++ b/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
@@ -27,12 +27,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.25"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.23"
-  beta: "v1.24"
+  beta: "v1.25"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->
This commit adds the details to the KEP for promoting Portworx CSI migration from alpha to beta in v1.25

One-line PR description: Update KEP for Portworx CSI Migration

Issue link: Portworx file in-tree to CSI driver migration #https://github.com/kubernetes/enhancements/issues/2589

Other comments:

/sig storage

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: