### PR TITLE
Remove prr approvers 2

### DIFF
--- a/keps/NNNN-kep-template/kep.yaml
+++ b/keps/NNNN-kep-template/kep.yaml
@@ -15,13 +15,6 @@ approvers:
   - TBD
   - "@oscar.doe"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "/keps/sig-aaa/1234-we-heard-you-like-keps"
   - "/keps/sig-bbb/2345-everyone-gets-a-kep"

--- a/keps/prod-readiness/sig-api-machinery/1929.yaml
+++ b/keps/prod-readiness/sig-api-machinery/1929.yaml
@@ -1,0 +1,3 @@
+kep-number: 1929
+stable:
+  approver: "@deads2k"

--- a/keps/prod-readiness/sig-architecture/1659.yaml
+++ b/keps/prod-readiness/sig-architecture/1659.yaml
@@ -1,0 +1,3 @@
+kep-number: 1659
+stable:
+  approver: "@johnbelamaric"

--- a/keps/prod-readiness/sig-architecture/2527.yaml
+++ b/keps/prod-readiness/sig-architecture/2527.yaml
@@ -1,0 +1,3 @@
+kep-number: 2527
+stable:
+  approver: "@johnbelamaric"

--- a/keps/prod-readiness/sig-cli/1020.yaml
+++ b/keps/prod-readiness/sig-cli/1020.yaml
@@ -1,0 +1,3 @@
+kep-number: 1020
+stable:
+  approver: "@deads2k"

--- a/keps/prod-readiness/sig-instrumentation/1753.yaml
+++ b/keps/prod-readiness/sig-instrumentation/1753.yaml
@@ -1,0 +1,3 @@
+kep-number: 1753
+alpha:
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-instrumentation/383.yaml
+++ b/keps/prod-readiness/sig-instrumentation/383.yaml
@@ -1,0 +1,3 @@
+kep-number: 383
+stable:
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-network/1453.yaml
+++ b/keps/prod-readiness/sig-network/1453.yaml
@@ -1,0 +1,3 @@
+kep-number: 1453
+stable:
+  approver: "wojtek-t"

--- a/keps/prod-readiness/sig-node/1898.yaml
+++ b/keps/prod-readiness/sig-node/1898.yaml
@@ -1,0 +1,6 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group 
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 1898
+alpha:
+  approver: "deads2k"

--- a/keps/prod-readiness/sig-node/281.yaml
+++ b/keps/prod-readiness/sig-node/281.yaml
@@ -1,0 +1,6 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group 
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 281
+removed:
+  approver: "@johnbelamaric"

--- a/keps/prod-readiness/sig-scheduling/1451.yaml
+++ b/keps/prod-readiness/sig-scheduling/1451.yaml
@@ -1,0 +1,3 @@
+kep-number: 1451
+beta:
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-scheduling/1819.yaml
+++ b/keps/prod-readiness/sig-scheduling/1819.yaml
@@ -1,0 +1,3 @@
+kep-number: 1819
+stable:
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-security/2763.yaml
+++ b/keps/prod-readiness/sig-security/2763.yaml
@@ -1,0 +1,3 @@
+kep-number: 2730
+alpha:
+  approver: "@ehashman"

--- a/keps/prod-readiness/sig-storage/177.yaml
+++ b/keps/prod-readiness/sig-storage/177.yaml
@@ -1,0 +1,3 @@
+kep-number: 177
+stable:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/1929-built-in-default/kep.yaml
+++ b/keps/sig-api-machinery/1929-built-in-default/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - kensipe
 approvers:
   - TBD
-prr-approvers:
-  - deads2k
 see-also:
   - "/keps/sig-api-machinery/20190426-crd-defaulting.md"
 stage: stable

--- a/keps/sig-api-machinery/3157-watch-list/kep.yaml
+++ b/keps/sig-api-machinery/3157-watch-list/kep.yaml
@@ -14,13 +14,6 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
 replaces:
 

--- a/keps/sig-api-machinery/365-paginated-lists/kep.yaml
+++ b/keps/sig-api-machinery/365-paginated-lists/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
 approvers:
   - "@deads2k"
   - "@lavalamp"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 replaces:
 

--- a/keps/sig-architecture/1659-standard-topology-labels/kep.yaml
+++ b/keps/sig-architecture/1659-standard-topology-labels/kep.yaml
@@ -16,8 +16,6 @@ approvers:
 see-also: []
 replaces: []
 
-prr-approvers:
-  - "@johnbelamaric"
 stage: stable
 feature-gates: []
 disable-supported: false

