### PR TITLE
amend feature gate name to be accurate

### DIFF
--- a/keps/sig-instrumentation/3466-kubernetes-component-health-slis/README.md
+++ b/keps/sig-instrumentation/3466-kubernetes-component-health-slis/README.md
@@ -331,13 +331,13 @@ We do not plan to modify these metrics, so it should be safe for version skew.
 
 ### Feature Enablement and Rollback
 
-We will target this feature behind a flag `ComponentHealthSLIsFeatureGate`
+We will target this feature behind a flag `ComponentSLIs`
 
 ###### How can this feature be enabled / disabled in a live cluster?
 
 
 - [ ] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: `ComponentSLIsFeatureGate`
+  - Feature gate name: `ComponentSLIs`
   - Components depending on the feature gate:
     + apiserver
     + kubelet

--- a/keps/sig-instrumentation/3466-kubernetes-component-health-slis/kep.yaml
+++ b/keps/sig-instrumentation/3466-kubernetes-component-health-slis/kep.yaml
@@ -29,7 +29,7 @@ milestone:
   stable: "v1.29"
 
 feature-gates:
-  - name: ComponentSLIsFeatureGate
+  - name: ComponentSLIs
     components:
       - kube-apiserver
       - kube-controller-manager


### PR DESCRIPTION
This amends the feature-gate name in KEP-3466 to be accurate. 

/sig instrumentation
/assign @dashpole @dgrisonnet 