### PR TITLE
KEP-3178: rename feature gate to IPTablesOwnershipCleanup

### DIFF
--- a/keps/sig-network/3178-iptables-cleanup/README.md
+++ b/keps/sig-network/3178-iptables-cleanup/README.md
@@ -352,7 +352,7 @@ because it is more of a cleanup/bugfix than a new feature.) We should
 also ensure that kpng gets updated.
 
 Kubelet's behavior will not change by default, but if you enable the
-`IPTablesCleanup` feature gate, then:
+`IPTablesOwnershipCleanup` feature gate, then:
 
   1. It will stop creating `KUBE-MARK-DROP`, `KUBE-MARK-MASQ`,
      `KUBE-POSTROUTING`, and `KUBE-KUBELET-CANARY`. (`KUBE-FIREWALL`
@@ -518,7 +518,7 @@ This section must be completed when targeting alpha to a release.
 ###### How can this feature be enabled / disabled in a live cluster?
 
 - [X] Feature gate (also fill in valuesin `kep.yaml`)
-  - Feature gate name: IPTablesCleanup
+  - Feature gate name: IPTablesOwnershipCleanup
   - Components depending on the feature gate:
     - kubelet
 
@@ -684,6 +684,7 @@ Major milestones might include:
 
 - Initial proposal: 2022-01-23
 - Updated: 2022-03-27, 2022-04-29
+- Updated: 2022-07-26 (feature gate rename)
 
 ## Drawbacks
 

--- a/keps/sig-network/3178-iptables-cleanup/kep.yaml
+++ b/keps/sig-network/3178-iptables-cleanup/kep.yaml
@@ -32,7 +32,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: IPTablesCleanup
+  - name: IPTablesOwnershipCleanup
     components:
       - kubelet
 disable-supported: true


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: renames feature gate from `IPTablesCleanup` to `IPTablesOwnershipCleanup` based on feedback from @thockin in https://github.com/kubernetes/kubernetes/pull/110291

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3178

<!-- other comments or additional information -->
- Other comments: