### PR TITLE
KEP-1731 : Publishing Kubernetes packages on community infrastructure

### DIFF
--- a/keps/sig-release/1731-publishing-packages/README.md
+++ b/keps/sig-release/1731-publishing-packages/README.md
@@ -1,6 +1,7 @@
 # Publishing kubernetes packages
 
 <!-- toc -->
+
 - [Release Signoff Checklist](#release-signoff-checklist)
 - [Summary](#summary)
 - [Motivation](#motivation)
@@ -8,6 +9,7 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
+    - [User Roles](#user-roles)
   - [Implementation Details/Notes/Constraints](#implementation-detailsnotesconstraints)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -16,7 +18,6 @@
     - [Alpha](#alpha)
     - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
     - [Beta -&gt; GA Graduation](#beta---ga-graduation)
-    - [Removing deprecated publishing artifacts](#removing-deprecated-publishing-artifacts)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Implementation History](#implementation-history)
@@ -36,26 +37,25 @@
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
-
 ## Summary
 
-This document describes how deb & rpm packages get published as part of cutting a release, with the tooling the release and patch management teams have at hand ([anago], [gcbmgr] and others from [k/release], [k/k/build] and potentially other places).
+This document describes how deb and rpm packages get published in the same way as the currently [documented package mirror] as part of cutting a release, with the tooling the release management team has at hand ([krel] and others from [k/release], [k/k/build] and potentially other places).
 
-[anago]: https://github.com/kubernetes/release/tree/master/anago
+[documented package mirror]: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
 [gcbmgr]: https://github.com/kubernetes/release/tree/master/gdcbmgr
 [k/release]: https://github.com/kubernetes/release
 [k/k/build]: https://github.com/kubernetes/kubernetes/tree/master/build
 
 ## Motivation
 
-Currently ...
+Currently:
+
 - Only Googlers can publish packages.
-- Package spec file updates are not committed to a public repository.
 - The packages get published on Google infrastructure.
-- After publishing a new release but before sending out the release
-  notification emails the process needs to be paused. Googlers need to build
-  and publish the deb and rpm packages before the branch management team can
-  continue and send notification can be sent out.
+- After publishing a new release but before sending out the release notification
+  emails the process needs to be paused. Googlers need to build and publish the
+  deb and rpm packages before the branch manager can continue and send the
+  release announcement.
 - We can only publish packages for stable releases right now.
 - We use different packages in CI then we officially release.
 
@@ -63,64 +63,80 @@ This all prolongs the release process, it is a hard dependency on a small group 
 
 ### Goals
 
-The whole process should be folded into the release tooling, it should be part of the release process, and should not involve anyone other than the release branch / patch release team.
+The whole process should be folded into the release tooling, it should be part of the release process, and should not involve anyone other than the release managers.
 For each release the release team cuts, packages should also be generated and published automatically.
 
 There should be multiple channels users can subscribe to: **stable**, **dev**, and **nightly**.
 
-
 ### Non-Goals
 
-The actual package generation is a different problem that is discussed in [this KEP][pkg-gen-kep].
+The original version of this KEP had the following statement:
+
+> The actual package generation is a different problem that is discussed in [this KEP][pkg-gen-kep].
+
+Based on a review of this KEP, Kubernetes contributor @saschagrunert wants SIG
+Release to own the process of automatically building and publishing the packages
+and this will implicitly achieve the main goal of
+[#2503](https://github.com/kubernetes/enhancements/issues/2503).
 
 [pkg-gen-kep]: https://github.com/kubernetes/enhancements/pull/858
 
 ## Proposal
 
 - Make the infrastructure generic and simple enough to be easily handed off to the CNCF
-    - Storage buckets (to store the staged/released packages)
-    - DNS entries (e.g. apt.kubernetes.io, ...)
-    - package mirror (e.g. a self hosted aptly/artifactory/... or as a service)
-        - have multiple channels, e.g. `stable`, `dev`, `nightly`
-- Run the [package building][pkg-gen-kep] as part of the staging process
-    - on GCB / not on an individual's machine
+  - Storage buckets (to store the staged/released packages) or anything similar
+  - DNS entries (e.g. apt.kubernetes.io, ...)
+  - package mirror (e.g. a self hosted aptly/artifactory/... or as a service)
+    - have multiple channels, e.g. `stable`, `dev`, `nightly`
+- Run the package builds as part of [krel stage and release]
 - Have a safe way to store the signing key and make it available to the release team and release tooling
 - Automatically sign the repository and packages
 - Automatically build and publish packages on a nightly basis
 
+[krel stage and release]: https://github.com/kubernetes/release/blob/master/docs/krel/README.md#usage
 
 ### User Stories
 
-*Note*: The following user stories are using the keywords of the [gherkin language][gherkin].
+_Note_: The following user stories are using the keywords of the [gherkin language][gherkin].
 
-[gherkin]: https://docs.cucumber.io/gherkin/reference/
+[gherkin]: https://cucumber.io/docs/gherkin/reference/
 
+#### User Roles
+
+[Release Managers] are SIG Release Team Members that are
+
+> ... Kubernetes contributors responsible for maintaining release branches and creating releases by using the tools SIG Release provides.
+
+[release managers]: https://kubernetes.io/releases/release-managers
+
+An [End User] is used in the CNCF sense to refer to consumers of the Kubernetes artifacts built and published by [Release Managers]
+
+[end user]: https://www.cncf.io/enduser/
 
 ```
-Scenario: Enduser installs a kubelet from the stable channel
-  Given a user has configured the officially documented package mirror for stable releases for a specific kubernetes minor version ("the minor") on their machine
-   When they use the system's package manager to query the list of kubelet packages available (e.g. apt-cache policy kubelet)
-   Then they see a list of all stable patch versions of the kubelet that stem from the minor and a preference to install the latest patch version of the kubelet
-    But don't see any alpha, beta, rc or nightly releases of the kubelet from this specific kubernetes minor version
-    And they don't see any packages of any other kubernetes minor release
+Scenario: End User lists the available packages from the stable channel
+  Given an End User has configured the officially documented package mirror for stable releases on their machine
+  When they use their system's package manager to query the list of kubelet packages available (e.g. apt-cache policy kubelet)
+  Then they see a list of all stable patch versions of the kubelet and a preference to install the latest available patch version
+  But they do not see any alpha, beta, release candidate or nightly releases of the kubelet package from this specific kubernetes minor version
+  And they do not see any packages of any other kubernetes minor releases
 ```
 
 ```
 Scenario: Release tools automatically publish new packages
-  Given a release team member ran `./gcbmgr stage master --build-at-head --nomock`
-    And a release team member ran `./gcbmgr release master --buildversion=${{VERSIONID}} --nomock`
-   When a user inspects the officially documented deb and rpm kubernetes repositories for this specific kubernetes minor version
-   Then they see the newly cut alpha releases published in the alpha channel only
+  Given a Release Manager ran `./krel stage --nomock` and `./krel release --nomock` to create a new  release (alpha, beta, rc or final).
+  When an End User inspects the officially documented deb and rpm kubernetes repositories for this specific kubernetes minor version
+  Then they see the newly cut releases published in the appropriate channel only
 ```
 
 ```
-Scenario: End users can get the public key the packages or the repository metadata is signed with
-  Given a user has a system configured with not allowing unsigned untrusted package repositories
-    And they have setup the officially documented repository for a specific kubernetes minor release
-   When they download the public key from the location stated in the official documentation
-    And they configure their system's package manager to use that key
-    And they use their system's package manager to install a package from this specific kubernetes minor release
-   Then their package manager will not complain about untrusted packages, sources or repositories
+Scenario: End users can retrieve the public key that signed the packages, or the repository metadata is signed with
+  Given an End User configured their system to disallow the use of unsigned, untrusted package repositories
+  And they have setup the officially documented repository for a specific kubernetes minor release
+  When they download the public key from the location stated in the official documentation
+  And they configure their system's package manager to use that key
+  And they use their system's package manager to install a package from this specific kubernetes minor release
+  Then their package manager does not complain about untrusted packages, sources or repositories
 ```
 
 <!--
@@ -135,46 +151,47 @@ Scenario: [...]
 
 ### Implementation Details/Notes/Constraints
 
-Packages will be published for different ...
-- **`${dist}`**: a combination of `<distribution>-<code-name-or-version>`
-  (e.g. `debian-jessie`, `ubuntu-xenial`, `fedora-23`, `centos-7`, ...)
+Packages will be published for different:
+
+- Package managers, like `apt` (consumes deb packages) and `yum` (consumes rpm packages).
 - **`${k8s_release}`**: the version of kubernetes `<major>.<minor>`
   (e.g. `1.12`, `1.13`, `1.14`, ...)
 - **`${channel}`**: can be `stable`, `dev`, `nightly`
-    - `stable`: all official releases for `${k8s_release}`
-      (e.g.: `1.13.0`, `1.13.1`, `1.13.2`, ...)
-    - `dev`: all development releases for all minor releases in this `${k8s_release}`, including `alpha`s, `beta`s and `rc`s
-      (e.g.: `1.13.0-rc.2`, `1.13.2-beta.0`, `1.13.1-alpha.3`, ...)
-    - `nightly`: any package cut automatically on a daily basis
+  - `stable`: all official releases for `${k8s_release}`
+    (e.g.: `1.13.0`, `1.13.1`, `1.13.2`, ...)
+  - `dev`: all development releases for all minor releases in this `${k8s_release}`, including `alpha`s, `beta`s and `rc`s
+    (e.g.: `1.13.0-rc.2`, `1.13.2-beta.0`, `1.13.1-alpha.3`, ...)
+  - `nightly`: any package cut automatically on a daily basis (optionally)
 
-
-This means, that end-users can configure their systems’ package managers to use those different `${channel}`s of a kubernetes `${k8s_release}` for their `${dist}`.
+This means, that End Users can configure their systems’ package managers to use
+those different `${channel}`s of a kubernetes `${k8s_release}` for their
+corresponding package manager.
 
 A configuration for the package managers might look something like:
 
 - deb:
-    ```
-    # deb http://apt.kubernetes.io/${dist} ${k8s_release} ${channel}
-    deb http://apt.kubernetes.io/debian-jessie 1.13 nightly
-    ```
+  ```
+  # deb http://apt.kubernetes.io ${k8s_release} ${channel}
+  deb [signed-by=/etc/keyrings/kubernetes-keyring.gpg] http://apt.kubernetes.io/debian 1.26 nightly
+  ```
 - rpm/yum:
-    ```
-    [kubernetes]
-    name=Kubernetes
-    # baseurl=http://yum.kubernetes.io/${dist}/${k8s_release}/${channel}
-    baseurl=http://yum.kubernetes.io/fedora-27/1.13/nightly
-    enabled=1
-    gpgcheck=1
-    repo_gpgcheck=1
-    gpgkey=file:///etc/pki/rpm-gpg/kubernetes.gpg.pub
-    ```
+  ```
+  [kubernetes]
+  name=Kubernetes
+  # baseurl=http://yum.kubernetes.io/${k8s_release}/${channel}
+  baseurl=http://yum.kubernetes.io/fedora/1.26/nightly
+  enabled=1
+  gpgcheck=1
+  repo_gpgcheck=1
+  gpgkey=file:///etc/pki/rpm-gpg/kubernetes.gpg.pub
+  ```
 
 Different architectures will be published into the same repos, it is up to the package managers to pull and install the correct package for the target platform.
 
+Ideally and optionally, publishing/promoting a package means to commit a change
+to a configuration file which triggers a "package promotion tool", which:
 
-Ideally, publishing/promoting a package means to commit a change to a configuration file which triggers a "package promotion tool".
-That tool ...
-- manages which packages need to go into which `${channel}` for which `${dist}` of which `${k8s_release}`
+- manages which packages need to go into which `${channel}` for which package manager of which `${k8s_release}`
 - guard that by the packages checksum
 - is able to promote a package from a bucket and also from a `${channel}` to the other
 - work off of a declarative configuration
@@ -183,11 +200,12 @@ This tool does for packages what the [Image Promoter][img-promoter] tool does
 for container images. Therefore, ideally, we can implement this work-flow as part
 of the [Image Promoter][img-promoter] or at least use its libraries.
 
-
-As soon as the [redirector] is in place the repositories should be mirrored and the [redirector] should be used.
-
-[redirector]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190121-artifact-management.md#http-redirector-design
 [img-promoter]: https://github.com/kubernetes/enhancements/blob/7a2e7c25ee3f2a50f2218557801fbd8dd79fd0f2/keps/sig-release/k8s-image-promoter.md
+
+We can achieve the same directly in `krel release`, means that the dedicated
+promotion is an optional part of this KEP. As an intermediate solution we can
+also leave the package publishing on the Google side and focus on building them
+before graduating the KEP to GA.
 
 All architectures that are supported by the [package building tool][pkg-gen-kep] should be published.
 This KEP suggests to start with publishing a single supported architecture
@@ -199,59 +217,72 @@ process (see also: [Risks](#risks-and-mitigations)).
 
 ### Risks and Mitigations
 
-- *Risk*: We don't find a proper way to share secrets like the signing key  
-  *Mitigation*: TBA
-- *Risk*: Building all the packages for all the distributions and their version takes too long to be done nightly or via cutting the release  
-  *Mitigation*: TBA
+- _Risk_: We don't find a proper way to share secrets like the signing key
+  _Mitigation_: Using a third party tool like 1Password
+- _Risk_: Building all the packages for all the distributions and their version takes too long to be done nightly or via cutting the release  
+  _Mitigation_: We do not deliver nightly packages.
 
 ## Design Details
 
 ### Test Plan
 
-There should be a post-publish tests, which can be run as part or after the release process
-- pull packages from the  official mirrors (via the [redirector] if in place)
+There should be post-publish tests, which can be run as part or after the release process
+
+- pull packages from the official mirrors
 - assert that all the packages we expect to be published are actually published
+- assert that all published packages have the expected checksums
 - assert that the packages and the repo metadata is signed with the current signing key
+- assert that installed packages contain the correct binary versions
 
 ### Graduation Criteria
 
-In general we can keep the current way of publishing (via googlers onto google's infrastructure) and introduce new infrastructure in parallel.
+In general we can keep the current way of publishing (via googlers onto Google's
+infrastructure) and introduce new infrastructure in parallel. For example, it is
+still possible to optimize the current package building process by splitting up
+the rapture script into a build script and sign/publish one. This would allow us
+to intermediately automate the build step to publish artifacts on the release
+GCS bucket. The sign/publish script would then be able to utilize those
+artifacts and publish them into the current destination manually.
 
 Once the tests show that the mirrors are good, we can adapt the official documentation. This includes:
+
 - for release team members:
   - How and where do the packages get published as part of the release process
-  - How can the post-publish test be run
+  - How can the post-publish tests be run
 - for kubernetes contributors:
-  - How and where do the nightlies get published
+  - How and where do the nightly builds get published
 - for kubernetes users:
-  - Which repository are available for users
+
+  - Which repositories are available for users
   - How to configure their package managers
 
-
-
+- There is a documented process to create and publish deb and rpm packages of Kubernetes components
+- It is possible to consume the published deb and rpm packages using steps that document the process
 
 #### Alpha
 
-- Needed infrastructure is in place (buckets, dns, repos, …)
+- Needed infrastructure is in place (buckets, DNS, repos, …)
+- There is a documented process to create and publish deb and rpm packages of Kubernetes components
+- It is possible to consume the published deb and rpm packages using steps similar to the documented process
 
 #### Alpha -> Beta Graduation
 
+- [ ] [krel] creates deb and rpm packages of Kubernetes components
+- [ ] Packages are signed
+- [ ] Repository indices are updated after packages are copied to the repositories
+- [ ] Post-publish tests are written and run as part of the release process
+- [ ] Nightly builds will be built and published on a daily basis using [krel] which will be improved to take over this task from [kubepkg] making use of [pre-existing periodic jobs] (https://github.com/kubernetes/test-infra/blob/97cb34fa9e2bfc4af35de3e561cb9fc5a1094da1/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml#L120-L166)
+- [ ] Documentation written checked to be complete and correct.
+- [ ] Outline deprecation policy and communication plan
 
-- [anago] [creates packages][pkg-gen-kep] and published those packages as part of the release process
-- post-publish tests are in places and run as part of the release process
-- nightlies will be build and published on a daily basis
-- documentation is in place
+[kubepkg]: https://github.com/kubernetes/release/tree/master/cmd/kubepkg
+[krel]: https://github.com/kubernetes/release/blob/master/docs/krel/README.md
 
 #### Beta -> GA Graduation
 
+This new publishing infrastructure and mechanisms can be considered GA when no Googler is needed anymore to publish the packages.
 
-This new publishing infrastructure and mechanisms can be considered GA when no googler is needed anymore to publish the packages.
-
-#### Removing deprecated publishing artifacts
-
-When 2 releases have been cut and published with the new mechanism any of the older tools and processes (e.g. `k/release/{deb,rpm}`) can be removed.
-
-N/A
+- Removing remaining documentation for old Google hosted packages
 
 ### Upgrade / Downgrade Strategy
 
@@ -260,7 +291,6 @@ N/A
 ### Version Skew Strategy
 
 N/A
-
 
 ## Implementation History
 
@@ -285,4 +315,6 @@ N/A
 
 ## Infrastructure Needed
 
-TBA
+New infrastructure is required to manage keys used to sign the deb and rpm
+artifacts so as to remove the dependency on existing infrastructure and
+personal.

--- a/keps/sig-release/1731-publishing-packages/kep.yaml
+++ b/keps/sig-release/1731-publishing-packages/kep.yaml
@@ -2,6 +2,8 @@ title: Publishing kubernetes packages
 kep-number: 1731
 authors:
   - "@hoegaarden"
+  - "@RobertKielty"
+  - "@saschagrunert"
 owning-sig: sig-release
 participating-sigs:
   - sig-cluster-lifecycle
@@ -17,7 +19,7 @@ approvers:
   - "@tpepper"
 editor: TBD
 creation-date: 2019-02-19
-last-updated: 2019-02-27
+last-updated: 2022-10-12
 status: provisional
 see-also:
   - "https://github.com/kubernetes/enhancements/pull/858"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Updates the KEP-1731 to reflect current SIG Release Processes
- Issue link: #1731 
<!-- other comments or additional information -->
Other comments: 
- Defines the Release Manager and End User roles
- Removes references to anago (name of a bash script formerly used in this space) anago functionality has been re-implemented as a go module and subsumed into the krel command. 
- Added proper noun capitalization for defined roles 

Adds or fixes refs for
- the "officially documented package mirror"
- a Gherkin reference for the user stories
- kubepkg

This is an initial attempt to revive this KEP by bringing it into line with all of the tooling improvements that have been made by the SIG Release Team since this KEP was first written.

It will we will need careful review of experienced SIG Release Team members

Specifically, I would ask the following of reviewers:
1. Let's review and re-validate all Motivations for this work are they still correct and accurate?  
2. Let's review and ensure that the User Stories are correct based on current Release Manager processes
3. Do the User Stories completely cover and describe all requirements?