### PR TITLE
KEP 3178: mark implementable, update Test Plan for alpha

### DIFF
--- a/keps/sig-network/3178-iptables-cleanup/kep.yaml
+++ b/keps/sig-network/3178-iptables-cleanup/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-network
 participating-sigs:
   - sig-node
-status: provisional
+status: implementable
 creation-date: 2022-01-23
 reviewers:
   - "@thockin"


### PR DESCRIPTION
- One-line PR description: updates for alpha: mark "implementable", update Test Plan from latest template
- Issue link: https://github.com/kubernetes/enhancements/issues/3178

