### PR TITLE
KEP-1435: Support of mixed protocols in Services with type=LoadBalancer is implemented

### DIFF
--- a/keps/sig-network/1435-mixed-protocol-lb/kep.yaml
+++ b/keps/sig-network/1435-mixed-protocol-lb/kep.yaml
@@ -6,8 +6,9 @@ authors:
 owning-sig: sig-network
 participating-sigs:
   - sig-cloud-provider
-status: implementable
+status: implemented
 creation-date: 2020-01-03
+last-updated: 2023-01-05
 reviewers:
   - "@thockin"
   - "@dcbw"


### PR DESCRIPTION
* One-line PR description: `Support of mixed protocols in Services with type=LoadBalancer` has graduated to `stable` and can be considered implemented.

* Issue link: [Support of mixed protocols in Services with type=LoadBalancer #1435
](https://github.com/kubernetes/enhancements/issues/1435)

* Other comments: 

Fixes https://github.com/kubernetes/enhancements/issues/1435

/assign @thockin 
/cc @marosset @janosi 

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
