### PR TITLE
Updated enhancements README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ The Exceptions Process is handled by the Release Team, please see their [documen
 | `sig/foo` | Denotes the SIG(s) which owns this enhancement—e.g., `SIG Foo` | Set the label using the comment `/sig foo` (on a separate line) | Anyone |
 | `kind/feature` | Denotes that the issue should be tracked as an enhancement (all enhancement issues should be marked with this label) | Set the label using the comment `/kind feature` (on a separate line) | Anyone |
 | `tracked/yes` | Denotes an issue has been reviewed by a Feature Maintainer (SIG Release) and is actively tracked for the current milestone | Manually set | Feature Maintainers (SIG Release) ONLY |
-| `tracked/no` | Denotes an issue has been reviewed by a Feature Maintainer (SIG Release) and will not actively tracked for the current milestone | Manually set | Feature Maintainers (SIG Release) ONLY |
+| `tracked/no` | Denotes an issue has been reviewed by a Feature Maintainer (SIG Release) and will not be actively tracked for the current milestone | Manually set | Feature Maintainers (SIG Release) ONLY |
 | `stage/{alpha,beta,stable}` | Denotes the stage of an issue in the features process | Set the label using the comment `/stage alpha` (on a separate line) | Anyone |
 
 ## Glossary
 
-Please refer to the [Glossary](docs/glossary.md) for definition of any terminology and acronyms used in Enhancements subproject.
+Please refer to the [Glossary](docs/glossary.md) for the definition of any terminology and acronyms used in the Enhancements subproject.


### PR DESCRIPTION
Why:
missed verb & Incorrect article usage

What's being changed:
Changed "not actively" to "not be actively" -> missing verb, so added it for better read
Changed "for definition" to "for the definition" -> article usage fixed
Changed "in Enhancements" to "in the Enhancements" -> added a article

Check off the following:
 I have reviewed my changes in staging (look for the "Automatically generated comment" and click the links in the "Preview" column to view your latest changes).
 For content changes, I have completed the self-review checklist.