### PR TITLE
KEP-2395: Bump dates for in-tree cloud provider removal

### DIFF
--- a/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md
+++ b/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md
@@ -123,10 +123,11 @@ For alpha, the feature gates will be used for testing purposes. When enabled, te
 disabled by default.
 
 For beta, the feature gates will be on by default, meaning core components will disallow use of in-tree cloud providers. This will act as a warning for users to migrate to external components. Users may
-choose to continue using the in-tree provider by explicitly disabling the feature gates. Beta is targeted for v1.23 or v1.24.
+choose to continue using the in-tree provider by explicitly disabling the feature gates. Beta is targeted for v1.26 with the caveat that a majority of our CI signal jobs across providers should have converted to use CCM by then.
 
-For GA, the feature gate will be enabled by default and locked. Users at this point MUST migrate to external components and use of the in-tree cloud providers will be disallowed. One release after GA,
-the in-tree cloud providers can be safely removed. GA is targeted for v1.25 or v1.26.
+For GA, the feature gate will be enabled by default and locked. Users at this point MUST migrate to external components and use of the in-tree cloud providers will be disallowed. GA is targeted for v1.27. One release after GA, the in-tree cloud providers can be safely removed. 
+
+NOTE: the removal of the code will depend on when we can remove the in-tree storage plugins, so the actual removal may end up in a later release.
 
 ### Staging Directory
 


### PR DESCRIPTION
We blew past some deadlines, so update them! Also note the dependency on the removal of in-tree storage plugins.

You may want to see the dates for the CSI migration that will drive removal of specific providers:
https://github.com/dims/enhancements/pull/new/bump-dates-for-in-tree-cloud-provider-removal

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2395

<!-- other comments or additional information -->
- Other comments: