### PR TITLE
KEP-2053: Graduate DownwardAPIHugePages feature to stable

### DIFF
--- a/keps/prod-readiness/sig-node/2053.yaml
+++ b/keps/prod-readiness/sig-node/2053.yaml
@@ -1,3 +1,5 @@
 kep-number: 2053
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/2053-downward-api-hugepages/README.md
+++ b/keps/sig-node/2053-downward-api-hugepages/README.md
@@ -239,6 +239,11 @@ No
 resource usage (CPU, RAM, disk, IO, ...) in any components?**
 No
 
+* **Can enabling / using this feature result in resource exhaustion of some node
+  resources (PIDs, sockets, inodes, etc.)?**
+
+No
+
 ### Troubleshooting
 
 * **How does this feature react if the API server and/or etcd is unavailable?**
@@ -252,7 +257,9 @@ Not applicable
 
 ## Implementation History
 
-v1.20: Launch `Alpha` state
+- v1.27: Updated KEP to stable
+- v1.21: Updated KEP to beta
+- v1.20: Launch `Alpha` state
 
 ## Drawbacks
 

--- a/keps/sig-node/2053-downward-api-hugepages/kep.yaml
+++ b/keps/sig-node/2053-downward-api-hugepages/kep.yaml
@@ -2,6 +2,7 @@ title: Downward API HugePages
 kep-number: 2053
 authors:
   - "@derekwaynecarr"
+  - "@saschagrunert"
 owning-sig: sig-node
 participating-sigs: []
 status: implementable
@@ -18,18 +19,18 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.20"
   beta: "v1.21"
-  stable: "v1.22"
+  stable: "v1.27"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: We now graduate the DownwardAPIHugePages feature to stable.
- Issue link: https://github.com/kubernetes/enhancements/issues/2053
- Other comments: PTAL @kubernetes/sig-node-pr-reviews 