### PR TITLE
Retarget in-place pod resize KEP to 1.27 alpha

### DIFF
--- a/keps/sig-node/1287-in-place-update-pod-resources/README.md
+++ b/keps/sig-node/1287-in-place-update-pod-resources/README.md
@@ -902,6 +902,12 @@ over-subscription. In order to address this, the feature-gate will remain defaul
 atleast two versions after v1.27 alpha release. i.e: beta is planned for v1.29 and
 InPlacePodVeritcalScaling feature-gate will be true in versions v1.29+
 
+kubelet: When feature-gate is disabled, if kubelet sees a Proposed resize, it rejects the
+resize as Infeasible.
+
+scheduler: If PodStatus.Resize field is not empty, scheduler uses max(ResourcesAllocated, Requests)
+even if the feature-gate is disabled.
+
 Allowed [version skews](https://kubernetes.io/releases/version-skew-policy/) are handled as below:
 
 | apiserver ver -> |    v1.27    |    v1.28     |    v1.29    |    v1.30    |

--- a/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
+++ b/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
@@ -36,7 +36,7 @@ latest-milestone: "v1.27"
 
 milestone:
   alpha: "v1.27"
-  beta: "v1.28"
+  beta: "v1.29"
   stable: "v1.30"
 
 feature-gates:

--- a/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
+++ b/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
@@ -32,12 +32,12 @@ replaces:
 
 stage: "alpha"
 
-latest-milestone: "v1.26"
+latest-milestone: "v1.27"
 
 milestone:
-  alpha: "v1.26"
-  beta: "v1.27"
-  stable: "v1.29"
+  alpha: "v1.27"
+  beta: "v1.28"
+  stable: "v1.30"
 
 feature-gates:
   - name: InPlacePodVerticalScaling


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Allow resizing pod CPU and memory resources without pod restarts. We have merged the CRI changes in 1.25 to facilitate runtime support implementation. Main feature is now targeted for alpha in 1.27

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1287

<!-- other comments or additional information -->
- Other comments: