### PR TITLE
KEP-2379: adding support for shell-completion for plugins

### DIFF
--- a/keps/sig-cli/2379-kubectl-plugins/kep.yaml
+++ b/keps/sig-cli/2379-kubectl-plugins/kep.yaml
@@ -15,7 +15,7 @@ approvers:
   - "@soltysh"
 editor: juanvallejo
 creation-date: 2018-07-24
-last-updated: 2010-02-26
+last-updated: 2019-02-26
 status: implemented
 see-also:
   - n/a


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
Add support for shell-completion for plugins.

<!-- link to the k/enhancements issue -->
- Issue: https://github.com/kubernetes/kubernetes/issues/74178
- Implementation: https://github.com/kubernetes/kubernetes/pull/105867

<!-- other comments or additional information -->

This improvement was discussed during the SIG-CLI meeting of [March 22nd], 2022(https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit#bookmark=kix.alt3br5igshx), and it was requested to update the KEP to document the proposal.