### PR TITLE
KEP-1491: set latest milestone for vSphere migration to 1.26

### DIFF
--- a/keps/prod-readiness/sig-storage/1491.yaml
+++ b/keps/prod-readiness/sig-storage/1491.yaml
@@ -1,3 +1,5 @@
 kep-number: 1491
+beta:
+  approver: "@wojtek-t"
 stable:
   approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-storage/1491.yaml
+++ b/keps/prod-readiness/sig-storage/1491.yaml
@@ -1,3 +1,3 @@
 kep-number: 1491
-beta:
+stable:
   approver: "@wojtek-t"

--- a/keps/sig-storage/1491-csi-migration-vsphere/kep.yaml
+++ b/keps/sig-storage/1491-csi-migration-vsphere/kep.yaml
@@ -22,12 +22,12 @@ prr-approvers:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.25"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
set latest milestone for vSphere migration to 1.26

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1491

<!-- other comments or additional information -->
- Other comments: