### PR TITLE
KEP-2413: Graduate SeccompDefault to stable

### DIFF
--- a/keps/prod-readiness/sig-node/2413.yaml
+++ b/keps/prod-readiness/sig-node/2413.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-node/2413-seccomp-by-default/README.md
+++ b/keps/sig-node/2413-seccomp-by-default/README.md
@@ -185,8 +185,13 @@ configuration.
 
 #### Beta to GA Graduation
 
-- [ ] Allowing time for feedback (3 releases)
-- [ ] Risks have been addressed by every common container runtime
+- [x] Allowing time for feedback (3 releases)
+- [x] Enabling the Kubelet feature flag by default
+- [x] Risks have been addressed by every common container runtime
+- [x] Documenting the seccomp performance impact on k/website as well as its
+      workarounds (disabling the feature completely, turning off spectre
+      mitigations for certain kernel versions or updating the kernel as well as
+      runc)
 
 ### Upgrade / Downgrade Strategy
 
@@ -421,6 +426,7 @@ _This section must be completed when targeting beta graduation to a release._
 
 ## Implementation History
 
+- 2023-01-10: Updated KEP to stable
 - 2022-03-15: Updated KEP to beta
 - 2021-05-05: KEP promoted to implementable
 

--- a/keps/sig-node/2413-seccomp-by-default/kep.yaml
+++ b/keps/sig-node/2413-seccomp-by-default/kep.yaml
@@ -15,18 +15,18 @@ approvers:
   - "@mrunalp"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.25"
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.25"
-  stable: "v1.28"
+  stable: "v1.27"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION

- One-line PR description: We now graduate `SeccompDefault` to stable by basically making the feature enabled by default.
- Issue link: https://github.com/kubernetes/enhancements/issues/2413
- Other comments: PTAL @mrunalp @kubernetes/sig-node-pr-reviews 