### PR TITLE
Cleanup prr-approvers from kep.yaml for which corresponding prod-readiness file exists

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/kep.yaml
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/kep.yaml
@@ -19,8 +19,6 @@ reviewers:
 approvers:
 - "@deads2k"
 - "@lavalamp"
-prr-approvers:
-- "@wojtek-t"
 creation-date: 2019-02-28
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-api-machinery/1164-remove-selflink/kep.yaml
+++ b/keps/sig-api-machinery/1164-remove-selflink/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 approvers:
   - "@lavalamp"
   - "@deads2k"
-prr-approvers:
-  - "@deads2k"
 creation-date: 2019-07-11
 last-updated: 2022-05-09
 status: implemented

--- a/keps/sig-api-machinery/1295-insecure-backend-proxy/kep.yaml
+++ b/keps/sig-api-machinery/1295-insecure-backend-proxy/kep.yaml
@@ -17,8 +17,6 @@ reviewers:
 approvers:
   - "@lavalamp"
   - "@mikedanese"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-api-machinery/1693-warnings/kep.yaml
+++ b/keps/sig-api-machinery/1693-warnings/kep.yaml
@@ -9,8 +9,6 @@ participating-sigs:
   - sig-instrumentation
 status: implemented
 creation-date: 2020-04-16
-prr-approvers:
-  - "@ehashman"
 reviewers:
   - "@lavalamp"
   - "@deads2k"

--- a/keps/sig-api-machinery/1904-efficient-watch-resumption/kep.yaml
+++ b/keps/sig-api-machinery/1904-efficient-watch-resumption/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@deads2k"
   - "@lavalamp"
-prr-approvers:
-  - "@deads2k"
 see-also:
   - "/keps/sig-api-machinery/20191210-consistent-reads-from-cache.md"
 replaces:

--- a/keps/sig-api-machinery/2155-clientgo-apply/kep.yaml
+++ b/keps/sig-api-machinery/2155-clientgo-apply/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 approvers:
   - "@deads2k"
   - "@lavalamp"
-prr-approvers:
-  - "@deads2k"
 see-also:
   - "/keps/sig-api-machinery/0006-apply.md"
 

--- a/keps/sig-api-machinery/2558-publish-version-openapi/kep.yaml
+++ b/keps/sig-api-machinery/2558-publish-version-openapi/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@apelisse"
-prr-approvers:
-  - "@deads2k"
 see-also:
   - "https://groups.google.com/g/kubernetes-sig-architecture/c/UmPwm-J3ztE/m/QckZWJAABQAJ"
 replaces: []

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
@@ -18,13 +18,6 @@ approvers:
   - "@lavalamp"
   - "@liggitt"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "/keps/sig-api-machinery/95-custom-resource-definitions"
 

--- a/keps/sig-api-machinery/2885-server-side-unknown-field-validation/kep.yaml
+++ b/keps/sig-api-machinery/2885-server-side-unknown-field-validation/kep.yaml
@@ -14,13 +14,6 @@ approvers:
   - "@deads2k"
   - "@liggitt"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
 replaces:
 

--- a/keps/sig-api-machinery/2887-openapi-enum-types/kep.yaml
+++ b/keps/sig-api-machinery/2887-openapi-enum-types/kep.yaml
@@ -14,8 +14,6 @@ approvers:
   - "@jpbetz"
   - "@deads2k"
   - "@lavalamp"
-prr-approvers:
-  - "@deads2k"
 
 see-also:
   - https://github.com/kubernetes/enhancements/issues/2896

--- a/keps/sig-api-machinery/2896-openapi-v3/kep.yaml
+++ b/keps/sig-api-machinery/2896-openapi-v3/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
 approvers:
   - "@deads2k"
   - "@lavalamp"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-api-machinery/3352-aggregated-discovery/kep.yaml
+++ b/keps/sig-api-machinery/3352-aggregated-discovery/kep.yaml
@@ -15,14 +15,6 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-prr-approvers:
-  - "@deads2k"
-
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 

--- a/keps/sig-api-machinery/555-server-side-apply/kep.yaml
+++ b/keps/sig-api-machinery/555-server-side-apply/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
   - "@erictune"
 approvers:
   - "@bgrant0607"
-prr-approvers:
-  - "@deads2k"
 editor: TBD
 creation-date: 2018-03-28
 last-updated: 2021-09-21

--- a/keps/sig-apps/1591-daemonset-surge/kep.yaml
+++ b/keps/sig-apps/1591-daemonset-surge/kep.yaml
@@ -14,10 +14,6 @@ approvers:
   - "@kow3ns"
   - "@janetkuo"
   - "@soltysh"
-prr-approvers:
-  - "@deads2k"
-  - "@ehashman"
-  - "@wojtek-t"
 editor: TBD
 creation-date: 2020-03-02
 last-updated: 2022-05-10

--- a/keps/sig-apps/1847-autoremove-statefulset-pvcs/kep.yaml
+++ b/keps/sig-apps/1847-autoremove-statefulset-pvcs/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@xing-yang"
   - "@msau42"
   - "@janetkuo"
-prr-approvers:
-  - "@johnbelamaric"
 approvers:
   - "@msau42"
   - "@janetkuo"

--- a/keps/sig-apps/19-Graduate-CronJob-to-Stable/kep.yaml
+++ b/keps/sig-apps/19-Graduate-CronJob-to-Stable/kep.yaml
@@ -19,8 +19,6 @@ approvers:
   - "@janetkuo"
   - "@liggitt"
   - "@wojtek-t"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 replaces:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apps/cronjob.md"

--- a/keps/sig-apps/2185-random-pod-select-on-replicaset-downscale/kep.yaml
+++ b/keps/sig-apps/2185-random-pod-select-on-replicaset-downscale/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
 approvers:
   - "@janetkuo"
   - "@kow3ns"
-prr-approvers:
-  - "wojtek-t"
 see-also:
   - "/keps/sig-apps/1828-delete-priority-annotations"
 replaces:

--- a/keps/sig-apps/2232-suspend-jobs/kep.yaml
+++ b/keps/sig-apps/2232-suspend-jobs/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@alculquicondor"
 approvers:
   - "@janetkuo"
-prr-approvers:
-  - "@wojtek-t"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-apps/2255-pod-cost/kep.yaml
+++ b/keps/sig-apps/2255-pod-cost/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@alculquicondor"
 approvers:
   - "@janetkuo"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
   - https://github.com/kubernetes/kubernetes/issues/45509
   - https://github.com/kubernetes/kubernetes/issues/4301

--- a/keps/sig-apps/2307-job-tracking-without-lingering-pods/kep.yaml
+++ b/keps/sig-apps/2307-job-tracking-without-lingering-pods/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 - "@soltysh"
 approvers:
 - "@janetkuo"
-prr-approvers:
-- "@wojtek-t"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-apps/2599-minreadyseconds-for-statefulsets/kep.yaml
+++ b/keps/sig-apps/2599-minreadyseconds-for-statefulsets/kep.yaml
@@ -12,10 +12,6 @@ reviewers:
   - "@soltysh"
 approvers:
   - "@soltysh"
-prr-approvers:
-  - "@ehashman"
-  - "@deads2k"
-  - "@wojtek-t"
 see-also:
   - https://github.com/kubernetes/kubernetes/issues/65098
 

--- a/keps/sig-apps/2804-consolidate-workload-controllers-status/kep.yaml
+++ b/keps/sig-apps/2804-consolidate-workload-controllers-status/kep.yaml
@@ -13,9 +13,6 @@ reviewers:
   - "@soltysh"
 approvers:
   - "@soltysh"
-prr-approvers:
-  - "@ehashman"
-
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-apps/592-ttl-after-finish/kep.yaml
+++ b/keps/sig-apps/592-ttl-after-finish/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@tnozicka"
 approvers:
   - "@kow3ns"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
   - n/a
 replaces:

--- a/keps/sig-apps/85-Graduate-PDB-to-Stable/kep.yaml
+++ b/keps/sig-apps/85-Graduate-PDB-to-Stable/kep.yaml
@@ -18,8 +18,6 @@ approvers:
   - "@kow3ns"
   - "@liggitt"
   - "@wojtek-t"
-prr-approvers:
-  - "@wojtek-t"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-architecture/1143-node-role-labels/kep.yaml
+++ b/keps/sig-architecture/1143-node-role-labels/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@wojtek-t"
 creation-date: 2019-07-16
 last-updated: 2021-04-02
 status: implemented

--- a/keps/sig-architecture/3136-beta-apis-off-by-default/kep.yaml
+++ b/keps/sig-architecture/3136-beta-apis-off-by-default/kep.yaml
@@ -14,13 +14,6 @@ approvers:
   - "@derekwaynecarr"
   - "@dims"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "/keps/sig-architecture/1635-prevent-permabeta"
 replaces:

--- a/keps/sig-auth/1393-oidc-discovery/kep.yaml
+++ b/keps/sig-auth/1393-oidc-discovery/kep.yaml
@@ -17,8 +17,6 @@ approvers:
   - "@enj"
   - "@micahhausler"
   - "@ericchiang"
-prr-approvers:
-  - "@johnbelamaric"
 editor: TBD
 creation-date: 2018-06-26
 last-updated: 2020-01-25

--- a/keps/sig-auth/2579-psp-replacement/kep.yaml
+++ b/keps/sig-auth/2579-psp-replacement/kep.yaml
@@ -22,8 +22,6 @@ approvers:
   - "@IanColdwater"
   - "@mikedanese"
   - "@tabbysable"
-prr-approvers:
-  - "@deads2k"
 see-also:
   - https://github.com/kubernetes/enhancements/issues/2802
 replaces: []

--- a/keps/sig-auth/3325-self-subject-attributes-review-api/kep.yaml
+++ b/keps/sig-auth/3325-self-subject-attributes-review-api/kep.yaml
@@ -12,7 +12,6 @@ reviewers:
 - "@mikedanese"
 approvers:
 - TBD
-prr-approvers: []
 creation-date: "2022-05-30"
 status: implementable
 stage: alpha

--- a/keps/sig-auth/541-external-credential-providers/kep.yaml
+++ b/keps/sig-auth/541-external-credential-providers/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@liggitt"
   - "@mikedanese"
-prr-approvers:
-  - "@deads2k"
 stage: stable
 latest-milestone: "v1.22"
 milestone:

--- a/keps/sig-autoscaling/2702-graduate-hpa-api-to-GA/kep.yaml
+++ b/keps/sig-autoscaling/2702-graduate-hpa-api-to-GA/kep.yaml
@@ -10,8 +10,6 @@ reviewers:
 approvers:
   - "@josephburnett"
   - "@gjtempleton"
-prr-approvers:
-  - "@johnbelamaric"
 creation-date: 2021-05-10
 last-updated: 2021-09-08
 status: implemented

--- a/keps/sig-cli/2227-kubectl-default-container/kep.yaml
+++ b/keps/sig-cli/2227-kubectl-default-container/kep.yaml
@@ -16,9 +16,6 @@ reviewers:
 approvers:
   - "@soltysh"
   - "@rikatz"
-prr-approvers:
-  - "@johnbelamaric"
-  - "@deads2k"
 see-also:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-cli/2590-kubectl-subresource/kep.yaml
+++ b/keps/sig-cli/2590-kubectl-subresource/kep.yaml
@@ -10,8 +10,6 @@ reviewers:
   - "@soltysh"
 approvers:
   - "@soltysh"
-prr-approvers:
-  - "@johnbelamaric"
 
 creation-date: 2021-04-06
 last-updated: 2022-01-20

--- a/keps/sig-cli/3104-introduce-kuberc/kep.yaml
+++ b/keps/sig-cli/3104-introduce-kuberc/kep.yaml
@@ -13,13 +13,6 @@ reviewers:
 approvers:
   - "@soltysh"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - https://github.com/kubernetes/enhancements/issues/2775
 replaces: []

--- a/keps/sig-cli/859-kubectl-headers/kep.yaml
+++ b/keps/sig-cli/859-kubectl-headers/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - "@lavalamp"
 approvers:
   - "@soltysh"
-prr-approvers:
-  - "@deads2k"
 editor: TBD
 creation-date: 2019-02-22
 last-updated: 2019-05-11

--- a/keps/sig-cloud-provider/1959-service-lb-class-field/kep.yaml
+++ b/keps/sig-cloud-provider/1959-service-lb-class-field/kep.yaml
@@ -15,8 +15,6 @@ approvers:
   - "@bowei"
   - "@cheftako"
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-cloud-provider/2025-extend-konnectivity-for-both-directions/kep.yaml
+++ b/keps/sig-cloud-provider/2025-extend-konnectivity-for-both-directions/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
   - "@andrewsykim"
 approvers:
   - TBD
-prr-approvers:
-  - deads2k
 see-also:
   - "keps/sig-api-machinery/20190226-network-proxy.md"
 replaces:

--- a/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/kep.yaml
+++ b/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/kep.yaml
@@ -20,8 +20,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@liggit"
-prr-approvers:
-  - "@wojtek-t"
 editor: TBD
 creation-date: 2018-12-18
 last-updated: 2019-04-11

--- a/keps/sig-cloud-provider/2436-controller-manager-leader-migration/kep.yaml
+++ b/keps/sig-cloud-provider/2436-controller-manager-leader-migration/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - "@andrewsykim"
 approvers:
   - "@cheftako"
-prr-approvers:
-  - "@deads2k"
 creation-date: 2019-04-22
 status: implementable
 see-also:

--- a/keps/sig-cloud-provider/2699-add-webhook-hosting-to-ccm/kep.yaml
+++ b/keps/sig-cloud-provider/2699-add-webhook-hosting-to-ccm/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@jiahuif"
 approvers:
   - "@andrewsykim"
-prr-approvers:
-  - "@deads2k"
 see-also:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-cluster-lifecycle/kubeadm/2568-kubeadm-non-root-control-plane/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/2568-kubeadm-non-root-control-plane/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
 approvers:
   - "@neolit123"
   - "@fabriziopandini"
-prr-approvers:
-  - "@ehashman"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-instrumentation/1209-metrics-stability/kep.yaml
+++ b/keps/sig-instrumentation/1209-metrics-stability/kep.yaml
@@ -28,8 +28,6 @@ reviewers:
   - "@andrewsykim" # cloud-provider
 approvers:
   - "@brancz"
-prr-approvers:
-  - "@johnbelamaric" # PRR-reviewer
 see-also:
   - "/keps/sig-instrumentation/1206-metrics-overhaul"
 

--- a/keps/sig-instrumentation/1602-structured-logging/kep.yaml
+++ b/keps/sig-instrumentation/1602-structured-logging/kep.yaml
@@ -17,9 +17,6 @@ reviewers:
 approvers:
   - "@brancz"
   - "@thockin"
-prr-approvers:
-  - "@wojtek-t"
-  - "@johnbelamaric"
 see-also:
 replaces:
 stage: beta

--- a/keps/sig-instrumentation/1748-pod-resource-metrics/kep.yaml
+++ b/keps/sig-instrumentation/1748-pod-resource-metrics/kep.yaml
@@ -16,8 +16,6 @@ approvers:
   - "@brancz"
   - "@dashpole"
   - "@ahg-g"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
 replaces:
 latest-milestone: "v1.21"

--- a/keps/sig-instrumentation/2305-metrics-cardinality-enforcement/kep.yaml
+++ b/keps/sig-instrumentation/2305-metrics-cardinality-enforcement/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@x13n"
 approvers:
   - "@ehashman"
-prr-approvers:
-  - "@johnbelamaric"
 creation-date: 2020-04-15
 last-updated: 2021-02-08
 stage: alpha

--- a/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
+++ b/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
@@ -17,8 +17,6 @@ reviewers:
 approvers:
   - "@brancz"
   - "@lavalamp"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 replaces:
 stage: beta

--- a/keps/sig-multicluster/2149-clusterid/kep.yaml
+++ b/keps/sig-multicluster/2149-clusterid/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
   - "@mikedanese"
 approvers:
   - "@pmorie"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
   - "/keps/sig-multicluster/1645-multi-cluster-services-api"
 #replaces:

--- a/keps/sig-network/0752-endpointslices/kep.yaml
+++ b/keps/sig-network/0752-endpointslices/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@bowei"
   - "@thockin"
-prr-approvers:
-  - "@wojtek-t"
 creation-date: 2019-06-01
 last-updated: 2021-08-19
 status: implemented

--- a/keps/sig-network/1435-mixed-protocol-lb/kep.yaml
+++ b/keps/sig-network/1435-mixed-protocol-lb/kep.yaml
@@ -14,7 +14,6 @@ reviewers:
   - "@andrewsykim"
 approvers:
   - "@thockin"
-prr-approvers:
 see-also:
 replaces:
   - "/keps/sig-network/ 20200103-mixed-protocol-lb"

--- a/keps/sig-network/1507-app-protocol/kep.yaml
+++ b/keps/sig-network/1507-app-protocol/kep.yaml
@@ -9,8 +9,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@dcbw"
-prr-approvers:
-  - "@deads2k"
 creation-date: "2019-12-27"
 last-updated: "2021-02-05"
 status: implementable

--- a/keps/sig-network/1669-proxy-terminating-endpoints/kep.yaml
+++ b/keps/sig-network/1669-proxy-terminating-endpoints/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@smarterclayton"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 creation-date: 2020-04-07
 last-updated: 2022-01-21
 status: implementable

--- a/keps/sig-network/1864-disable-lb-node-ports/kep.yaml
+++ b/keps/sig-network/1864-disable-lb-node-ports/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
   - "@rikatz"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-network/1880-multiple-service-cidrs/kep.yaml
+++ b/keps/sig-network/1880-multiple-service-cidrs/kep.yaml
@@ -15,13 +15,6 @@ approvers:
   - "@thockin"
   - "@lavalamp"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "keps/sig-network/3070-reserved-service-ip-range"
 replaces:

--- a/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
+++ b/keps/sig-network/2086-service-internal-traffic-policy/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "thockin"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
   - "/keps/sig-network/2004-topology-aware-subsetting"
   - "/keps/sig-network/20181024-service-topology.md"

--- a/keps/sig-network/2091-admin-network-policy/kep.yaml
+++ b/keps/sig-network/2091-admin-network-policy/kep.yaml
@@ -17,8 +17,6 @@ reviewers:
   - "@danwinship"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-network/2200-externalips-admission/kep.yaml
+++ b/keps/sig-network/2200-externalips-admission/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@tallclair"
   - "@lavalamp"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
   - "https://github.com/kubernetes/kubernetes/issues/97110"
 

--- a/keps/sig-network/2365-ingressclass-namespaced-params/kep.yaml
+++ b/keps/sig-network/2365-ingressclass-namespaced-params/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - "@bowei"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
   - "/keps/sig-network/1453-ingress-api"
 

--- a/keps/sig-network/2433-topology-aware-hints/kep.yaml
+++ b/keps/sig-network/2433-topology-aware-hints/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@wojtek-t"
-prr-approvers:
-  - "@wojtek-t"
 
 see-also:
   - "https://docs.google.com/document/d/1ZzUoFY1SrdjVefl7gVOJZJLt1I1LHttw8pcX95nlgMY/edit?usp=sharing"

--- a/keps/sig-network/2593-multiple-cluster-cidrs/kep.yaml
+++ b/keps/sig-network/2593-multiple-cluster-cidrs/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@aojea"
-prr-approvers:
-  - "@wojtek-t"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-network/2595-expanded-dns-config/kep.yaml
+++ b/keps/sig-network/2595-expanded-dns-config/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@sftim"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
 replaces:
 

--- a/keps/sig-network/2943-networkpolicy-status/kep.yaml
+++ b/keps/sig-network/2943-networkpolicy-status/kep.yaml
@@ -17,13 +17,6 @@ approvers:
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha 
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "/keps/sig-network/2079-network-policy-port-range"
 

--- a/keps/sig-network/563-dual-stack/kep.yaml
+++ b/keps/sig-network/563-dual-stack/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
   - "@danwinship"
 approvers:
   - "@thockin"
-prr-approvers:
-  - "@johnbelamaric"
 editor: TBD
 creation-date: "2018-05-21"
 last-updated: "2022-01-03"

--- a/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
+++ b/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
@@ -27,8 +27,6 @@ approvers:
   - "@ahg-g"
   - "@mwielgus"
   - "@thockin"
-prr-approvers:
-  - "@ehashman"
 see-also:
 replaces:
 

--- a/keps/sig-node/1539-hugepages/kep.yaml
+++ b/keps/sig-node/1539-hugepages/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@vishnu"
 approvers:
   - "@dawnchen"
-prr-approvers:
-  - "@ehashman"
 stage: stable
 latest-milestone: "v1.22"
 # The milestone at which this feature was, or is targeted to be, at each stage.

--- a/keps/sig-node/1769-memory-manager/kep.yaml
+++ b/keps/sig-node/1769-memory-manager/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@derekwaynecarr"
 approvers:
   - "@derekwaynecarr"
-prr-approvers:
-  - "@deads2k"
 see-also:
 replaces:
 

--- a/keps/sig-node/1797-configure-fqdn-as-hostname-for-pods/kep.yaml
+++ b/keps/sig-node/1797-configure-fqdn-as-hostname-for-pods/kep.yaml
@@ -17,8 +17,6 @@ reviewers:
   - "@wojtek-t"
 approvers:
   - "@dchen1107"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
   - "N/A"
 replaces:

--- a/keps/sig-node/1967-size-memory-backed-volumes/kep.yaml
+++ b/keps/sig-node/1967-size-memory-backed-volumes/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@dashpole"
 approvers:
   - "@dashpole"
-prr-approvers:
-  - johnbelamaric
 see-also:
 replaces:
 

--- a/keps/sig-node/2000-graceful-node-shutdown/kep.yaml
+++ b/keps/sig-node/2000-graceful-node-shutdown/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
 approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@johnbelamaric"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-node/2008-forensic-container-checkpointing/kep.yaml
+++ b/keps/sig-node/2008-forensic-container-checkpointing/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
   - "@elfinhe"
 approvers:
   - "@dchen1107"
-prr-approvers:
-  - "@ehashman"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-node/2033-kubelet-in-userns-aka-rootless/kep.yaml
+++ b/keps/sig-node/2033-kubelet-in-userns-aka-rootless/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
   - "@sftim"
 approvers:
   - TBD
-prr-approvers:
-  - "@ehashman"
 see-also:
   # `add KEP for cgroups v2 support`
   - "https://github.com/kubernetes/enhancements/pull/1370"

--- a/keps/sig-node/2040-kubelet-cri/kep.yaml
+++ b/keps/sig-node/2040-kubelet-cri/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
 approvers:
   - "@derekwaynecarr"
   - "@dchen1107"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-node/2053-downward-api-hugepages/kep.yaml
+++ b/keps/sig-node/2053-downward-api-hugepages/kep.yaml
@@ -13,10 +13,6 @@ approvers:
   - "@dashpole"
   - "@sjenning"
   - "@dchen1107"
-prr-approvers:
-  - "deads2k"
-  - "johnbelamaric"
-  - "wojtek-t"
 see-also:
   - "/keps/sig-node/20190129-hugepages.md"
 replaces: []

--- a/keps/sig-node/2129-remove-cadvisor-json-metrics/kep.yaml
+++ b/keps/sig-node/2129-remove-cadvisor-json-metrics/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "derekwaynecarr"
   - "dawnchen"
-prr-approvers:
-  - "@johnbelamaric"
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-node/213-run-as-group/kep.yaml
+++ b/keps/sig-node/213-run-as-group/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 approvers:
   - "@liggitt"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@johnbelamaric"
 editor: TBD
 creation-date: 2017-06-21
 last-updated: 2021-04-08

--- a/keps/sig-node/2133-kubelet-credential-providers/kep.yaml
+++ b/keps/sig-node/2133-kubelet-credential-providers/kep.yaml
@@ -17,8 +17,6 @@ approvers:
   - "@cheftako"
   - "@liggitt"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@deads2k"
 replaces:
   - "/keps/sig-cloud-provider/20191004-out-of-tree-credential-providers.md"
 

--- a/keps/sig-node/2221-remove-dockershim/kep.yaml
+++ b/keps/sig-node/2221-remove-dockershim/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
 approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
-prr-approvers:
-  - johnbelamaric
 see-also:
 replaces:
 

--- a/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
+++ b/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
   - "@mikebrow"
 approvers:
   - "@dchen1107"
-prr-approvers:
-  - "@ehashman"
 creation-date: 2021-01-27
 last-updated: 2022-06-16
 status: implementable

--- a/keps/sig-node/2400-node-swap/kep.yaml
+++ b/keps/sig-node/2400-node-swap/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
 approvers:
   - "@derekwaynecarr"
   - "@dchen1107"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-node/2403-pod-resources-allocatable-resources/kep.yaml
+++ b/keps/sig-node/2403-pod-resources-allocatable-resources/kep.yaml
@@ -15,7 +15,6 @@ reviewers:
   - "@klueska"
 approvers:
   - "@sig-node-leads"
-prr-approvers: []
 see-also:
   - "keps/sig-node/606-compute-device-assignment/"
   - "keps/sig-node/2043-pod-resource-concrete-assigments/"

--- a/keps/sig-node/2411-cri-container-log-rotation/kep.yaml
+++ b/keps/sig-node/2411-cri-container-log-rotation/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
 approvers:
   - "@mrunalp"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-node/2413-seccomp-by-default/kep.yaml
+++ b/keps/sig-node/2413-seccomp-by-default/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
   - "@tallclair"
 approvers:
   - "@mrunalp"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-node/2535-ensure-secret-pulled-images/kep.yaml
+++ b/keps/sig-node/2535-ensure-secret-pulled-images/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@johnbelarmic"
 stage: alpha
 latest-milestone: "v1.24"
 milestone:

--- a/keps/sig-node/2570-memory-qos/kep.yaml
+++ b/keps/sig-node/2570-memory-qos/kep.yaml
@@ -9,8 +9,6 @@ reviewers:
   - "@giuseppe"
 approvers:
   - "@derekwaynecarr"
-prr-approvers:
-  - "@johnbelamaric"
 owning-sig: sig-node
 status: implementable
 editor: TBD

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - "@klueska"
 approvers:
   - "@sig-node-leads"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
 - "keps/sig-node/2902-cpumanager-distribute-cpus-policy-option/"
 replaces: []

--- a/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown/kep.yaml
+++ b/keps/sig-node/2712-pod-priority-based-graceful-node-shutdown/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@SergeyKanzhelev"
 approvers:
   - "@derekwaynecarr"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta

--- a/keps/sig-node/2727-grpc-probe/kep.yaml
+++ b/keps/sig-node/2727-grpc-probe/kep.yaml
@@ -18,8 +18,6 @@ approvers:
   - "@thockin"
   - "@dchen1107"
 see-also:
-prr-approvers:
-  - "@johnbelarmic"
 stage: "beta"
 latest-milestone: "v1.24"
 milestone:

--- a/keps/sig-node/277-ephemeral-containers/kep.yaml
+++ b/keps/sig-node/277-ephemeral-containers/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@dchen1107"
   - "@liggitt"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
   - "/keps/sig-cli/1441-kubectl-debug"
 

--- a/keps/sig-node/3085-pod-conditions-for-starting-completition-of-sandbox-creation/kep.yaml
+++ b/keps/sig-node/3085-pod-conditions-for-starting-completition-of-sandbox-creation/kep.yaml
@@ -15,13 +15,6 @@ approvers:
   - "@derekwaynecarr"
   - "@aojea"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - none
 replaces:

--- a/keps/sig-node/3386-kubelet-evented-pleg/kep.yaml
+++ b/keps/sig-node/3386-kubelet-evented-pleg/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@SergeyKanzhelev"
 approvers:
   - "@derekwaynecarr"
-prr-approvers:
-  - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-node/34-sysctl-fields/kep.yaml
+++ b/keps/sig-node/34-sysctl-fields/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@derekwaynecarr"
 approvers:
   - "@derekwaynecarr"
-prr-approvers:
-  - "@johnbelamaric"
 editor:
 creation-date: 2018-04-30
 last-updated: 2021-04-08

--- a/keps/sig-release/2818-reducing-build-maintenance/kep.yaml
+++ b/keps/sig-release/2818-reducing-build-maintenance/kep.yaml
@@ -14,9 +14,6 @@ approvers:
   - "@amwat"
   - "@justaugustus"
 
-prr-approvers:
-  - "@ehashman"
-
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable
 

--- a/keps/sig-scheduling/1258-default-pod-topology-spread/kep.yaml
+++ b/keps/sig-scheduling/1258-default-pod-topology-spread/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 approvers:
 - "@ahg-g"
 - "@Huang-Wei"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 - "/keps/sig-scheduling/895-pod-topology-spread"
 stage: stable

--- a/keps/sig-scheduling/1923-prefer-nominated-node/kep.yaml
+++ b/keps/sig-scheduling/1923-prefer-nominated-node/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
 approvers:
   - "@Huang-Wei"
   - "@ahg-g"
-prr-approvers:
-  - "@wojtek-t"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-scheduling/2249-pod-affinity-namespace-selector/kep.yaml
+++ b/keps/sig-scheduling/2249-pod-affinity-namespace-selector/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
 approvers:
   - "@Huang-Wei"
   - "@liggitt"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-scheduling/2458-node-resource-score-strategy/kep.yaml
+++ b/keps/sig-scheduling/2458-node-resource-score-strategy/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@Huang-Wei"
 approvers:
   - "@Huang-Wei"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-scheduling/2891-simplified-config/kep.yaml
+++ b/keps/sig-scheduling/2891-simplified-config/kep.yaml
@@ -14,13 +14,6 @@ approvers:
   - "@ahg-g"
   - "@Huang-Wei"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "keps/sig-scheduling/624-scheduling-framework"
 

--- a/keps/sig-scheduling/2926-job-mutable-scheduling-directives/kep.yaml
+++ b/keps/sig-scheduling/2926-job-mutable-scheduling-directives/kep.yaml
@@ -14,13 +14,6 @@ reviewers:
 approvers:
   - "@Huang-Wei"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "/keps/sig-apps/2232-suspend-jobs"
 

--- a/keps/sig-scheduling/3094-pod-topology-spread-considering-taints/kep.yaml
+++ b/keps/sig-scheduling/3094-pod-topology-spread-considering-taints/kep.yaml
@@ -17,13 +17,6 @@ see-also:
   - "/keps/sig-scheduling/895-pod-topology-spread"
   - "/keps/sig-scheduling/1258-default-pod-topology-spread"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/kep.yaml
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/kep.yaml
@@ -16,13 +16,6 @@ see-also:
   - "/keps/sig-scheduling/3022-min-domains-in-pod-topology-spread"
   - "/keps/sig-scheduling/3094-pod-topology-spread-considering-taints"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 

--- a/keps/sig-scheduling/785-scheduler-component-config-api/kep.yaml
+++ b/keps/sig-scheduling/785-scheduler-component-config-api/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
 approvers:
   - "@ahg-g"
   - "@liggitt"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
   - "/keps/sig-scheduling/1451-multi-scheduling-profiles"
   - "/keps/sig-scheduling/2458-node-resource-score-strategy"

--- a/keps/sig-security/1933-secret-logging-static-analysis/kep.yaml
+++ b/keps/sig-security/1933-secret-logging-static-analysis/kep.yaml
@@ -18,8 +18,6 @@ reviewers:
 approvers:
 - "@dashpole"
 - "@ehashman"
-prr-approvers:
-- "@deads2k"
 see-also:
 - /keps/sig-instrumentation/1753-logs-sanitization
 - /keps/sig-instrumentation/1602-structured-logging

--- a/keps/sig-storage/1412-immutable-secrets-and-configmaps/kep.yaml
+++ b/keps/sig-storage/1412-immutable-secrets-and-configmaps/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@msau42"
 approvers:
   - "@saad-ali"
-prr-approvers:
-  - "@johnbelamaric"
 creation-date: 2019-11-17
 last-updated: 2020-12-10
 see-also:

--- a/keps/sig-storage/1472-storage-capacity-tracking/kep.yaml
+++ b/keps/sig-storage/1472-storage-capacity-tracking/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@saad-ali"
   - "@msau42"
-prr-approvers:
-  - "@wojtek-t"
 stage: stable
 see-also:
   - "https://docs.google.com/document/d/1WtX2lRJjZ03RBdzQIZY3IOvmoYiF5JxDX35-SsCIAfg"

--- a/keps/sig-storage/1487-csi-migration-aws/kep.yaml
+++ b/keps/sig-storage/1487-csi-migration-aws/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/1489-csi-migration-cinder/kep.yaml
+++ b/keps/sig-storage/1489-csi-migration-cinder/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/1490-csi-migration-azuredisk/kep.yaml
+++ b/keps/sig-storage/1490-csi-migration-azuredisk/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/1491-csi-migration-vsphere/kep.yaml
+++ b/keps/sig-storage/1491-csi-migration-vsphere/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/1495-volume-populators/kep.yaml
+++ b/keps/sig-storage/1495-volume-populators/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
 approvers:
   - "@thockin"
   - "@saad-ali"
-prr-approvers:
-  - "@deads2k"
 replaces:
   - "/keps/sig-storage/20200120-generic-data-populators.md"
 stage: beta

--- a/keps/sig-storage/1698-generic-ephemeral-volumes/kep.yaml
+++ b/keps/sig-storage/1698-generic-ephemeral-volumes/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@jsafrane"
 approvers:
   - "@saad-ali"
-prr-approvers:
-  - "@wojtek-t"
 stage: stable
 latest-milestone: "v1.23"
 milestone:

--- a/keps/sig-storage/1790-recover-resize-failure/kep.yaml
+++ b/keps/sig-storage/1790-recover-resize-failure/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@saad-ali"
   - "@xing-yang"
-prr-approvers:
-  - "@deads2k"
 editor: TBD
 creation-date: 2020-01-27
 last-updated: 2022-01-26

--- a/keps/sig-storage/1845-prioritization-on-volume-capacity/kep.yaml
+++ b/keps/sig-storage/1845-prioritization-on-volume-capacity/kep.yaml
@@ -17,8 +17,6 @@ approvers:
   - "@jsafrane"
   - "@Huang-Wei"
   - "@ahg-g"
-prr-approvers:
-  - "@wojtek-t"
 
 stage: alpha
 

--- a/keps/sig-storage/1885-csi-migration-azurefile/kep.yaml
+++ b/keps/sig-storage/1885-csi-migration-azurefile/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/2317-fsgroup-on-mount/kep.yaml
+++ b/keps/sig-storage/2317-fsgroup-on-mount/kep.yaml
@@ -12,7 +12,6 @@ reviewers:
   - "@jsafrane"
 approvers:
   - "@msau42"
-prr-approvers:
 see-also:
   - https://github.com/kubernetes/enhancements/issues/1682
 replaces:

--- a/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/kep.yaml
+++ b/keps/sig-storage/2485-read-write-once-pod-pv-access-mode/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
   - "@alculquicondor"
 approvers:
   - "@msau42"
-prr-approvers:
-  - "@ehashman"
 see-also:
 replaces:
 

--- a/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
+++ b/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@ehashman"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/2644-honor-pv-reclaim-policy/kep.yaml
+++ b/keps/sig-storage/2644-honor-pv-reclaim-policy/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@jsafrane"
   - "@xing-yang"
-prr-approvers:
-  - "@ehashman"
 see-also:
 replaces:
 

--- a/keps/sig-storage/2923-csi-migration-ceph-rbd/kep.yaml
+++ b/keps/sig-storage/2923-csi-migration-ceph-rbd/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@ehashman"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/2924-csi-migration-cephfs/kep.yaml
+++ b/keps/sig-storage/2924-csi-migration-cephfs/kep.yaml
@@ -17,8 +17,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-storage/3333-reconcile-default-storage-class/kep.yaml
+++ b/keps/sig-storage/3333-reconcile-default-storage-class/kep.yaml
@@ -12,13 +12,6 @@ reviewers:
 approvers:
   - TBD
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
 replaces:
 

--- a/keps/sig-storage/625-csi-migration/kep.yaml
+++ b/keps/sig-storage/625-csi-migration/kep.yaml
@@ -19,8 +19,6 @@ disable-supported: true
 status: implementable
 see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/625-csi-migration/csi-migration-design.md"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/kep.yaml
+++ b/keps/sig-testing/2420-reducing-kubernetes-build-maintenance/kep.yaml
@@ -15,9 +15,6 @@ reviewers:
 approvers:
   - spiffxp
   - justaugustus
-# NOTE: there's no production change in this KEP
-prr-approvers:
-  - johnbelamaric
 see-also: []
 replaces: []
 

--- a/keps/sig-testing/2464-kubetest2-ci-migration/kep.yaml
+++ b/keps/sig-testing/2464-kubetest2-ci-migration/kep.yaml
@@ -14,9 +14,6 @@ reviewers:
 approvers:
 - spiffxp
 - saschagrunert
-# NOTE: there's no production change in this KEP
-prr-approvers:
-- johnbelamaric 
 see-also: []
 replaces: []
 

--- a/keps/sig-windows/1981-windows-privileged-container-support/kep.yaml
+++ b/keps/sig-windows/1981-windows-privileged-container-support/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
 approvers:
   - "@liggitt"
   - "@yujuhong"
-prr-approvers:
-  - "@deads2k"
 see-also:
 replaces:
 

--- a/keps/sig-windows/2258-node-service-log-viewer/kep.yaml
+++ b/keps/sig-windows/2258-node-service-log-viewer/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
   - "@thockin"
 approvers:
   - "@marosset"
-prr-approvers:
-  - "@johnbelamaric"
 creation-date: 2021-01-14
 last-updated: 2022-06-06
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-windows/2578-windows-conformance/kep.yaml
+++ b/keps/sig-windows/2578-windows-conformance/kep.yaml
@@ -18,8 +18,6 @@ reviewers:
   - "@jsturtevant"
 approvers:
   - "@marosset"
-prr-approvers:
-  - "@deads2k"
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 

--- a/keps/sig-windows/2802-identify-windows-pods-apiserver-admission/kep.yaml
+++ b/keps/sig-windows/2802-identify-windows-pods-apiserver-admission/kep.yaml
@@ -14,8 +14,6 @@ reviewers:
   - "@jsturtevant"
 approvers:
   - "@jsturtevant"
-prr-approvers:
-  - "@deads2k"
 creation-date: 2021-06-28
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable


### PR DESCRIPTION
Eventually we want to get rid of this field completely.

There are still couple KEPs where this is left, as they don't have corresponding file in prod-readiness directory.
To avoid loosing information, I'm going to propagate that in a separate PR.

/assign @johnbelamaric 