### PR TITLE
README: fix heading for enhancements spreadsheet section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Links:
 
 - [1.26 Milestone](http://bit.ly/k8s126-enhancements)
 
-## Enhancements Tracking Spreadsheet (deprecated)
+## Enhancements Tracking Spreadsheet
 
 Prior to the 1.26 release, enhancements from this repo were visualized using Enhancements Tracking Spreadsheets.
 


### PR DESCRIPTION
Remove the word deprecated in the sub-heading title to fix the broken link to #enhancements-tracking-spreadsheet subsection.