### PR TITLE
KEP-1645: fix multi-cluster-service-api doc decription

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -669,7 +669,7 @@ endpoints:
      topology.kubernetes.io/zone: us-west2-a
 ```
 
-The `ServiceImport.Spec.IP` (VIP) can be used to access this service from within
+The `ServiceImport.Spec.IP` (VIP) can be used to access this service from outside
 this cluster.
 
 ### ClusterSet Service Behavior Expectations


### PR DESCRIPTION
Signed-off-by: lmxia <xialingming@gmail.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

KEP-1645: fix serviceimport Spec.IPs doc description.
<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments:
Serviceimport.Spec.IPs is used to access this service from outside this cluster(not within).