### PR TITLE
KEP-596: Move GA milestone to 1.25, update PRR

### DIFF
--- a/keps/sig-storage/596-csi-inline-volumes/kep.yaml
+++ b/keps/sig-storage/596-csi-inline-volumes/kep.yaml
@@ -18,12 +18,12 @@ approvers:
   - "@saad-ali"
 
 stage: "stable"
-latest-milestone: "v1.24"
+latest-milestone: "v1.25"
 
 milestone:
   alpha: "v1.15"
   beta: "v1.16"
-  stable: "v1.24"
+  stable: "v1.25"
 
 feature-gates:
   - name: CSIInlineVolume


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
KEP-596: Move GA milestone to 1.25, update PRR

<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/596

<!-- other comments or additional information -->
- Other comments:

/cc @jsafrane @gnufied @xing-yang @wojtek-t 