### PR TITLE
api: correct JSON field name for Proposal.Number

### DIFF
--- a/api/approval.go
+++ b/api/approval.go
@@ -34,7 +34,7 @@ func (p *PRRApprovals) AddPRRApproval(prrApproval *PRRApproval) {
 }
 
 type PRRApproval struct {
-	Number string `json:"kep-number" yaml:"kep-number" validate:"required"`
+	Number string `json:"kepNumber" yaml:"kep-number" validate:"required"`
 
 	// TODO: Need to validate these milestone pointers are not nil
 	Alpha  *PRRMilestone `json:"alpha" yaml:"alpha,omitempty"`

--- a/api/proposal.go
+++ b/api/proposal.go
@@ -97,7 +97,7 @@ type Proposal struct {
 	Name     string `json:"name,omitempty"`
 
 	Title             string   `json:"title" yaml:"title" validate:"required"`
-	Number            string   `json:"kep-number" yaml:"kep-number" validate:"required"`
+	Number            string   `json:"kepNumber" yaml:"kep-number" validate:"required"`
 	Authors           []string `json:"authors" yaml:",flow" validate:"required"`
 	OwningSIG         string   `json:"owningSig" yaml:"owning-sig" validate:"required"`
 	ParticipatingSIGs []string `json:"participatingSigs" yaml:"participating-sigs,flow,omitempty"`


### PR DESCRIPTION
- One-line PR description: api: correct JSON field name for Proposal.Number

- Issue link: None

- Other comments: JSON usually has camelCase field names. Fixing that for `Number` field of `Proposal` struct.