### PR TITLE
KEP 1489: Mark CSI migration for Cinder as done

### DIFF
--- a/keps/sig-storage/1489-csi-migration-cinder/kep.yaml
+++ b/keps/sig-storage/1489-csi-migration-cinder/kep.yaml
@@ -12,9 +12,9 @@ approvers:
   - "@msau42"
 editor: "@Jiawei0227"
 creation-date: 2022-01-11
-last-updated: 2022-01-11
+last-updated: 2022-08-11
 disable-supported: true
-status: implementable
+status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
 prr-approvers:


### PR DESCRIPTION
CSI migration for OpenStack Cinder was GA in 1.24, mark the KEP as `implemented`.

And close the enhancement issue:
Fixes: #1489

cc @xing-yang @msau42 