### PR TITLE
KEP-2149: Update goals section re: cluster-level DNS

### DIFF
--- a/keps/sig-multicluster/2149-clusterid/README.md
+++ b/keps/sig-multicluster/2149-clusterid/README.md
@@ -225,7 +225,7 @@ know that this has succeeded?
 managed as Kubernetes resources
 * Define the standard to be strict enough to be useful in the following user stories:
   * Establish reliable coordinates for determining clusterset membership and identity of a cluster within its cluster set
-  * Enable cluster-granularity DNS names for multicluster services
+  * Enable disambiguation of DNS names for multicluster Headless services with the same hostnames
   * Facilitate enrichment of log / event / metrics data with cluster id / set coordinates
 
 ### Non-Goals


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Goal section predated final decisions to not allow this in general; see also [README.md#not-allowing-cluster-specific-targeting-via-dns](https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#not-allowing-cluster-specific-targeting-via-dns)

<!-- link to the k/enhancements issue -->
- Issue link: #2149 

<!-- other comments or additional information -->
- Other comments: cc and thank you @runakash for the catch :)