### PR TITLE
Change milestone for volume mount group to 1.25

### DIFF
--- a/keps/sig-storage/2317-fsgroup-on-mount/kep.yaml
+++ b/keps/sig-storage/2317-fsgroup-on-mount/kep.yaml
@@ -23,12 +23,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.25"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.23"
+  stable: "v1.25"
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:


### PR DESCRIPTION
Issue link - https://github.com/kubernetes/enhancements/issues/2317

/sig storage
