### PR TITLE
KEP-3478: Process KEP Template

### DIFF
--- a/keps/NNNN-process-kep-template/README.md
+++ b/keps/NNNN-process-kep-template/README.md
@@ -1,0 +1,242 @@
+<!--
+**Note:** When your KEP is complete, all of these comment blocks should be removed.
+
+This template is intended for use when enhancing a process. Consider using this
+template for a KEP that:
+
+- Is exclusively a change to a process and does not require code changes of any kind.
+- Is independent of the Kubernetes release cycle and enhancement freezes.
+- Does not involve any changes that require production readiness review.
+- Can be enacted immediately after it is approved.
+- Requires only updates to process related documentation and communication with
+  the appropriate process leads or groups to enact.
+
+To get started with this template:
+
+- [ ] **Ensure this is the correct template to use.**
+  See above criteria.
+- [ ] **Pick a hosting SIG.**
+  Make sure that the problem space is something the SIG is interested in taking
+  up. KEPs should not be checked in without a sponsoring SIG.
+- [ ] **Create an issue in kubernetes/enhancements**
+  When filing an enhancement tracking issue, please make sure to complete all
+  fields in that template. One of the fields asks for a link to the KEP. You
+  can leave that blank until this KEP is filed, and then go back to the
+  enhancement and add the link.
+- [ ] **Make a copy of this template directory.**
+  Copy this template into the owning SIG's directory and name it
+  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
+  leading-zero padding) assigned to your enhancement above.
+- [ ] **Fill out as much of the kep.yaml file as you can.**
+  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
+  "Status", and date-related fields.
+- [ ] **Fill out this file as best you can.**
+  At minimum, you should fill in the "Summary" and "Motivation" sections.
+  These should be easy if you've preflighted the idea of the KEP with the
+  appropriate SIG(s).
+- [ ] **Create a PR for this KEP.**
+  Assign it to people in the SIG who are sponsoring this process.
+- [ ] **Merge early and iterate.**
+  Avoid getting hung up on specific details and instead aim to get the goals of
+  the KEP clarified and merged quickly. The best way to do this is to just
+  start with the high-level sections and fill out details incrementally in
+  subsequent PRs.
+
+Just because a KEP is merged does not mean it is complete or approved. Any KEP
+marked as `provisional` is a working document and subject to change. You can
+denote sections that are under active debate as follows:
+
+```
+<<[UNRESOLVED optional short context or usernames ]>>
+Stuff that is being argued.
+<<[/UNRESOLVED]>>
+```
+
+When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
+focused. If you disagree with what is already in a document, open a new PR
+with suggested changes.
+
+One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
+You do not need a new KEP to move from beta to GA, for example. If
+new details emerge that belong in the KEP, edit the KEP. Once a feature has become
+"implemented", major changes should get new KEPs.
+
+The canonical place for the latest set of instructions (and the likely source
+of this file) is [here](/keps/NNNN-kep-template/README.md).
+
+**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
+it is marked `implementable`, must be approved by each of the KEP approvers.
+If none of those approvers are still appropriate, then changes to that list
+should be approved by the remaining approvers and/or the owning SIG (or
+SIG Architecture for cross-cutting KEPs).
+-->
+# KEP-NNNN: Your short, descriptive title
+
+<!--
+This is the title of your KEP. Keep it short, simple, and descriptive. A good
+title can help communicate what the KEP is and should be considered as part of
+any review.
+-->
+
+<!--
+A table of contents is helpful for quickly jumping to sections of a KEP and for
+highlighting any additional information provided beyond the standard KEP
+template.
+
+Ensure the TOC is wrapped with
+  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
+tags, and then generate with `hack/update-toc.sh`.
+-->
+
+<!-- toc -->
+- [Signoff Checklist](#signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+    - [Story 2](#story-2)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge a process enhancement as implemented, these
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+<!--
+This section is incredibly important for producing high-quality process
+enhancements. It should clearly state what the proposed process change is.
+
+A good summary is probably at least a paragraph in length.
+
+Both in this section and below, follow the guidelines of the [documentation
+style guide]. In particular, wrap lines to a reasonable length, to make it
+easier for reviewers to cite specific portions, and to minimize diff churn on
+updates.
+
+[documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
+-->
+
+## Motivation
+
+<!--
+This section is for explicitly listing the motivation, goals, and non-goals of
+this KEP.  Describe why the change is important and the benefits to users. The
+motivation section can optionally provide links to [experience reports] to
+demonstrate the interest in a KEP within the wider Kubernetes community.
+
+[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
+-->
+
+### Goals
+
+<!--
+List the specific goals of the KEP. What is it trying to achieve? How will we
+know that this has succeeded?
+-->
+
+### Non-Goals
+
+<!--
+What is out of scope for this KEP? Listing non-goals helps to focus discussion
+and make progress.
+-->
+
+## Proposal
+
+<!--
+This is where we get down to the specifics of what the proposal actually is.
+This should have enough detail that reviewers can understand exactly what
+you're proposing, but should not include things like API designs or
+implementation. What is the desired outcome and how do we measure success?.
+The "Design Details" section below is for the real
+nitty-gritty.
+-->
+
+### User Stories (Optional)
+
+<!--
+Detail the things that people will be able to do if this KEP is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+-->
+
+#### Story 1
+
+#### Story 2
+
+### Notes/Constraints/Caveats (Optional)
+
+<!--
+What are the caveats to the proposal?
+What are some important details that didn't come across above?
+Go in to as much detail as necessary here.
+This might be a good place to talk about core concepts and how they relate.
+-->
+
+### Risks and Mitigations
+
+<!--
+What are the risks of this proposal, and how do we mitigate? Think broadly.
+For example, consider both security and how this will impact the larger
+Kubernetes ecosystem.
+
+How will security be reviewed, and by whom?
+
+How will UX be reviewed, and by whom?
+
+Consider including folks who also work outside the SIG or subproject.
+-->
+
+## Design Details
+
+<!--
+This section should contain enough information that the specifics of your
+change are understandable. This may include API specs (though not always
+required) or even code snippets. If there's any ambiguity about HOW your
+proposal will be implemented, this is the place to discuss them.
+-->
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+## Alternatives
+
+<!--
+What other approaches did you consider, and why did you rule them out? These do
+not need to be as detailed as the proposal, but should include enough
+information to express the idea and why it was not acceptable.
+-->

--- a/keps/NNNN-process-kep-template/kep.yaml
+++ b/keps/NNNN-process-kep-template/kep.yaml
@@ -1,0 +1,28 @@
+title: Process KEP Template
+kep-type: process
+kep-number: NNNN
+authors:
+  - "@jane.doe"
+owning-sig: sig-xyz
+participating-sigs:
+  - sig-aaa
+  - sig-bbb
+# As a process KEP, if the status is "implemented", the process is enacted.
+status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
+creation-date: yyyy-mm-dd
+reviewers:
+  - TBD
+  - "@alice.doe"
+approvers:
+  - TBD
+  - "@oscar.doe"
+
+see-also:
+  - "/keps/sig-aaa/1234-we-heard-you-like-keps"
+  - "/keps/sig-bbb/2345-everyone-gets-a-kep"
+replaces:
+  - "/keps/sig-ccc/3456-replaced-kep"
+
+# All process KEPs use "stable" as the stage. See status determine if the process
+# enhancement is enacted or not.
+stage: stable

--- a/keps/sig-architecture/3478-process-kep-template/README.md
+++ b/keps/sig-architecture/3478-process-kep-template/README.md
@@ -1,0 +1,162 @@
+# KEP-3478: Process KEP Template
+
+<!-- toc -->
+- [Signoff Checklist](#signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge a process enhancement as implemented, these
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [x] (R) Enhancement issue, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+Quite a few process enhancements have been proposed using as KEPs.
+Overall KEPs are good way to propose, communicate and ratify process
+enhancements. But the main KEP template is a poor starting point.
+
+This KEP proposed a KEP template written specifically for process enhancements.
+Specifically, this template is intended any KEP that:
+
+- Is exclusively a change to a process and does not require code changes of any kind.
+- Is independent of the Kubernetes release cycle and enhancement freezes.
+- Does not involve any changes that require production readiness review.
+- Can be enacted immediately after it is approved.
+- Requires only updates to process related documentation and communication with
+  the appropriate process leads or groups to enact.
+
+## Motivation
+
+Process KEP authors are already individually trimming down the main KEP template
+when authoring process KEPs. Some examples of this include:
+
+- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/2527-clarify-status-observations-vs-rbac
+- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1635-prevent-permabeta
+- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1659-standard-topology-labels
+- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1194-prod-readiness
+- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default
+
+Determining which information in the main KEP template applies to a process KEP
+is not entirely trivial. Does the KEP still need to be milestone bound to a
+release? Which KEP sections are appropriate to omit? Does anything in Prod
+Readiness apply? Do stability levels and graduation apply to a process
+enhancement?
+
+Without a process KEP template, each KEP author must attempt to answer these
+questions individually. The goal of introducing a template it to make all those
+decisions collectively so that process KEPs are less burdonsome to author, and
+more consistent once written.
+
+### Goals
+
+Introduce a KEP template specifically for process enhancements.
+
+### Non-Goals
+
+Introduce mechanisms to keep the main KEP template and the new process KEP
+template in sync. Except for general changes to KEPs that apply to all
+templates, we expect the templates to diverge over time. We don't consider
+this a problem. We believe that the vast majority of changes to the feature
+enhancement KEP template will not apply to process enhancements and vis-versa.
+
+## Proposal
+
+Introduce a `NNNN-process-kep-template` that will be similar to `NNNN-kep-template`,
+except:
+
+- All instructions in the template will be re-written to be aimed at process
+  KEP authors.
+- Unnecessary sections will be dropped from both the `README.md` and
+  `kep.yaml`.
+- Documentation for the KEP process will call-out the existence of this
+  separate template for process KEPs.
+
+While the original KEP proposal did not explicitly suggest that multiple KEP
+templates might be needed for the project as a whole, it does suggest that
+[special purpose KEP templates may be useful](https://github.com/kubernetes/enhancements/blob/c7963986f074c2a712d483fdfd00e51b7c68c5d2/keps/sig-architecture/0000-kep-process/README.md?plain=1#L115-L120):
+
+> SIGs also have the freedom to customize the KEP template
+> according to their SIG-specific concerns. For example, the KEP template used to
+> track API changes will likely have different subsections than the template for
+> proposing governance changes.
+
+### Risks and Mitigations
+
+KEP authors might try to use the template for cases where it is not appropriate.
+This can be mitigated by clearly listing out the conditions where this template
+is appropriate. 
+
+## Design Details
+
+Process KEPs are not "graduated", they are "enacted". To minimize confusion
+about this and leverage existing KEP concepts as much as possible,
+"enacted" will be represented using the "implemented" KEP status. Also,
+process KEPs will not graduate between the "alpha", "beta" and "stable"
+stages, and will instead always be set to the "stable" stage.
+
+The release process (and it's freezes) does not prevent process KEPs from
+being merged or ratified. For this reason, process KEP tracking issues will
+not use release milestone labels.
+
+Structural differences from the main KEP template:
+
+`README.md`:
+
+- Include a list of conditions for when the process KEP template is appropriate.
+- Remove "Test Plan", "Graduation Criteria", "Upgrade / Downgrade Strategy",
+  "Version Skew Strategy", "Production Readiness Review Questionnaire" and
+  "Implementation History" sections.
+- Rewrite all instructions to be aimed at process enhancement authors.
+
+`kep.yaml`:
+- Add a `kep-type: process` field to make is easy to identify process KEPs.
+- Remove `latest-milestone`, `milestone`, `feature-gates`, `disable-supported`
+  and `metrics` fields.
+- Add comments explaining how `status` should should be interprested for process
+  KEPs.
+- Continue to include `stage` but field but default it to `stable` and include
+  comment explaining that process KEPs do transition through stability levels
+  and that they are "enacted", not "graduated". Keeping this field is primarily
+  intended to help keep `kep.yaml` files easy to process by tools.
+
+## Drawbacks
+
+See risks.
+
+## Alternatives
+
+- Interleave into the main KEP template instructions about how to handle
+  process KEPs. This complicates the main template and makes it more
+  burdonsome for feature enhancement authors.
+- We could have limited this template to sig-architecture instead of making
+  it a top level template. But this template seems generally useful to all
+  SIGs.

--- a/keps/sig-architecture/3478-process-kep-template/kep.yaml
+++ b/keps/sig-architecture/3478-process-kep-template/kep.yaml
@@ -1,0 +1,20 @@
+title: Process KEP Template
+kep-type: process
+kep-number: 3478
+authors:
+  - "@jpbetz"
+owning-sig: sig-architecture
+# As a process KEP, if the status is "implemented", the process is enacted.
+status: implementable
+creation-date: 2022-08-26
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+see-also:
+  - "/keps/sig-architecture/0000-kep-process"
+
+# All process KEPs use "stable" as the stage. See status determine if the process
+# enhancement is enacted or not.
+stage: stable


### PR DESCRIPTION
- One-line PR description: Add KEP proposing new KEP template for process enhancements. Included is proposed KEP template for process KEPs.

Why?
- Clarify and document how to process KEP should be written and enacted
  - Collectively instead of individually decide how a process KEP should be introduced and ratified
  - Reduce burden for authors of process KEPs

Examples of existing process KEPs:
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/2527-clarify-status-observations-vs-rbac
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1635-prevent-permabeta
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1659-standard-topology-labels
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/1194-prod-readiness
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default