### PR TITLE
KEP 1981 Windows HostProcessContainers to stable

### DIFF
--- a/keps/sig-windows/1981-windows-privileged-container-support/kep.yaml
+++ b/keps/sig-windows/1981-windows-privileged-container-support/kep.yaml
@@ -21,12 +21,12 @@ replaces:
 
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.25"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP updates for moving `WindowsHostProcessContainers` to stable

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1981

<!-- other comments or additional information -->
- Other comments: