### PR TITLE
KEP-1672: promote EndpointSliceTerminatingCondition feature to GA

### DIFF
--- a/keps/prod-readiness/sig-network/1672.yaml
+++ b/keps/prod-readiness/sig-network/1672.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-network/1672-tracking-terminating-endpoints/kep.yaml
+++ b/keps/sig-network/1672-tracking-terminating-endpoints/kep.yaml
@@ -20,17 +20,18 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.20"
   beta: "v1.22"
+  stable: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

Promote EndpointSliceTerminatingCondition feature gate to GA in v1.26. This feature has been Beta since v1.22 and was pending validation from sig-scalability on the performance implications of this change.

<!-- link to the k/enhancements issue -->
- Issue link: #1672 

<!-- other comments or additional information -->
- Other comments: