### PR TITLE
for now, comment out references to go-mod-outdated to get tests running

### DIFF
--- a/compile-tools
+++ b/compile-tools
@@ -48,18 +48,19 @@ compile() {
   echo "${tool} compiled & installed"
 }
 
-check_deps() {
-  echo "Checking dependencies..."
 
-  compile github.com/psampaz/go-mod-outdated
+# check_deps() {
+#   # echo "Checking dependencies..."
 
-  local gmo_args=( '-update' '-direct' )
-  if [ -n "${FAIL_ON_OUTDATED:-}" ]; then
-    gmo_args+=( '-ci' )
-  fi
+#   # compile github.com/psampaz/go-mod-outdated
 
-  go list -u -m -json all | go-mod-outdated "${gmo_args[@]}"
-}
+#   # local gmo_args=( '-update' '-direct' )
+#   # if [ -n "${FAIL_ON_OUTDATED:-}" ]; then
+#   #   gmo_args+=( '-ci' )
+#   # fi
+
+#   # go list -u -m -json all | go-mod-outdated "${gmo_args[@]}"
+# }
 
 compile_with_flags() {
   local git_tree_state
@@ -88,7 +89,7 @@ main() {
   cd "$(dirname "${BASH_SOURCE[0]}")"
 
   setup_env
-  check_deps
+  # check_deps
 
   if [ $# = 0 ]; then
     # default to all tools

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pkg/errors v0.9.1
-	github.com/psampaz/go-mod-outdated v0.7.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1086,7 +1086,6 @@ github.com/prometheus/procfs v0.0.10/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+G
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/psampaz/go-mod-outdated v0.7.0 h1:w5H7ZLWjDGOb2yeL6BRJ4vNMyuuDjG/sH/thgpnpDc0=
 github.com/psampaz/go-mod-outdated v0.7.0/go.mod h1:r78NYWd1z+F9Zdsfy70svgXOz363B08BWnTyFSgEESs=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -22,7 +22,6 @@ package internal
 
 import (
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
-	_ "github.com/psampaz/go-mod-outdated"
 
 	_ "k8s.io/release/pkg/version"
 )


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

Tests are failing in CI due to go-mod-outdated dragging in a bad dep.

- Issue link:
Fixes: https://github.com/kubernetes/enhancements/issues/3471
