### PR TITLE
KEP-1040: note that ceil in NominalCL contributes to excess sum

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -753,8 +753,9 @@ MinCL(i) = NominalCL(i) - LendableCL(i)
 Naturally the CurrentCL values are also limited by how many seats are
 available for borrowing from other priority levels.  The sum of the
 CurrentCLs is always equal to the server's concurrency limit
-(ServerCL) plus or minus a little for rounding in the adjustment
-algorithm below.
+(ServerCL), possibly plus a little for the `ceil` in the definition of
+the NominalCLs and plus or minus a little for rounding in the
+adjustment algorithm below.
 
 Dispatching is done independently for each priority level.  Whenever
 (1) a non-exempt priority level's number of occupied seats is zero or


### PR DESCRIPTION
Signed-off-by: Mike Spreitzer <mspreitz@us.ibm.com>

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Fixes an oversight in KEP-1040, adding a reason why the CurrentCL might sum to more than the server's concurrency limit.

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: