### PR TITLE
Remove ioutil for new go version

### DIFF
--- a/api/groups.go
+++ b/api/groups.go
@@ -19,7 +19,7 @@ package api
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -144,7 +144,7 @@ func (f *RemoteGroupFetcher) FetchPRRApprovers() ([]string, error) {
 		)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading owners aliases")
 	}

--- a/cmd/kepify/main.go
+++ b/cmd/kepify/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,7 +166,7 @@ func printJSONOutput(filePath string, proposals api.Proposals) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filePath, data, 0755); err != nil {
+	if err := os.WriteFile(filePath, data, 0755); err != nil {
 		return err
 	}
 

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*

--- a/pkg/proposal/create.go
+++ b/pkg/proposal/create.go
@@ -18,7 +18,6 @@ package proposal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +113,7 @@ func createKEP(kep *api.Proposal, opts *CreateOpts) error {
 		repo.ProposalFilename,
 	)
 
-	if writeErr := ioutil.WriteFile(newPath, template, os.ModePerm); writeErr != nil {
+	if writeErr := os.WriteFile(newPath, template, os.ModePerm); writeErr != nil {
 		return errors.Wrapf(writeErr, "writing KEP data to file")
 	}
 

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -19,7 +19,6 @@ package repo
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -181,7 +180,7 @@ func NewRepo(repoPath string, fetcher api.GroupFetcher) (*Repo, error) {
 
 func (r *Repo) SetGitHubToken(tokenFile string) error {
 	if tokenFile != "" {
-		token, err := ioutil.ReadFile(tokenFile)
+		token, err := os.ReadFile(tokenFile)
 		if err != nil {
 			return err
 		}
@@ -199,7 +198,7 @@ func (r *Repo) getProposalTemplate() ([]byte, error) {
 		ProposalFilename,
 	)
 
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func (r *Repo) findLocalKEPMeta(sig string) ([]string, error) {
@@ -459,7 +458,7 @@ func (r *Repo) LoadPullRequestKEPs(sig string) ([]*api.Proposal, error) {
 // within the given repoPath, or an error if the Proposal is invalid
 func (r *Repo) loadKEPFromYaml(repoPath, kepPath string) (*api.Proposal, error) {
 	fullKEPPath := filepath.Join(repoPath, kepPath)
-	b, err := ioutil.ReadFile(fullKEPPath)
+	b, err := os.ReadFile(fullKEPPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read KEP metadata for %s: %w", fullKEPPath, err)
 	}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -18,7 +18,6 @@ package repo_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,7 +108,7 @@ func TestProposalValidate(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			b, err := ioutil.ReadFile(tc.file)
+			b, err := os.ReadFile(tc.file)
 			require.NoError(t, err)
 
 			var p api.Proposal

--- a/pkg/repo/write.go
+++ b/pkg/repo/write.go
@@ -19,7 +19,7 @@ package repo
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+
 	"os"
 	"path/filepath"
 
@@ -56,5 +56,5 @@ func (r *Repo) WriteKEP(kep *api.Proposal) error {
 
 	logrus.Infof("writing KEP metadata to %s", kepYamlPath)
 
-	return ioutil.WriteFile(kepYamlPath, b, os.ModePerm)
+	return os.WriteFile(kepYamlPath, b, os.ModePerm)
 }

--- a/pkg/repo/write_test.go
+++ b/pkg/repo/write_test.go
@@ -18,7 +18,6 @@ package repo_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,7 +70,7 @@ func TestWriteKep(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "")
+			tempDir, err := os.MkdirTemp("", "")
 			mkErr := os.MkdirAll(
 				filepath.Join(
 					tempDir,
@@ -123,7 +122,7 @@ func TestWriteKep(t *testing.T) {
 
 			c := newTestClient(t, repoPath)
 
-			b, err := ioutil.ReadFile(tc.kepFile)
+			b, err := os.ReadFile(tc.kepFile)
 			require.NoError(t, err)
 
 			var p api.Proposal
@@ -135,7 +134,7 @@ func TestWriteKep(t *testing.T) {
 
 			err = c.r.WriteKEP(&p)
 
-			files, readErr := ioutil.ReadDir(c.r.ProposalPath)
+			files, readErr := os.ReadDir(c.r.ProposalPath)
 			require.Nil(t, readErr)
 
 			for _, f := range files {
@@ -196,7 +195,7 @@ func (tc *testClient) addTemplate(file string) {
 		file,
 	)
 
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		tc.T.Fatal(err)
 	}
@@ -209,7 +208,7 @@ func (tc *testClient) addTemplate(file string) {
 
 	dest := filepath.Join(dirPath, file)
 	tc.T.Logf("Writing %s to %s", file, dest)
-	err = ioutil.WriteFile(dest, data, os.ModePerm)
+	err = os.WriteFile(dest, data, os.ModePerm)
 	if err != nil {
 		tc.T.Fatal(err)
 	}


### PR DESCRIPTION
Remove io/ioutil for new go version.
The io/ioutil package has been deprated in go 1.16: https://go.dev/doc/go1.16#ioutil