### PR TITLE
OWNERS_ALIASES: update-sig-testing-leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -90,7 +90,10 @@ aliases:
   sig-testing-leads:
     - BenTheElder
     - alvaroaleman
+    - aojea
     - cjwagner
+    - michelle192837
+    - pohly
     - spiffxp
     - stevekuznetsov
   sig-ui-leads:


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/community/issues/6913