### PR TITLE
use new format for the unit test coverage part

### DIFF
--- a/keps/sig-storage/2923-csi-migration-ceph-rbd/README.md
+++ b/keps/sig-storage/2923-csi-migration-ceph-rbd/README.md
@@ -57,7 +57,7 @@ RBD in k/k repository.
 
 ##### Unit tests
 
-The unit tests for RBD translation lib available [here](https://github.com/kubernetes/csi-translation-lib/blob/master/plugins/rbd_test.go)
+- `k8s.io/csi-translation-lib/blob/master/plugins/rbd_test.go`: `2022-06-27` - `69.7`
 will be validated.
 
 ##### Integration tests

--- a/keps/sig-storage/2924-csi-migration-cephfs/README.md
+++ b/keps/sig-storage/2924-csi-migration-cephfs/README.md
@@ -57,8 +57,7 @@ cephfs in k/k repository.
 
 ##### Unit tests
 
-The unit tests for CephFS translation lib will be added [here](https://github.com/kubernetes/csi-translation-lib/blob/master/plugins/rbd_test.go)
-and validated.
++- `k8s.io/csi-translation-lib/blob/master/plugins/cephfs_test.go`: `2022-06-27` - `69.7`
 
 ##### Integration tests
 


### PR DESCRIPTION
For RBD and CephFS  the UNIT test part, the new format has been used.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

