### PR TITLE
Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -142,26 +142,26 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - celestehorgan
-    - karenhchu
-    - palnabarun
-    - tpepper
-    - vllry
+    - detiber
+    - endocrimes
+    - hlipsig
+    - jeremyrickard
+    - salaxander
   committee-security-response:
     - cjcullen
+    - enj
     - joelsmith
     - lukehinds
     - micahhausler
-    - swamymsft
     - tabbysable
     - tallclair
   committee-steering:
+    - BenTheElder
     - cblecker
-    - dims
+    - cpanato
     - justaugustus
-    - liggitt
     - mrbobbytables
-    - parispittman
+    - palnabarun
     - tpepper
 ## BEGIN CUSTOM CONTENT
   enhancements-approvers:


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

- One-line PR description: clean up `OWNER_ALIASES`
- Issue link: None
- Other comments: It looks like the code of [conduct committee README](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct#terms) also needs to get updated

* code of conduct committee: https://github.com/orgs/kubernetes/teams/code-of-conduct-committee
* steering committee: https://github.com/kubernetes/community/tree/master/committee-steering#members 
* security response committee: https://github.com/kubernetes/community/tree/master/committee-security-response#members 