--- a/keps/sig-architecture/2527-clarify-status-observations-vs-rbac/kep.yaml
+++ b/keps/sig-architecture/2527-clarify-status-observations-vs-rbac/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - "@smarterclayton"
 approvers:
   - "@liggitt"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
   - https://groups.google.com/g/kubernetes-sig-architecture/c/d96tt2Mw69s
 replaces: []

--- a/keps/sig-cli/1020-kubectl-staging/kep.yaml
+++ b/keps/sig-cli/1020-kubectl-staging/kep.yaml
@@ -12,8 +12,6 @@ reviewers:
   - "@liggitt"
 approvers:
   - "@pwittrock"
-prr-approvers:
-  - "@deads2k"
 see-also:
 replaces:
 

--- a/keps/sig-cli/2953-kustomize-plugin-graduation/kep.yaml
+++ b/keps/sig-cli/2953-kustomize-plugin-graduation/kep.yaml
@@ -14,13 +14,6 @@ reviewers:
 approvers:
   - "@monopole"
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 see-also:
   - "/keps/sig-cli/2299-kustomize-plugin-composition"
   - "https://github.com/kubernetes/enhancements/pull/2908"

--- a/keps/sig-cli/2985-public-krm-functions-registry/kep.yaml
+++ b/keps/sig-cli/2985-public-krm-functions-registry/kep.yaml
@@ -17,13 +17,6 @@ approvers:
 status: provisional
 creation-date: 2021-09-21
 
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
-
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 

--- a/keps/sig-instrumentation/1753-logs-sanitization/kep.yaml
+++ b/keps/sig-instrumentation/1753-logs-sanitization/kep.yaml
@@ -19,6 +19,4 @@ reviewers:
   - "@ehashman"
 approvers:
   - "@dashpole"
-prr-approvers:
-  - "@wojtek-t"
 disable-supported: true

--- a/keps/sig-instrumentation/383-new-event-api-ga-graduation/kep.yaml
+++ b/keps/sig-instrumentation/383-new-event-api-ga-graduation/kep.yaml
@@ -13,8 +13,6 @@ reviewers:
   - "@wojtek-t"
 approvers:
   - "@brancz"
-prr-approvers:
-  - "@wojtek-t"
 creation-date: 2019-01-31
 last-updated: 2021-02-03
 status: implementable

--- a/keps/sig-network/1453-ingress-api/kep.yaml
+++ b/keps/sig-network/1453-ingress-api/kep.yaml
@@ -14,8 +14,6 @@ approvers:
   - "@caseydavenport"
   - "@ligitt"
   - "@thockin"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
 replaces:
   - "/keps/sig-network/20190125-ingress-api-group.md "

--- a/keps/sig-network/614-SCTP-support/kep.yaml
+++ b/keps/sig-network/614-SCTP-support/kep.yaml
@@ -10,7 +10,6 @@ reviewers:
   - "@thockin"
 approvers:
   - "@thockin"
-prr-approvers:
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable

--- a/keps/sig-node/1867-disable-accelerator-usage-metrics/kep.yaml
+++ b/keps/sig-node/1867-disable-accelerator-usage-metrics/kep.yaml
@@ -14,10 +14,6 @@ approvers:
   - "dashpole"
   - "derekwaynecarr"
   - "dawnchen"
-prr-approvers:
-  - "deads2k"
-  - "johnbelamaric"
-  - "wojtek-t"
 see-also:
   - "/keps/sig-node/606-compute-device-assignment"
 replaces: []

--- a/keps/sig-node/1898-hardened-exec/kep.yaml
+++ b/keps/sig-node/1898-hardened-exec/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - derekwaynecarr
   - liggitt
-prr-approvers:
-  - deads2k
 see-also:
   - "/keps/sig-node/20191205-container-streaming-requests.md"
 

--- a/keps/sig-node/2043-pod-resource-concrete-assigments/kep.yaml
+++ b/keps/sig-node/2043-pod-resource-concrete-assigments/kep.yaml
@@ -16,7 +16,6 @@ reviewers:
   - "@dashpole"
 approvers:
   - "@sig-node-leads"
-prr-approvers: []
 see-also:
   - "keps/sig-node/606-compute-device-assignment/"
 replaces: []

--- a/keps/sig-node/281-dynamic-kubelet-configuration/kep.yaml
+++ b/keps/sig-node/281-dynamic-kubelet-configuration/kep.yaml
@@ -15,8 +15,6 @@ reviewers:
 approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
-prr-approvers:
-  - "@johnbelamaric"
 see-also:
 replaces:
 

--- a/keps/sig-node/585-runtime-class/kep.yaml
+++ b/keps/sig-node/585-runtime-class/kep.yaml
@@ -14,7 +14,6 @@ reviewers:
 approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
-prr-approvers: []
 see-also: []
 replaces: []
 

--- a/keps/sig-node/606-compute-device-assignment/kep.yaml
+++ b/keps/sig-node/606-compute-device-assignment/kep.yaml
@@ -15,7 +15,6 @@ reviewers:
   - "@vishh"
 approvers:
   - "@sig-node-leads"
-prr-approvers: []
 see-also: []
 replaces: []
 

--- a/keps/sig-release/2853-k-core-branch-rename/kep.yaml
+++ b/keps/sig-release/2853-k-core-branch-rename/kep.yaml
@@ -19,12 +19,6 @@ approvers:
   - "@justaugustus"
 
 status: provisional
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
 
 #see-also:
 #  - "/keps/sig-aaa/1234-we-heard-you-like-keps"

--- a/keps/sig-release/3027-slsa-compliance/kep.yaml
+++ b/keps/sig-release/3027-slsa-compliance/kep.yaml
@@ -17,12 +17,6 @@ approvers:
   - "@saschagrunert"
 
 # status: provisional|implementable|implemented|deferred|rejected|withdrawn|replaced
-##### WARNING !!! ######
-# prr-approvers has been moved to its own location
-# You should create your own in keps/prod-readiness
-# Please make a copy of keps/prod-readiness/template/nnnn.yaml
-# to keps/prod-readiness/sig-xxxxx/00000.yaml (replace with kep number)
-#prr-approvers:
 
 #see-also:
 #  - "/keps/sig-aaa/1234-we-heard-you-like-keps"

--- a/keps/sig-scheduling/1451-multi-scheduling-profiles/kep.yaml
+++ b/keps/sig-scheduling/1451-multi-scheduling-profiles/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
   - "@liggitt"
 approvers:
   - "@Huang-Wei"
-prr-approvers:
-  - "@wojtek-t"
 see-also:
   - "/keps/sig-scheduling/20180409-scheduling-framework.md"
   - "/keps/sig-scheduling/20190226-default-even-pod-spreading.md"

--- a/keps/sig-scheduling/1819-scheduler-extender/kep.yaml
+++ b/keps/sig-scheduling/1819-scheduler-extender/kep.yaml
@@ -11,8 +11,6 @@ reviewers:
 approvers:
   - "@ahg-g"
   - "@Huang-Wei"
-prr-approvers:
-  - "@wojtek-t"
 replaces:
   - "https://github.com/cofyc/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md"
 

--- a/keps/sig-security/2763-ambient-capabilities/kep.yaml
+++ b/keps/sig-security/2763-ambient-capabilities/kep.yaml
@@ -16,8 +16,6 @@ reviewers:
   - "@SergeyKanzhelev" # sig-node and CRI API
 approvers:
   - "@tabbysable"
-prr-approvers:
-  - "@ehashman"
 see-also:
   - TBD
 replaces:

--- a/keps/sig-storage/177-volume-snapshot/kep.yaml
+++ b/keps/sig-storage/177-volume-snapshot/kep.yaml
@@ -17,8 +17,6 @@ approvers:
   - "@msau42"
   - "@saad-ali"
   - "@thockin"
-prr-approvers:
-  - "@deads2k"
 see-also:
   - "keps/sig-storage/1900-volume-snapshot-validation-webhook"
 

--- a/keps/sig-storage/2261-staging-mount-library/kep.yaml
+++ b/keps/sig-storage/2261-staging-mount-library/kep.yaml
@@ -11,7 +11,6 @@ reviewers:
   - "@thockin"
 approvers:
   - "@msau42"
-prr-approvers:
 see-also:
 replaces:
 

--- a/keps/sig-storage/2263-volume-scale-testing/kep.yaml
+++ b/keps/sig-storage/2263-volume-scale-testing/kep.yaml
@@ -14,7 +14,6 @@ reviewers:
 approvers:
   - "@saad-ali"
   - "@wojtek-t"
-prr-approvers:
 see-also:
   - "https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md"
   - "https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/docs/design.md"

--- a/keps/sig-storage/2264-csi-release-ci-process/kep.yaml
+++ b/keps/sig-storage/2264-csi-release-ci-process/kep.yaml
@@ -11,7 +11,6 @@ reviewers:
   - "@saad-ali"
 approvers:
   - "@msau42"
-prr-approvers:
 see-also:
 replaces:
 


### PR DESCRIPTION
This continues the process started in https://github.com/kubernetes/enhancements/pull/3538

Given we have the coresponding files in prod-readiness/ directory, there is no point in keeping a copy of that in kep.yaml.
The remaining thing is to change the API package to get rid of parsing prr-approvers field.

/assign @johnbelamaric 