### PR TITLE
KEP-2763: Fix KEP metadata to use actual title

### DIFF
--- a/keps/sig-security/2763-ambient-capabilities/README.md
+++ b/keps/sig-security/2763-ambient-capabilities/README.md
@@ -1,4 +1,4 @@
-# KEP-2763: Support Ambient Capabilities in Kubernetes.
+# KEP-2763: Support Ambient Capabilities in Kubernetes
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)

--- a/keps/sig-security/2763-ambient-capabilities/kep.yaml
+++ b/keps/sig-security/2763-ambient-capabilities/kep.yaml
@@ -1,4 +1,4 @@
-title: KEP Template
+title: Support Ambient Capabilities in Kubernetes
 kep-number: 2763
 authors:
   - "@vinayakankugoyal"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
  Fix the title in the metadata for KEP-2763 (replace text “KEP Template” with actual KEP title).

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2763
