### PR TITLE
Update KEP-3329 "Retriable and non-retriable Pod failures for Jobs"

### DIFF
--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
@@ -1090,6 +1090,8 @@ Below are some examples to consider, in addition to the aforementioned [maturity
   (see: [Failing delete when after a condition is added](#failing-delete-after-a-condition-is-added))
 - Re-evaluate the decision about marking pods as failed to prevent pods getting
   stuck in the running phase (see: [Marking pods as Failed](marking-pods-as-failed))
+- Review and implement if feasible adding of pod conditions with the use of
+  [SSA](https://kubernetes.io/docs/reference/using-api/server-side-apply/) client.
 - The feature flag enabled by default
 
 #### GA

--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
@@ -765,6 +765,11 @@ const (
 	// This is an action which might be taken on a pod failure - the counter towards
 	// .backoffLimit is not incremented and a replacement pod is created.
 	PodFailurePolicyActionIgnore PodFailurePolicyAction = "Ignore"
+
+	// This is an action which might be taken on a pod failure - the pod failure
+	// is handled in the default way - the counter towards .backoffLimit is
+	// incremented.
+	PodFailurePolicyActionCount PodFailurePolicyAction = "Count"
 )
 
 type PodFailurePolicyOnExitCodesOperator string
@@ -830,6 +835,8 @@ type PodFailurePolicyRule struct {
 	//   running pods are terminated.
 	// - Ignore: indicates that the counter towards the .backoffLimit is not
 	//   incremented and a replacement pod is created.
+	// - Count: indicates that the pod is handled in the default way - the
+	//   counter towards the .backoffLimit is incremented.
 	Action PodFailurePolicyAction
 
 	// Represents the requirement on the container exit codes.
@@ -1340,7 +1347,7 @@ due to different reasons. For example, if jobs are terminated often due to
 with new rules to terminate jobs early more often
   - `job_pod_failure_total` (new): tracks the handling of failed pods. It will
 have the `action` label indicating how a pod failure was handled. Possible
-values are:`JobTerminated`, `Ignored` and `Default`. This metric can be used to
+values are:`JobTerminated`, `Ignored` and `Counted`. This metric can be used to
 assess the coverage of pod failure scenarios with `spec.podFailurePolicy` rules.
 
 <!--

--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
@@ -402,7 +402,7 @@ spec:
     - action: Ignore
       onPodConditions:
         operator: In
-        values: [ TargetedForDisruption ]
+        values: [ DisruptionTarget ]
 ```
 
 Note that, in this case the user supplies a list of Pod condition type values.
@@ -699,7 +699,7 @@ condition type will require an API review. The constants will allow users of the
 package to reduce the risk of typing mistakes.
 
 Additionally, for Beta, we will re-evaluate an idea of a generic opinionated condition
-type indicating that a pod can be retried, for example `TargetedForDisruption`.
+type indicating that a pod can be retried, for example `DisruptionTarget`.
 
 Finally, we are going to cover the handling of pod failures associated with the
 new PodCondition types in integration tests.
@@ -725,7 +725,7 @@ reason.
 
 ### New PodConditions
 
-A new condition type, called `TargetedForDisruption`, is introduced to indicate
+A new condition type, called `DisruptionTarget`, is introduced to indicate
 a pod failure caused by a disruption. In order to account for different
 reasons for pod termination we add the following reason types based on the
 invocation context (we focus on covering these scenarios were the new
@@ -901,7 +901,7 @@ spec:
     - action: Ignore
       onPodConditions:
         operator: In
-        values: [ TargetedForDisruption ]
+        values: [ DisruptionTarget ]
 ```
 
 ### Evaluation

--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/kep.yaml
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/kep.yaml
@@ -39,6 +39,7 @@ feature-gates:
       - kube-scheduler
   - name: JobPodFailurePolicy
     components:
+      - kube-apiserver
       - kube-controller-manager
 disable-supported: true
 

--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/kep.yaml
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/kep.yaml
@@ -32,11 +32,14 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: JobBackoffPolicy
+  - name: PodDisruptionConditions
     components:
       - kube-apiserver
       - kube-controller-manager
       - kube-scheduler
+  - name: JobPodFailurePolicy
+    components:
+      - kube-controller-manager
 disable-supported: true
 
 # The following PRR answers are required at beta release


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
One-line PR description:  Updates the KEP to the implemented state

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3329

<!-- other comments or additional information -->
- Other comments: main changes motivated by implementation in PRs https://github.com/kubernetes/kubernetes/pull/110959 and https://github.com/kubernetes/kubernetes/pull/111113:
  - update the set of introduced pod conditions and reasons
  - added a note on handling a failed delete after successful patch to append the pod condition
  - added a note on setting pod's phase as Failed by podgc and simplifying the related logic in job controller for Beta
  - renamed the feature gate `JobBackoffPolicy` as `JobPodFailurePolicy`
  - introduced a new feature gate `PodDisruptionConditions` for control appending of pod disruption conditions
  - renamed the job spec field `backoffPolicy` as `podFailurePolicy`
  - added a graduation criteria for Beta to attempt implementation of pod conditions using SSA
  - introduced a new pod failure policy action, called `Count`, to force the default behavior for handling a failed pod