### PR TITLE
KEP-2599: Promote STS minReadySeconds to GA

### DIFF
--- a/keps/prod-readiness/sig-apps/2599.yaml
+++ b/keps/prod-readiness/sig-apps/2599.yaml
@@ -2,4 +2,6 @@ kep-number: 2599
 alpha:
   approver: "@ehashman"
 beta:
-  approver: "@ehashman"  
+  approver: "@ehashman"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/2599-minreadyseconds-for-statefulsets/kep.yaml
+++ b/keps/sig-apps/2599-minreadyseconds-for-statefulsets/kep.yaml
@@ -7,24 +7,26 @@ participating-sigs:
   - "sig-apps"
 status: implementable
 creation-date: 2021-04-07
-last-updated: 2021-04-12
+last-updated: 2022-06-08
 reviewers:
   - "@soltysh"
 approvers:
   - "@soltysh"
 prr-approvers:
   - "@ehashman"
+  - "@deads2k"
+  - "@wojtek-t"
 see-also:
   - https://github.com/kubernetes/kubernetes/issues/65098
 
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.25"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -43,4 +45,5 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-#  - my_feature_metric
+  - kube_statefulset_status_replicas_available
+


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Promote STS minReadySeconds to GA
<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/2599
<!-- other comments or additional information -->
- Other comments: