### PR TITLE
Update KEP 2644 to reflect drop in support for in-tree statically provisioned volumes

### DIFF
--- a/keps/sig-storage/2644-honor-pv-reclaim-policy/README.md
+++ b/keps/sig-storage/2644-honor-pv-reclaim-policy/README.md
@@ -257,10 +257,7 @@ The pv-controller is also expected to add the finalizer to all existing in-tree 
 
 The pv-controller would also be responsible to add or remove the finalizer based on CSI Migration being disabled or enabled respectively.
 
-
-Statically provisioned volumes would behave the same as dynamically provisioned volumes except in cases where the PV is not associated with a PVC, in such cases finalizer `kubernetes.io/pv-controller` is not added.
-
-If at any point a statically provisioned PV is `Bound` to a PVC, then the finalizer `kubernetes.io/pv-controller` gets added by the pv-controller.
+The finalizer `kubernetes.io/pv-controller` will not be added on statically provisioned in-tree volumes.
 
 ### Test Plan
 


### PR DESCRIPTION
- One-line PR description: Drop support for in-tree statically provisioned volumes

- Issue link: https://github.com/kubernetes/enhancements/issues/2644

- Other comments:

Signed-off-by: Deepak Kinni <dkinni@vmware.com>