### PR TITLE
KEP-2086: promote ServiceInternalTrafficPolicy to GA in v1.26

### DIFF
--- a/keps/prod-readiness/sig-network/2086.yaml
+++ b/keps/prod-readiness/sig-network/2086.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -13,6 +13,10 @@
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
@@ -148,13 +152,33 @@ Overlap with topology-aware routing:
 
 ### Test Plan
 
-Unit tests:
-* unit tests validating API strategy/validation for when `internalTrafficPolicy` is set on Service.
-* unit tests exercising kube-proxy behavior when `internalTrafficPolicy` is set to all possible values.
+[X] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
 
-E2E test:
-* e2e tests validating default behavior with kube-proxy did not change when `internalTrafficPolicy` defaults to `Cluster`. Existing tests should cover this.
-* e2e tests validating that traffic is only sent to node-local endpoints when `internalTrafficPolicy` is set to `Local`.
+##### Prerequisite testing updates
+
+##### Unit tests
+
+- `pkg/registry/core/service`: `v1.22` - `API strategy tests for feature enablement and upgrade safety (dropping disabled fields)`
+- `pkg/apis/core/v1`: `v1.22` - `API defauting tests`
+- `pkg/proxy/iptables`: `v1.22` - `iptables rules tests + feature enablement`
+- `pkg/proxy/ipvs`: `v1.22` - `ipvs rules tests + feature enablement`
+- `pkg/proxy`: `v1.22` - `generic kube-proxy Service tests`
+
+NOTE: search [ServiceInternalTrafficPolicy](https://github.com/kubernetes/kubernetes/search?q=ServiceInternalTrafficPolicy) in the Kubernetes repo for references to existing tests.
+
+##### Integration tests
+
+- `Test_ExternalNameServiceStopsDefaultingInternalTrafficPolicy`: https://github.com/kubernetes/kubernetes/blob/61b983a66b92142e454c655eb2add866c9b327b0/test/integration/service/service_test.go#L34
+- `Test_ExternalNameServiceDropsInternalTrafficPolicy`: https://github.com/kubernetes/kubernetes/blob/61b983a66b92142e454c655eb2add866c9b327b0/test/integration/service/service_test.go#L78
+- `Test_ConvertingToExternalNameServiceDropsInternalTrafficPolicy`: https://github.com/kubernetes/kubernetes/blob/61b983a66b92142e454c655eb2add866c9b327b0/test/integration/service/service_test.go#L125
+
+##### e2e tests
+
+- `should respect internalTrafficPolicy=Local Pod to Pod`: https://github.com/kubernetes/kubernetes/blob/4bc1398c0834a63370952702eef24d5e74c736f6/test/e2e/network/service.go#L2520
+- `should respect internalTrafficPolicy=Local Pod (hostNetwork: true) to Pod`: https://github.com/kubernetes/kubernetes/blob/4bc1398c0834a63370952702eef24d5e74c736f6/test/e2e/network/service.go#L2598
+- `should respect internalTrafficPolicy=Local Pod and Node, to Pod (hostNetwork: true)`: https://github.com/kubernetes/kubernetes/blob/4bc1398c0834a63370952702eef24d5e74c736f6/test/e2e/network/service.go#L2678
 
 ### Graduation Criteria
 

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -245,7 +245,7 @@ Rollout should have minimal impact because the default value of `internalTraffic
 
 * **What specific metrics should inform a rollback?**
 
-Metrics representing Services being black-holed will be added. This metric can inform rollback.
+The `sync_proxy_rules_no_local_endpoints_total` metric will inform users whether a Service is dropping local traffic.
 
 * **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
 
@@ -557,12 +557,12 @@ _This section must be completed when targeting beta graduation to a release._
 * **How can an operator determine if the feature is in use by workloads?**
 
 * Check Service to see if `internalTrafficPolicy` is set to `Local`.
-* A per-node "blackhole" metric will be added to kube-proxy which represent Services that are being intentionally dropped (internalTrafficPolicy=Local and no endpoints). The metric will be named `kubeproxy/sync_proxy_rules_no_endpoints_total` (subject to rename).
+* A per-node "blackhole" metric will be added to kube-proxy which represent Services that are being intentionally dropped (internalTrafficPolicy=Local and no endpoints). The metric will be named `kubeproxy/sync_proxy_rules_no_local_endpoints_total` (subject to rename).
 
 * **What are the SLIs (Service Level Indicators) an operator can use to determine
 the health of the service?**
 
-They can check the `kubeproxy/sync_proxy_rules_no_endpoints_total` metric when internalTrafficPolicy=Local and there are no endpoints.
+They can check the `kubeproxy/sync_proxy_rules_no_local_endpoints_total` metric when internalTrafficPolicy=Local and there are no endpoints.
 
 * **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
 
@@ -571,7 +571,7 @@ This will depend on Service topology and whether `internalTrafficPolicy=Local` i
 * **Are there any missing metrics that would be useful to have to improve observability
 of this feature?**
 
-A new metric will be added to represent Services that are being "blackholed" (internalTrafficPolicy=Local and no endpoints).
+The `sync_proxy_rules_no_local_endpoints_total` metric was added to inform users on whether a Service is dropping local traffic.
 
 ### Dependencies
 

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -9,7 +9,6 @@
 - [Proposal](#proposal)
   - [User Stories (Optional)](#user-stories-optional)
     - [Story 1](#story-1)
-    - [Story 2](#story-2)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Test Plan](#test-plan)
@@ -96,13 +95,8 @@ The `internalTrafficPolicy` field will not apply for headless Services or Servic
 
 #### Story 1
 
-As an application owner, I would like traffic to cluster DNS servers to always prefer local endpoints to reduce
-latency in my application.
-
-#### Story 2
-
-As a platform owner, I want to create a Service that always directs traffic to a logging daemon on the same node.
-Traffic should never bounce to a daemon on another node.
+As a platform owner, I want to create a Service that always directs traffic to a logging daemon or metrics agent on the same node.
+Traffic should never bounce to a daemon on another node since the logs would then report an incorrect log source.
 
 ### Risks and Mitigations
 

--- a/keps/sig-network/2086-service-internal-traffic-policy/README.md
+++ b/keps/sig-network/2086-service-internal-traffic-policy/README.md
@@ -169,13 +169,14 @@ Beta:
 
 GA:
 * metrics for total number of Services that have no endpoints (kubeproxy/sync_proxy_rules_no_endpoints_total) with additional labels for internal/external and local/cluster policies.
-* consensus on whether or not "PreferLocal" should be included as a new policy type
+* Fix a bug where internalTrafficPolicy=Local would force externalTrafficPolicy=Local (https://github.com/kubernetes/kubernetes/pull/106497).
+* Sufficient integration/e2e tests (many were already added for Beta, but we'll want to revisit tests based on changes that landed during Beta).
 
 ### Upgrade / Downgrade Strategy
 
-* The `trafficPolicy` field will be off by default during the alpha stage but can handle any existing Services that has the field already set.
+* The `internalTrafficPolicy` field will be off by default during the alpha stage but can handle any existing Services that has the field already set.
 This ensures n-1 apiservers can handle the new field on downgrade.
-* On upgrade, if the feature gate is enabled there should be no changes in the behavior since the default value for `trafficPolicy` is `Cluster`.
+* On upgrade, if the feature gate is enabled there should be no changes in the behavior since the default value for `internalTrafficPolicy` is `Cluster`.
 
 ### Version Skew Strategy
 
@@ -242,12 +243,12 @@ _This section must be completed when targeting beta graduation to a release._
 * **How can an operator determine if the feature is in use by workloads?**
 
 * Check Service to see if `internalTrafficPolicy` is set to `Local`.
-* A per-node "blackhole" metric will be added to kube-proxy which represent Services that are being intentionally dropped (internalTrafficPolicy=Local and no endpoints). The metric will be named `kubeproxy/sync_proxy_rules/blackhole_total` (subject to rename).
+* A per-node "blackhole" metric will be added to kube-proxy which represent Services that are being intentionally dropped (internalTrafficPolicy=Local and no endpoints). The metric will be named `kubeproxy/sync_proxy_rules_no_endpoints_total` (subject to rename).
 
 * **What are the SLIs (Service Level Indicators) an operator can use to determine
 the health of the service?**
 
-They can check the "blackhole" metric when internalTrafficPolicy=Local and there are no endpoints.
+They can check the `kubeproxy/sync_proxy_rules_no_endpoints_total` metric when internalTrafficPolicy=Local and there are no endpoints.
 
 * **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
 
@@ -314,8 +315,8 @@ already have many checks like this for `externalTrafficPolicy: Local`.
 resource usage (CPU, RAM, disk, IO, ...) in any components?**
 
 Any increase in CPU usage by kube-proxy to calculate node-local topology will likely
-be offset by reduced iptable rules it needs to sync when using `PreferLocal` or `Local`
-traffic policies.
+be offset by reduced iptable rules it needs to sync when using the `Local`
+traffic policy.
 
 ### Troubleshooting
 

--- a/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
+++ b/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
@@ -16,18 +16,18 @@ see-also:
   - "/keps/sig-network/20181024-service-topology.md"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.21"
   beta: "v1.22"
-  stable: "v1.25"
+  stable: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

Updates ServiceInternalTrafficPolicy feature to GA in v1.26. Feature has been in Beta since v1.22 and was blocked on a metric that was added in v1.24.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2086

<!-- other comments or additional information -->
- Other comments: