### PR TITLE
KEP-2258: Update milestones to 1.26

### DIFF
--- a/keps/sig-windows/2258-node-service-log-viewer/README.md
+++ b/keps/sig-windows/2258-node-service-log-viewer/README.md
@@ -302,13 +302,13 @@ e2e tests. For Windows a new set of tests will be added to the existing
 
 ### Graduation Criteria
 
-The plan is to introduce the feature as alpha in the v1.25 time frame behind the
+The plan is to introduce the feature as alpha in the v1.26 time frame behind the
 `NodeLogViewer` kubelet feature gate and using the `kubectl alpha node-logs`
 sub-command.
 
 #### Alpha -> Beta Graduation
 
-The plan is to graduate the feature to beta in the v1.26 time frame. At that
+The plan is to graduate the feature to beta in the v1.27 time frame. At that
 point we would have collected feedback from cluster administrators and
 developers who have enabled the feature. Based on this feedback and issues
 opened we should consider adding a kubelet side throttle for the viewing the
@@ -320,7 +320,7 @@ The kubectl implementation will move from `kubectl alpha node-logs` to
 `kubectl node-logs`.
 #### Beta -> GA Graduation
 
-The plan is to graduate the feature to GA in the v1.27 time frame at which point
+The plan is to graduate the feature to GA in the v1.28 time frame at which point
 any major issues should have been surfaced and addressed during the alpha and
 beta phases.
 

--- a/keps/sig-windows/2258-node-service-log-viewer/kep.yaml
+++ b/keps/sig-windows/2258-node-service-log-viewer/kep.yaml
@@ -18,18 +18,18 @@ approvers:
 prr-approvers:
   - "@johnbelamaric"
 creation-date: 2021-01-14
-last-updated: 2021-05-05
+last-updated: 2022-06-06
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.25"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.25"
+  alpha: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: Update the milestones on the KEP for node service log viewer to 1.26+

- Issue link: https://github.com/kubernetes/enhancements/issues/2258