### PR TITLE
KEP-3031: Update signing KEP to match new scope

### DIFF
--- a/keps/sig-release/3031-signing-release-artifacts/README.md
+++ b/keps/sig-release/3031-signing-release-artifacts/README.md
@@ -118,6 +118,14 @@ tarballs, documentation and the SBOM.
 This explicitly exudes the provenance data, which will be signed into a
 different location once we graduate the feature to GA.
 
+Part of this graduation is that we integrate the file signing into our existing
+release pipeline. This incorporates an architectural change, because we will now
+sign images as well as files in a dedicated step. We call this step `krel sign`,
+and it will run between `krel stage` and `krel release`. The purpose of
+`krel sign` will be to read the staged files and images, sign them and push the
+signatures into their desired locations for the following promotion as well as
+`krel release` steps.
+
 ### User Stories (Optional)
 
 - As an end user, I would like to be able to verify the Kubernetes release

--- a/keps/sig-release/3031-signing-release-artifacts/kep.yaml
+++ b/keps/sig-release/3031-signing-release-artifacts/kep.yaml
@@ -18,6 +18,6 @@ stage: beta
 latest-milestone: "v1.25"
 milestone:
   alpha: "v1.24"
-  beta: "v1.25"
+  beta: "v1.26"
   # stable: "v1.22"
 disable-supported: true


### PR DESCRIPTION
This changes the KEP to match the new scope as well as targeting the implementation for v1.26.

cc @kubernetes/release-engineering 