### PR TITLE
update status and milestone for KEP 3157 (watch-list)

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/3157.yaml
+++ b/keps/prod-readiness/sig-api-machinery/3157.yaml
@@ -1,0 +1,3 @@
+kep-number: 3157
+alpha:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/3157-watch-list/kep.yaml
+++ b/keps/sig-api-machinery/3157-watch-list/kep.yaml
@@ -1,12 +1,12 @@
 title: Allow informers for getting a stream of data instead of chunking
-kep-number: NNNN
+kep-number: 3157
 authors:
   - "@sttts"
   - "@p0lyn0mial"
 owning-sig: sig-api-machinery
 participating-sigs:
   - sig-scalability
-status: provisional
+status: implementable
 creation-date: 2022-01-14
 reviewers:
   - "@wojtek-t"
@@ -14,22 +14,17 @@ approvers:
   - "@deads2k"
   - "@lavalamp"
 
-see-also:
-replaces:
-
 # The target maturity stage in the current dev cycle for this KEP.
-stage: implementable
+stage: alpha
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.26"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.24"
-  beta: "tbd"
-  stable: "tbd"
+  alpha: "v1.26"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
updates the status to `implementable` and milestone to `v1.26`