### PR TITLE
Update docs for common labels for enhancement tracking issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,14 @@ Please comment on the enhancement issue to:
 Please do not comment on the enhancement issue to:
 - discuss a detail of the design, code or docs. Use a linked-to-issue or PR for that
 
+
+## Current Release Info
+
+[Dates and further information for the 1.26 Release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.26)
+
 ## Enhancements Tracking Board
 
-As of the 1.26 release, enhancements from this repo are visualized in the Enhancements Tracking Boards.
+As of the 1.26 release, enhancements from this repo are tracked through a Github Project Board.
 
 Links:
 
@@ -80,17 +85,10 @@ Links:
 
 ## Enhancements Tracking Spreadsheet
 
-Prior to the 1.26 release, enhancements from this repo were visualized using Enhancements Tracking Spreadsheets.
+Prior to the 1.26 release, enhancements from this repo were tracked through a Google Sheets spreadsheet.
 
 Please refer to the [Enhancements Tracking Spreadsheet Archive](docs/archived-tracking-sheets.md) for links to
 these sheets.
-
-Procedure:
-*TBA*
-
-### Current Release Cycle
-
-[Dates and further information for the 1.25 Release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.25)
 
 ## Exceptions to Enhancement Milestone Dates
 
@@ -104,7 +102,7 @@ The Exceptions Process is handled by the Release Team, please see their [documen
 | `kind/feature` | Denotes an issue should be tracked as an enhancement (all enhancement issues should be marked with this label) | Set the label using the comment `/kind feature` (on a separate line) | Anyone |
 | `tracked/yes` | Denotes an issue has been reviewed by the enhancements team (SIG Release) and is actively tracked for the current milestone | Set the label using the comment `/label tracked/yes` (on a separate line) | Release enhancements team ONLY |
 | `tracked/no` | Denotes an issue has been reviewed by the enhancements team (SIG Release) and will not be actively tracked for the current milestone | Set the label using the comment `/label tracked/no` (on a separate line) | Release enhancements team ONLY |
-| `tracked/out-of-tree` | Denotes an issue has an out-of-tree implementation | Set the label using the comment `/label tracked/out-of-tree` (on a separate line) | Release enhancements team ONLY |
+| `tracked/out-of-tree` | Denotes an issue has an out-of-tree (outside of [k/k](https://github.com/kubernetes/kubernetes)) implementation | Set the label using the comment `/label tracked/out-of-tree` (on a separate line) | Release enhancements team ONLY |
 | `stage/{alpha,beta,stable}` | Denotes the stage of an issue in the features process | Set the label using the comment `/stage alpha` (on a separate line) | Anyone |
 | `lead-opted-in` | Denotes that an issue has been opted in to a release | Set the label using the comment `/label lead-opted-in` (on a separate line) | SIG leads ONLY |
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Create an [issue](https://github.com/kubernetes/enhancements/issues/new) in this
 
 ## Why Are Enhancements Tracked
 
-Once users adopt an enhancement, they expect to use it for an extended period of time. Therefore, we hold new enhancements to a high standard of conceptual integrity and require consistency with other parts of the system, thorough testing, and complete documentation. As the project grows, no single person can track whether all those requirements are met. 
+Once users adopt an enhancement, they expect to use it for an extended period of time. Therefore, we hold new enhancements to a high standard of conceptual integrity and require consistency with other parts of the system, thorough testing, and complete documentation. As the project grows, no single person can track whether all those requirements are met.
 
 The development of an enhancement often spans three stages: Alpha, Beta, and Stable. Enhancement Tracking Issues provide a checklist that allows for different approvers for different aspects, and ensures that nothing is forgotten across the
 development lifetime of an enhancement.
@@ -82,7 +82,7 @@ Links:
 
 Prior to the 1.26 release, enhancements from this repo were visualized using Enhancements Tracking Spreadsheets.
 
-Please refer to the [Enhancements Tracking Spreadsheet Archive](docs/archived-tracking-sheets.md) for links to 
+Please refer to the [Enhancements Tracking Spreadsheet Archive](docs/archived-tracking-sheets.md) for links to
 these sheets.
 
 Procedure:
@@ -100,11 +100,13 @@ The Exceptions Process is handled by the Release Team, please see their [documen
 
 | Label Name | Purpose | How to use this label | Who should use this label |
 | ------ | ------ | ------ | ------ |
-| `sig/foo` | Denotes the SIG(s) which owns this enhancement—e.g., `SIG Foo` | Set the label using the comment `/sig foo` (on a separate line) | Anyone |
-| `kind/feature` | Denotes that the issue should be tracked as an enhancement (all enhancement issues should be marked with this label) | Set the label using the comment `/kind feature` (on a separate line) | Anyone |
-| `tracked/yes` | Denotes an issue has been reviewed by a Feature Maintainer (SIG Release) and is actively tracked for the current milestone | Manually set | Feature Maintainers (SIG Release) ONLY |
-| `tracked/no` | Denotes an issue has been reviewed by a Feature Maintainer (SIG Release) and will not be actively tracked for the current milestone | Manually set | Feature Maintainers (SIG Release) ONLY |
+| `sig/foo` | Denotes the SIG(s) which owns the enhancement and other responsible SIG(s)-e.g., `SIG Foo` | Set the label using the comment `/sig foo` (on a separate line) | Anyone |
+| `kind/feature` | Denotes an issue should be tracked as an enhancement (all enhancement issues should be marked with this label) | Set the label using the comment `/kind feature` (on a separate line) | Anyone |
+| `tracked/yes` | Denotes an issue has been reviewed by the enhancements team (SIG Release) and is actively tracked for the current milestone | Set the label using the comment `/label tracked/yes` (on a separate line) | Release enhancements team ONLY |
+| `tracked/no` | Denotes an issue has been reviewed by the enhancements team (SIG Release) and will not be actively tracked for the current milestone | Set the label using the comment `/label tracked/no` (on a separate line) | Release enhancements team ONLY |
+| `tracked/out-of-tree` | Denotes an issue has an out-of-tree implementation | Set the label using the comment `/label tracked/out-of-tree` (on a separate line) | Release enhancements team ONLY |
 | `stage/{alpha,beta,stable}` | Denotes the stage of an issue in the features process | Set the label using the comment `/stage alpha` (on a separate line) | Anyone |
+| `lead-opted-in` | Denotes that an issue has been opted in to a release | Set the label using the comment `/label lead-opted-in` (on a separate line) | SIG leads ONLY |
 
 ## Glossary
 


### PR DESCRIPTION
Update documentation for common labels to account for how they are actually used and the changes in the enhancement opt in process starting with the 1.26 cycle

/cc @gracenng @leonardpahlke @marosset @reylejano 

Part of https://github.com/kubernetes/sig-release/issues/2009

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: