### PR TITLE
KEP-2831: adding beta graduation criteria

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/2831.yaml
+++ b/keps/prod-readiness/sig-instrumentation/2831.yaml
@@ -1,4 +1,6 @@
 kep-number: 2831
 alpha:
   approver: "@ehashman"
+beta:
+  approver: "@ehashman"
 

--- a/keps/prod-readiness/sig-instrumentation/2831.yaml
+++ b/keps/prod-readiness/sig-instrumentation/2831.yaml
@@ -2,5 +2,5 @@ kep-number: 2831
 alpha:
   approver: "@ehashman"
 beta:
-  approver: "@ehashman"
+  approver: "@wojtek-t"
 

--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -237,7 +237,7 @@ Beta
 - [] Unit/integration test to verify connected traces in kubelet.
 - [] Revisit the format used to export spans.
 - [] Parity with the old text-based Traces
-
+- [ ] Connecting traces from container runtimes via the Container Runtime Interface
 GA
 
 ## Production Readiness Review Questionnaire

--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -106,7 +106,7 @@ From there, OpenTelemetry trace data can be exported to a tracing backend of cho
 specified within `kubernetes/component-base` with the default URL to make the kubelet send its spans to the collector.
 Alternatively, I can point the kubelet at an OpenTelemetry collector listening on a different port or URL if I need to.
 
-#### Continuous Trace Collection
+#### Continuous trace collection
 
 As a cluster administrator or cloud provider, I would like to collect gRPC and HTTP trace data from the transactions between the API server and the 
 kubelet and interactions with a node's container runtime (Container Runtime Interface) to debug cluster problems.  I can set the `SamplingRatePerMillion`
@@ -115,7 +115,7 @@ debug, I can search span metadata or specific nodes to find a trace which displa
 The sampling rate for trace exports can be configured based on my needs. I can collect each node's kubelet trace data as distinct tracing services
 to diagnose node issues.
 
-##### Example Scenarios
+##### Example scenarios
 
 * Latency or timeout experienced when:
     * Attach or exec to running containers

--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -143,7 +143,10 @@ OpenTelemetry-Go provides the [propagation package](https://github.com/open-tele
 
 ### Connected Traces with Nested Spans
 
-Nested spans with top-level traces in the kubelet will connect CRI calls together. Nested spans will be created for the following:
+With the initial implementation of this proposal, kubelet tracing produced disconnected spans, because context was not wired through kubelet CRI calls.
+With [this PR](https://github.com/kubernetes/kubernetes/pull/113591), context is now plumbed between CRI calls and kubelet.
+It is now possible to connect spans for CRI calls. Nested spans with top-level traces in the kubelet will connect CRI calls together.
+Nested spans will be created for the following:
 * Sync Loops (e.g. syncPod, eviction manager, various gc routines) where the kubelet initiates new work.
     * [top-level traces for pod sync and GC](https://github.com/kubernetes/kubernetes/pull/114504)
 * Incoming requests (exec, attach, port-forward, metrics endpoints, podresources)
@@ -233,11 +236,12 @@ Beta
 - [X] OpenTelemetry reaches GA
 - [X] Publish examples of how to use the OT Collector with kubernetes
 - [X] Allow time for feedback
-- [] Add top level traces to connect spans in sync loops, incoming requests, and outgoing requests.
-- [] Unit/integration test to verify connected traces in kubelet.
-- [] Revisit the format used to export spans.
-- [] Parity with the old text-based Traces
+- [ ] Add top level traces to connect spans in sync loops, incoming requests, and outgoing requests.
+- [ ] Unit/integration test to verify connected traces in kubelet.
+- [ ] Revisit the format used to export spans.
+- [ ] Parity with the old text-based Traces
 - [ ] Connecting traces from container runtimes via the Container Runtime Interface
+  - https://github.com/kubernetes/kubernetes/pull/114504
 
 GA
 

--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -230,6 +230,12 @@ Alpha
 
 - [X] Implement tracing of incoming and outgoing gRPC, HTTP requests in the kubelet
 - [X] Integration testing of tracing
+  - _component-base tracing/api/v1 integration test_ https://github.com/kubernetes/kubernetes/blob/master/test/integration/apiserver/tracing/tracing_test.go
+- [X] Unit testing of kubelet tracing and tracing configuration
+  - https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/validation/validation_test.go#L503-#L532
+  - https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cri/remote/remote_runtime_test.go#L65-#L97
+  - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+  - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
 
 Beta
 
@@ -299,7 +305,17 @@ _This section must be completed when targeting beta graduation to a release._
   No impact to running workloads, logs will indicate the problem.
 
 ###### What specific metrics should inform a rollback?
-  To be determined.
+
+  * This KEP is following the [opentelemetry-go issue #2547](https://github.com/open-telemetry/opentelemetry-go/issues/2547).
+
+  ```
+  ...using the OTLP trace exporter, it isn't currently possible to monitor (with metrics) whether or not spans are being successfully collected and exported.
+  For example, if my SDK cannot connect to an opentelemetry collector, and isn't able to send traces, I would like to be able to measure how many traces are collected,
+  vs how many are not sent. I would like to be able to set up SLOs to measure successful trace delivery from my applications.
+  ```
+
+  * Pod Lifecycle and Kubelet [SLOs](https://github.com/kubernetes/community/tree/master/sig-scalability/slos) are the signals that should guide a rollback.  In particular, the [`kubelet_pod_start_duration_seconds_count`, `kubelet_runtime_operations_errors_total`, and `kubelet_pleg_relist_interval_seconds_bucket`] would surface issues affecting kubelet performance.
+
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
   Upgrades and rollbacks will be tested while feature-gate is experimental

--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -211,13 +211,18 @@ spans propagated from kubelet to API server match what is expected from the requ
 
 ##### Unit tests
 
-- `k8s.io/component-base/traces`: no test grid results - k8s.io/component-base/traces/config_test.go
+- https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/validation/validation_test.go#L503-#L532
+- https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cri/remote/remote_runtime_test.go#L65-#L97
+- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
 
 ##### Integration tests
 
-An integration test will verify that spans exported by the kubelet match what is
-expected from the request. We will also add an integration test that verifies
+Integration tests verify that spans exported by the kubelet match what is
+expected from the request. Also an integration test that verifies
 spans propagated from kubelet to API server match what is expected from the request.
+
+- _component-base tracing/api/v1 integration test_ https://github.com/kubernetes/kubernetes/blob/master/test/integration/apiserver/tracing/tracing_test.go
 
 ##### e2e tests
 
@@ -230,18 +235,14 @@ Alpha
 
 - [X] Implement tracing of incoming and outgoing gRPC, HTTP requests in the kubelet
 - [X] Integration testing of tracing
-  - _component-base tracing/api/v1 integration test_ https://github.com/kubernetes/kubernetes/blob/master/test/integration/apiserver/tracing/tracing_test.go
 - [X] Unit testing of kubelet tracing and tracing configuration
-  - https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/config/validation/validation_test.go#L503-#L532
-  - https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cri/remote/remote_runtime_test.go#L65-#L97
-  - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
-  - https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
 
 Beta
 
 - [X] OpenTelemetry reaches GA
 - [X] Publish examples of how to use the OT Collector with kubernetes
 - [X] Allow time for feedback
+- [ ] Test and document results of upgrade and rollback while feature-gate is enabled.
 - [ ] Add top level traces to connect spans in sync loops, incoming requests, and outgoing requests.
 - [ ] Unit/integration test to verify connected traces in kubelet.
 - [ ] Revisit the format used to export spans.
@@ -283,7 +284,7 @@ GA
       of a node? **No, restarting the kubelet with feature-gate disabled will disable tracing**
 
 ##### Does enabling the feature change any default behavior?
-  No. The feature is disabled unlesss the feature gate is enabled and the TracingConfiguration is populated in Kubelet Configuration.
+  No. The feature is disabled unless the feature gate is enabled and the TracingConfiguration is populated in Kubelet Configuration.
   When the feature is enabled, it doesn't change behavior from the users' perspective; it only adds tracing telemetry.
 
 ##### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
@@ -293,8 +294,8 @@ GA
   It will start generating and exporting traces again.
 
 ##### Are there any tests for feature enablement/disablement?
-  Unit tests switching feature gates will be added. Manual testing of disabling, reenabling the feature on nodes, ensuring the kubelet comes up w/out error will
-  also be performed.
+  Enabling and disabling kubelet tracing is an in-memory switch. Explicit enablement/disablement tests will not provide value so will not be added.
+  Manual testing of disabling, reenabling the feature on nodes, ensuring the kubelet comes up w/out error will be performed and documented.
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -344,7 +345,7 @@ _This section must be completed when targeting beta graduation to a release._
 ##### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
 - [] Metrics
-  - Metric name: tbd
+  - Metric name: tbd [opentelemetry-go issue #2547](https://github.com/open-telemetry/opentelemetry-go/issues/2547)
   - Components exposing the metric: kubelet
 
 ##### Are there any missing metrics that would be useful to have to improve observability 

--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -238,6 +238,7 @@ Beta
 - [] Revisit the format used to export spans.
 - [] Parity with the old text-based Traces
 - [ ] Connecting traces from container runtimes via the Container Runtime Interface
+
 GA
 
 ## Production Readiness Review Questionnaire

--- a/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
@@ -12,9 +12,11 @@ status: implementable
 creation-date: 2021-07-21
 reviewers:
   - "@dashpole"
+  - "@ehashman"
   - "@wojtek-t"
 approvers:
   - "@dashpole"
+  - "@ehashman"
   - "@wojtek-t"
 see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/647-apiserver-tracing"

--- a/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
@@ -12,10 +12,10 @@ status: implementable
 creation-date: 2021-07-21
 reviewers:
   - "@dashpole"
-  - "@ehashman"
+  - "@wojtek-t"
 approvers:
   - "@dashpole"
-  - "@ehashman"
+  - "@wojtek-t"
 see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/647-apiserver-tracing"
 replaces:

--- a/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 2831
 authors:
   - "@husky-parul"
   - "@somalley"
+  - "@dashpole"
 owning-sig: sig-instrumentation
 participating-sigs:
   - sig-architecture
@@ -18,12 +19,12 @@ approvers:
 see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/647-apiserver-tracing"
 replaces:
-stage: alpha
-latest-milestone: "v1.25"
+stage: beta
+latest-milestone: "v1.27"
 milestone:
   alpha: "v1.25"
-  beta: "v1.26"
-  stable: "v1.27"
+  beta: "v1.27"
+  stable: "v1.28"
 feature-gates:
   - name: KubeletTracing
     components:


### PR DESCRIPTION
- updates to KEP-2831 to track connected traces in kubelet and beta graduation

- Issue link: https://github.com/kubernetes/enhancements/issues/2831

/cc @dashpole 
/cc @saschagrunert 
/cc @vrutkovs