### PR TITLE
KEP-1040: Revise initialization of SmoothSeatDemand

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -791,9 +791,11 @@ is introduced or removed or its NominalCL, LendableCL, or BorrowingCL
 changes.  At such a time, the current adjustment period comes to an
 early end and the regular adjustment logic runs; the adjustment timer
 is reset to next fire 10 seconds later.  For a newly introduced
-priority level, we set HighSeatDemand, AvgSeatDemand, and
-SmoothSeatDemand to NominalCL-LendableSD/2 and StDevSeatDemand to
-zero.
+priority level, we set HighSeatDemand, AvgSeatDemand,
+SmoothSeatDemand, and StDevSeatDemand to zero.  Initializing
+SmoothSeatDemand to a higher value would risk creating an illusion of
+pressure that decays only slowly; initializing to zero is safe because
+the arrival of actual pressure gets a quick response.
 
 For adjusting the CurrentCL values, each non-exempt priority level `i`
 has a lower bound (`MinCurrentCL(i)`) for the new value.  It is simply


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Revise initialization of SmoothSeatDemand in concurrency borrowing description

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: This corresponds to a change made late in the implementation, as results from testing revealed a problem.