### PR TITLE
KEP:2433 option to always enforce topology routing

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/README.md
+++ b/keps/sig-network/2433-topology-aware-hints/README.md
@@ -21,6 +21,7 @@
     - [Example](#example)
     - [Overload](#overload)
     - [Handling Node Updates](#handling-node-updates)
+  - [Manual enforcement of Topology Aware Routing](#manual-enforcement-of-topology-aware-routing)
   - [Future Expansion](#future-expansion)
   - [Test Plan](#test-plan)
     - [Unit tests](#unit-tests)
@@ -368,6 +369,34 @@ of the following scenarios:
 1. A deleted Node results in a Service exceeding the overload threshold.
 2. A new Node results in a Service that is able to achieve an endpoint
    distribution below 20% for the first time.
+
+### Manual enforcement of Topology Aware Routing
+
+The algorithm proposed for mitigating the risk of overload works best with large
+numbers of endpoints and nodes, such that the percentage thresholds are unlikely
+to be broached with service restarts and node additions/removals within zones.
+There are a number of use cases however where the proposed algorithm for automatic
+assignments of zone hints is not suitable:
+
+1. Small multi-region clusters with a low number of zones and endpoints. For 
+example a rolling restart with a service in a 3 zone cluster with 2-2-2 
+endpoint distribution will cause the proposed algorithm to remove hints for the 
+service during the restart, this could have severe impact for high latency 
+environments.
+2. Multi-region clusters that deploy applications in a subset of regions. Unless 
+all regions in a cluster contain an endpoint then Topology Hints will not be 
+applied.
+
+As such we should ensure that service owners have a way to enforce traffic is
+sent to endpoints in the same zone, regardless of node/endpoint distribution.
+If there is no endpoint in the zone, endpoints in the region should be
+preferred. If there is no endpoint in the zone nor region, then the default 
+service load balancing strategy should be used on all endpoints for the service 
+regardless of topology.
+
+This option value can be added to the previously defined "Auto" and "Disabled"
+as a new "Always" value. The caveats and risks described in previous sections 
+should be highlighted in the documentation around this feature.
 
 ### Future Expansion
 

--- a/keps/sig-network/2433-topology-aware-hints/README.md
+++ b/keps/sig-network/2433-topology-aware-hints/README.md
@@ -378,21 +378,19 @@ to be broached with service restarts and node additions/removals within zones.
 There are a number of use cases however where the proposed algorithm for automatic
 assignments of zone hints is not suitable:
 
-1. Small multi-region clusters with a low number of zones and endpoints. For 
+1. Small multi-zone clusters with a low number of zones and endpoints. For 
 example a rolling restart with a service in a 3 zone cluster with 2-2-2 
 endpoint distribution will cause the proposed algorithm to remove hints for the 
 service during the restart, this could have severe impact for high latency 
 environments.
-2. Multi-region clusters that deploy applications in a subset of regions. Unless 
-all regions in a cluster contain an endpoint then Topology Hints will not be 
+2. Multi-zone clusters that deploy applications in a subset of zones. Unless 
+all zones in a cluster contain an endpoint then Topology Hints will not be 
 applied.
 
 As such we should ensure that service owners have a way to enforce traffic is
 sent to endpoints in the same zone, regardless of node/endpoint distribution.
-If there is no endpoint in the zone, endpoints in the region should be
-preferred. If there is no endpoint in the zone nor region, then the default 
-service load balancing strategy should be used on all endpoints for the service 
-regardless of topology.
+If there is no endpoint in the zone, then the default service load balancing
+strategy should be used on all endpoints for the service regardless of topology.
 
 This option value can be added to the previously defined "Auto" and "Disabled"
 as a new "Always" value. The caveats and risks described in previous sections 


### PR DESCRIPTION
The existing "Auto" value with the currently defined algorithm works well for large clusters with services with large endpoints. However there are situations where that approach doesn't work, namely low node count multi-region clusters or for service applications that are not present across all zones within a cluster by design.

This proposal would add an "Always" value to the Topology Aware Hints annotation to have the controller always sent the Zone hints on the endpoint slices regardless of node/endpoint count within zones. As long as an endpoint exists in the zone (or region) then traffic from that zone should be sent to it.

It would be important for us to ensure we highlight the risks with overload when we document this feature

/cc @robscott
/sig network