### PR TITLE
KEP-647: Update beta version to 1.26 and add graduation criterion

### DIFF
--- a/keps/sig-instrumentation/647-apiserver-tracing/README.md
+++ b/keps/sig-instrumentation/647-apiserver-tracing/README.md
@@ -176,10 +176,11 @@ Alpha
 Beta
 
 - [] Tracing 100% of requests does not break scalability tests (this does not necessarily mean trace backends can handle all the data).
-- [] OpenTelemetry reaches GA
+- [X] OpenTelemetry reaches GA
 - [] Publish examples of how to use the OT Collector with kubernetes
-- [] Allow time for feedback
+- [X] Allow time for feedback
 - [] Revisit the format used to export spans.
+- [] Parity with the old text-based Traces
 
 GA
 

--- a/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
+++ b/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
@@ -22,11 +22,11 @@ prr-approvers:
 see-also:
 replaces:
 stage: beta
-last-updated: 2022-01-18
-latest-milestone: "v1.24"
+last-updated: 2022-09-19
+latest-milestone: "v1.26"
 milestone:
   alpha: "v1.22"
-  beta: "v1.24"
+  beta: "v1.26"
 feature-gates:
   - name: APIServerTracing
 disable-supported: true


### PR DESCRIPTION
- One-line PR description: Update beta version to 1.26 and add graduation criterion

- Issue link: https://github.com/kubernetes/enhancements/issues/647

- Other comments: Additional instrumentation was requested in https://github.com/kubernetes/enhancements/issues/647#issuecomment-1078834288.  APIServer tracing did not graduate in 1.24 because we were unable to update to the stable OpenTelemetry version.