### PR TITLE
Remove SelectorSpread plugin when graduating scheduler Component Config

### DIFF
--- a/keps/sig-scheduling/785-scheduler-component-config-api/README.md
+++ b/keps/sig-scheduling/785-scheduler-component-config-api/README.md
@@ -117,6 +117,7 @@ More information on the discussion can be found [here](https://github.com/kubern
 
 The fourth iteration, `kubescheduler.config.k8s.io/v1`, includes the following changes:
   - Mark `v1beta2` as deprecated
+  - Remove Plugin `SelectorSpread` (in favor of `PodTopologySpread`)
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Mark SelectorSpread plugin as deprecated when graduating scheduler Component Config

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/785

<!-- other comments or additional information -->
- Other comments: