### PR TITLE
KEP-3638: Enable built-in command shadowing by plugins

### DIFF
--- a/keps/prod-readiness/sig-cli/3638.yaml
+++ b/keps/prod-readiness/sig-cli/3638.yaml
@@ -1,0 +1,3 @@
+kep-number: 3638
+alpha:
+  approver: "@johnbelamaric"

--- a/keps/sig-cli/2379-kubectl-plugins/kep.yaml
+++ b/keps/sig-cli/2379-kubectl-plugins/kep.yaml
@@ -18,7 +18,7 @@ creation-date: 2018-07-24
 last-updated: 2019-02-26
 status: implemented
 see-also:
-  - n/a
+  - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/3638-built-in-command-shadowing"
 replaces:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cli/kubectl-extension.md"
   - "https://github.com/kubernetes/community/pull/481"

--- a/keps/sig-cli/3638-built-in-command-shadowing/README.md
+++ b/keps/sig-cli/3638-built-in-command-shadowing/README.md
@@ -613,6 +613,18 @@ This through this both in small and large cases, again with respect to the
 -->
 No
 
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+No
+
 ### Troubleshooting
 
 <!--

--- a/keps/sig-cli/3638-built-in-command-shadowing/README.md
+++ b/keps/sig-cli/3638-built-in-command-shadowing/README.md
@@ -1,0 +1,681 @@
+# KEP-3638: Enable built-in command shadowing by plugins 
+<!--
+A table of contents is helpful for quickly jumping to sections of a KEP and for
+highlighting any additional information provided beyond the standard KEP
+template.
+
+Ensure the TOC is wrapped with
+  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
+tags, and then generate with `hack/update-toc.sh`.
+-->
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+This KEP enables external plugins being used as subcommands of built-in `create` command via new `--use-plugin` flag.
+
+## Motivation
+
+There is a high demand for enriching some built-in kubectl commands with new subcommands. More specifically take an instance of create command, 
+even though it supports the creation of 18 resources(as of v1.25) with one line command execution(e.g. kubectl create job), 
+new requests to support other resources as well are occasionally filed. 
+These requests are understandable given the proliferation of CustomResourceDefinitions, but is not sustainable from the SIG CLI maintainers point of view. 
+Because that might bring about not only increase the size of the binary but also create a maintenance burden.
+
+This KEP proposes a viable alternative to users via plugins instead of creating static subcommands inside kubectl built-in commands.
+
+### Goals
+
+* Enable external plugin usage for `kubectl create` command
+
+### Non-Goals
+
+* Implement a plugin
+
+## Proposal
+
+This KEP introduces a new boolean flag, namely `--use-plugin`. Without this flag, plugin mechanism will work
+exactly the way it already works. On the other hand, if the user passes this flag;
+
+```sh
+$ kubectl foo --use-plugin
+(running kubectl-foo plugin without passing --use-plugin flag)
+
+$ kubectl set env --use-plugin
+("Error: set command is not allowed for shadowing by plugins")
+
+$ kubectl create job --use-plugin
+(running kubectl-create-job plugin without passing --use-plugin flag. If the plugin is not found, failing)
+```
+
+Being said that `--use-plugin` will be used to force plugin execution and do this only for allowed built-in commands. Currently,
+only `create` command will be supported and this list can be extended in future considerations.
+
+Because of starting as alpha and this is an explicitly opted-in feature, `--use-plugin` flag is only visible and usable after setting;
+```sh
+export KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true
+```
+
+### Notes/Constraints/Caveats
+
+In terms of built-in commands, there is not any constraint. Because if user passes the flag, command will be run as plugin regardless
+of existed or not. In terms of plugins, this proposal has a notable constraint that `--use-plugin` flag will be removed while
+executing plugin. That means that if plugin internally also supports `--use-plugin` flag, flag will not be passed. The reason of
+this constraint is that there is no differentiation between user passes `--use-plugin` flag to force plugin usage or actually tries
+to pass `--use-plugin` flag to plugin. This can simply be overcome by plugin owners will use different flag naming rather than `--use-plugin`
+which is supposed to be special flag in the manner of this proposal.
+
+### Risks and Mitigations
+
+Security considerations are the same with executing other external plugins and there is no additional risk.
+
+
+## Design Details
+
+### Test Plan
+
+<!--
+**Note:** *Not required until targeted at a release.*
+The goal is to ensure that we don't accept enhancements with inadequate testing.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
+when drafting this test plan.
+
+[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+<!--
+Based on reviewers feedback describe what additional tests need to be added prior
+implementing this enhancement to ensure the enhancements have also solid foundations.
+-->
+
+##### Unit tests
+
+<!--
+In principle every added code should have complete unit test coverage, so providing
+the exact set of tests will not bring additional value.
+However, if complete unit test coverage is not possible, explain the reason of it
+together with explanation why this is acceptable.
+-->
+
+<!--
+Additionally, for Alpha try to enumerate the core package you will be touching
+to implement this enhancement and provide the current unit coverage for those
+in the form of:
+- <package>: <date> - <current test coverage>
+The data can be easily read from:
+https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
+
+This can inform certain test coverage improvements that we want to do before
+extending the production code to implement this enhancement.
+-->
+
+- `k8s.io/kubectl/pkg/cmd/cmd.go`: `2023-01-16` - `63.5`
+
+##### Integration tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+-->
+
+Tests should include;
+- Running `kubectl create CRD` and expects error
+- Running `kubectl create CRD --use-plugin` and expect it creates CRD whose plugin should be existed
+- Running `kubectl set env --use-plugin` and expects error
+
+##### e2e tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+
+We expect no non-infra related flakes in the last month as a GA graduation criteria.
+-->
+
+Test should include;
+- Create a custom plugin for an example CRD and run `kubectl create CRD --use-plugin` and expects CRD is created
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+
+#### Alpha
+
+- Feature implemented behind a `KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true` environment variable
+- Initial unit tests
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Add integration tests
+
+#### GA
+
+- Add e2e test
+
+**Note:** Generally we also wait at least two releases between beta and
+GA/stable, because there's no opportunity for user feedback, or even bug reports,
+in back-to-back releases.
+
+**For non-optional features moving to GA, the graduation criteria must include
+[conformance tests].**
+
+[conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
+
+#### Deprecation
+
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+#### Alpha
+
+- Feature implemented behind a `KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true` environment variable
+- Initial unit tests
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Add integration tests
+
+#### GA
+
+- Add e2e test
+
+### Upgrade / Downgrade Strategy
+
+<!--
+If applicable, how will the component be upgraded and downgraded? Make sure
+this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to maintain previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to make use of the enhancement?
+-->
+N/A
+
+### Version Skew Strategy
+
+<!--
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- Does this enhancement involve coordinating behavior in the control plane and
+  in the kubelet? How does an n-2 kubelet without this feature available behave
+  when this feature is used?
+- Will any other components on the node change? For example, changes to CSI,
+  CRI or CNI may require updating that component before the kubelet.
+-->
+N/A
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+<!--
+This section must be completed when targeting alpha to a release.
+-->
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+<!--
+Pick one of these and delete the rest.
+
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
+
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
+
+- [ ] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name:
+  - Components depending on the feature gate:
+- [x] Other
+  - Describe the mechanism: Exporting `KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true` environment variable will enable the feature
+  - Will enabling / disabling the feature require downtime of the control
+    plane? No
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node? (Do not assume `Dynamic Kubelet Config` feature is enabled). No
+
+###### Does enabling the feature change any default behavior?
+
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+There would be a breaking change if any of built-in commands have `--use-plugin` flag. But there is none. 
+If the external plugins use `--use-plugin` flag, their plugins will not get `--use-plugin`'s value.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+
+### Rollout, Upgrade and Rollback Planning
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
+
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
+
+###### What specific metrics should inform a rollback?
+
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+### Monitoring Requirements
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### How can an operator determine if the feature is in use by workloads?
+
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
+
+###### How can someone using this feature know that it is working for their instance?
+
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [ ] Events
+  - Event Reason: 
+- [ ] API .status
+  - Condition name: 
+  - Other field: 
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+- [ ] Metrics
+  - Metric name:
+  - [Optional] Aggregation method:
+  - Components exposing the metric:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+### Dependencies
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+### Scalability
+
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
+
+For beta, this section is required: reviewers must answer these questions.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### Will enabling / using this feature result in any new API calls?
+
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
+
+###### Will enabling / using this feature result in introducing new API types?
+
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+
+### Troubleshooting
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+###### What are other known failure modes?
+
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of a KEP should be tracked in this section.
+Major milestones might include:
+- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
+- the `Proposal` section being merged, signaling agreement on a proposed design
+- the date implementation started
+- the first Kubernetes release where an initial version of the KEP was available
+- the version of Kubernetes where the KEP graduated to general availability
+- when the KEP was retired or superseded
+-->
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+## Alternatives
+
+<!--
+What other approaches did you consider, and why did you rule them out? These do
+not need to be as detailed as the proposal, but should include enough
+information to express the idea and why it was not acceptable.
+-->
+
+## Infrastructure Needed (Optional)
+
+<!--
+Use this section if you need things from the project/SIG. Examples include a
+new subproject, repos requested, or GitHub details. Listing these here allows a
+SIG to get the process for these resources started right away.
+-->

--- a/keps/sig-cli/3638-built-in-command-shadowing/README.md
+++ b/keps/sig-cli/3638-built-in-command-shadowing/README.md
@@ -122,7 +122,7 @@ In terms of risk considerations, users may adopt external plugins that do not ex
 built-in subcommand with the same name might be added. This brings about a risk about breaking users' scripts which
 rely on external plugins. To overcome that problem, there should be a some form of forcing mechanism to select
 external plugin instead built-in subcommand. `KUBECTL_ENABLE_CMD_SHADOW` flag can also be used also for that purpose
-in later stages. 
+in later stages to provide a way to the users always using external plugin instead built-in subcommand.
 
 ## Design Details
 

--- a/keps/sig-cli/3638-built-in-command-shadowing/README.md
+++ b/keps/sig-cli/3638-built-in-command-shadowing/README.md
@@ -105,7 +105,7 @@ for external plugins currently.
 Because of starting as alpha and this is an explicitly opted-in feature, shadowing functionality will be hidden behind the environment variable
 and will only be used after exporting;
 ```sh
-export KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true
+export KUBECTL_ENABLE_CMD_SHADOW=true
 ```
 
 ### Notes/Constraints/Caveats
@@ -118,6 +118,11 @@ which other built-in commands will also be requested for this shadowing.
 
 Security considerations are the same with executing other external plugins and there is no additional risk.
 
+In terms of risk considerations, users may adopt external plugins that do not exist as subcommand(e.g. `kubectl create foo`) but afterwards 
+built-in subcommand with the same name might be added. This brings about a risk about breaking users' scripts which
+rely on external plugins. To overcome that problem, there should be a some form of forcing mechanism to select
+external plugin instead built-in subcommand. `KUBECTL_ENABLE_CMD_SHADOW` flag can also be used also for that purpose
+in later stages. 
 
 ## Design Details
 
@@ -231,7 +236,7 @@ functionality is accessed.
 Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
 #### Alpha
 
-- Feature implemented behind a `KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true` environment variable
+- Feature implemented behind a `KUBECTL_ENABLE_CMD_SHADOW=true` environment variable
 - Initial unit tests
 
 #### Beta
@@ -262,7 +267,7 @@ in back-to-back releases.
 -->
 #### Alpha
 
-- Feature implemented behind a `KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true` environment variable
+- Feature implemented behind a `KUBECTL_ENABLE_CMD_SHADOW=true` environment variable
 - Initial unit tests
 
 #### Beta
@@ -352,7 +357,7 @@ well as the [existing list] of feature gates.
   - Feature gate name:
   - Components depending on the feature gate:
 - [x] Other
-  - Describe the mechanism: Exporting `KUBECTL_ENABLE_ALPHA_CMD_SHADOW=true` environment variable will enable the feature
+  - Describe the mechanism: Exporting `KUBECTL_ENABLE_CMD_SHADOW=true` environment variable will enable the feature
   - Will enabling / disabling the feature require downtime of the control
     plane? No
   - Will enabling / disabling the feature require downtime or reprovisioning

--- a/keps/sig-cli/3638-built-in-command-shadowing/README.md
+++ b/keps/sig-cli/3638-built-in-command-shadowing/README.md
@@ -378,7 +378,8 @@ feature.
 
 NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
 -->
-Yes, we can roll back to a previous release of `kubectl`
+Yes, we can roll back to a previous release of `kubectl` or it can be simply done by user
+by unsetting environment variable.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 Shadowing will continue being supported without any impact on default behavior.
@@ -416,6 +417,7 @@ feature flags will be enabled on some API servers and not others during the
 rollout. Similarly, consider large clusters and how enablement/disablement
 will rollout across nodes.
 -->
+No
 
 ###### What specific metrics should inform a rollback?
 
@@ -423,6 +425,7 @@ will rollout across nodes.
 What signals should users be paying attention to when the feature is young
 that might indicate a serious problem?
 -->
+N/A
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
@@ -431,12 +434,14 @@ Describe manual testing that was done and the outcomes.
 Longer term, we may want to require automated upgrade/rollback tests, but we
 are missing a bunch of machinery and tooling and can't do that now.
 -->
+N/A
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
 <!--
 Even if applying deprecation policies, they may still surprise some users.
 -->
+N/A
 
 ### Monitoring Requirements
 
@@ -454,6 +459,7 @@ Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
 checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
+N/A
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -465,14 +471,7 @@ Please describe all items visible to end users below with sufficient detail so t
 and operation of this feature.
 Recall that end users cannot usually observe component logs or access metrics.
 -->
-
-- [ ] Events
-  - Event Reason: 
-- [ ] API .status
-  - Condition name: 
-  - Other field: 
-- [ ] Other (treat as last resort)
-  - Details:
+N/A
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
@@ -490,19 +489,14 @@ high level (needs more precise definitions) those may be things like:
 These goals will help you determine what you need to measure (SLIs) in the next
 question.
 -->
+N/A
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
 <!--
 Pick one more of these and delete the rest.
 -->
-
-- [ ] Metrics
-  - Metric name:
-  - [Optional] Aggregation method:
-  - Components exposing the metric:
-- [ ] Other (treat as last resort)
-  - Details:
+N/A
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
@@ -510,6 +504,7 @@ Pick one more of these and delete the rest.
 Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
 implementation difficulties, etc.).
 -->
+N/A
 
 ### Dependencies
 
@@ -533,6 +528,7 @@ and creating new ones, as well as about cluster-level services (e.g. DNS):
       - Impact of its outage on the feature:
       - Impact of its degraded performance or high-error rates on the feature:
 -->
+No
 
 ### Scalability
 
@@ -545,6 +541,7 @@ For beta, this section is required: reviewers must answer these questions.
 For GA, this section is required: approvers should be able to confirm the
 previous answers based on experience in the field.
 -->
+N/A
 
 ###### Will enabling / using this feature result in any new API calls?
 
@@ -560,6 +557,7 @@ Focusing mostly on:
   - periodic API calls to reconcile state (e.g. periodic fetching state,
     heartbeats, leader election, etc.)
 -->
+No
 
 ###### Will enabling / using this feature result in introducing new API types?
 
@@ -569,6 +567,7 @@ Describe them, providing:
   - Supported number of objects per cluster
   - Supported number of objects per namespace (for namespace-scoped objects)
 -->
+No
 
 ###### Will enabling / using this feature result in any new calls to the cloud provider?
 
@@ -577,6 +576,7 @@ Describe them, providing:
   - Which API(s):
   - Estimated increase:
 -->
+No
 
 ###### Will enabling / using this feature result in increasing size or count of the existing API objects?
 
@@ -586,6 +586,7 @@ Describe them, providing:
   - Estimated increase in size: (e.g., new annotation of size 32B)
   - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
 -->
+No
 
 ###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
 
@@ -597,6 +598,7 @@ Think about adding additional work or introducing new steps in between
 
 [existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
 -->
+No
 
 ###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
 
@@ -609,6 +611,7 @@ This through this both in small and large cases, again with respect to the
 
 [supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
 -->
+No
 
 ### Troubleshooting
 

--- a/keps/sig-cli/3638-built-in-command-shadowing/kep.yaml
+++ b/keps/sig-cli/3638-built-in-command-shadowing/kep.yaml
@@ -4,6 +4,8 @@ authors:
   - "@ardaguclu"
 owning-sig: sig-cli
 status: implementable
+see-also:
+  - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2379-kubectl-plugins"
 creation-date: 2023-01-16
 reviewers:
   - "@brianpursley"

--- a/keps/sig-cli/3638-built-in-command-shadowing/kep.yaml
+++ b/keps/sig-cli/3638-built-in-command-shadowing/kep.yaml
@@ -1,0 +1,26 @@
+title: Add built-in command shadowing support by plugins
+kep-number: 3638
+authors:
+  - "@ardaguclu"
+owning-sig: sig-cli
+status: implementable
+creation-date: 2023-01-16
+reviewers:
+  - "@brianpursley"
+  - "@KnVerey"
+  - "@soltysh"
+approvers:
+  - "@brianpursley"
+  - "@KnVerey"
+  - "@soltysh"
+
+stage: alpha
+
+latest-milestone: "v1.27"
+
+milestone:
+  alpha: "v1.27"
+  beta: "v1.28"
+  stable: "v1.29"
+
+disable-supported: true


### PR DESCRIPTION
- One-line PR description:
Enable shadowing built-in commands by external plugins. This KEP proposes an extension to https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/2379-kubectl-plugins
- Issue link: https://github.com/kubernetes/enhancements/issues/3638
- Other comments:
Draft implementation of the proposal https://github.com/kubernetes/kubernetes/pull/113299