### PR TITLE
amend KEP template PRR question regarding how to detect feature enablement

### DIFF
--- a/keps/NNNN-kep-template/README.md
+++ b/keps/NNNN-kep-template/README.md
@@ -560,9 +560,13 @@ previous answers based on experience in the field.
 ###### How can an operator determine if the feature is in use by workloads?
 
 <!--
-Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
-checking if there are objects with field X set) may be a last resort. Avoid
-logs or events for this purpose.
+If you are using a feature-gate, then you do not have to answer this question, 
+you will be able to detect if your feature is enabled using the 
+`kubernetes_feature_enabled` metric. 
+
+Otherwise, ideally this should be a metric. Operations against the Kubernetes 
+API (e.g., checking if there are objects with field X set) may be a last resort. 
+Avoid logs or events for this purpose.
 -->
 
 ###### How can someone using this feature know that it is working for their instance?


### PR DESCRIPTION
This amends KEP template PRR question for how to detect feature enablement since [#112690](https://github.com/kubernetes/kubernetes/pull/112690) commits a generic way of detecting feature enablement. The question is still kept though, since it is possible that a feature gate is not being used. 