### PR TITLE
KEP-2307: Graduate JobTrackingWithFinalizers to GA

### DIFF
--- a/keps/prod-readiness/sig-apps/2307.yaml
+++ b/keps/prod-readiness/sig-apps/2307.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/2307-job-tracking-without-lingering-pods/README.md
+++ b/keps/sig-apps/2307-job-tracking-without-lingering-pods/README.md
@@ -422,6 +422,7 @@ for jobs with multiple sizes.
 - Job E2E tests graduate to conformance.
 - Job tracking scales to 10^5 completions per Job processed within an order of
   minutes.
+- Write blog post about the feature and the future deprecation plans.
 
 #### Deprecation
 
@@ -668,6 +669,13 @@ Yes, see [Deprecation](#deprecation) for the full plan.
       In newer versions, this can still happen if there is a buggy webhook
       that prevents pod updates to remove finalizers.
     - Testing: Discovered bugs are covered by unit and integration tests.
+  - Job pods might be recreated upon upgrade to 1.27.
+    - Detection:
+      In 1.26, there are non-finished jobs without annotation `batch.kubernetes.io/job-completion`.
+    - Mitigation:
+      - Keep `JobTrackingWithFinalizers` feature gate enabled in 1.25. This
+        minimizes the chances of having legacy jobs before upgrading to 1.27.
+      - Wait for Jobs without `batch.kubernetes.io/job-completion` to finish.
 
 #### What steps should be taken if SLOs are not being met to determine the problem?
 

--- a/keps/sig-apps/2307-job-tracking-without-lingering-pods/kep.yaml
+++ b/keps/sig-apps/2307-job-tracking-without-lingering-pods/kep.yaml
@@ -20,13 +20,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.23"
-  stable: "v1.25"
+  stable: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -35,7 +35,10 @@ feature-gates:
   components:
     - kube-apiserver
     - kube-controller-manager
-disable-supported: true
+- name: MigrateJobLegacyTracking
+  components:
+    - kube-controller-manager
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:

--- a/keps/sig-apps/2307-job-tracking-without-lingering-pods/kep.yaml
+++ b/keps/sig-apps/2307-job-tracking-without-lingering-pods/kep.yaml
@@ -35,9 +35,6 @@ feature-gates:
   components:
     - kube-apiserver
     - kube-controller-manager
-- name: MigrateJobLegacyTracking
-  components:
-    - kube-controller-manager
 disable-supported: false
 
 # The following PRR answers are required at beta release


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Add GA and deprecation notes

<!-- link to the k/enhancements issue -->
- Issue link: #2307

<!-- other comments or additional information -->
- Other comments:
  - Add metric `job_pod_tracking_finalizer`.
  - Add legacy to finalizers migration under `MigrateJobLegacyTracking` feature gate.
  - Add known failure modes.