### PR TITLE
2943: Withdrawn network policy status implementation

### DIFF
--- a/keps/sig-network/2943-networkpolicy-status/README.md
+++ b/keps/sig-network/2943-networkpolicy-status/README.md
@@ -450,6 +450,7 @@ For each of them, fill in the following information by copying the below templat
 ## Implementation History
 
 - 2022-02-01 Initial KEP
+- 2032-01-12 Feature has been withdrawn and will be removed from the code
 
 ## Drawbacks
 

--- a/keps/sig-network/2943-networkpolicy-status/README.md
+++ b/keps/sig-network/2943-networkpolicy-status/README.md
@@ -450,7 +450,7 @@ For each of them, fill in the following information by copying the below templat
 ## Implementation History
 
 - 2022-02-01 Initial KEP
-- 2032-01-12 Feature has been withdrawn and will be removed from the code
+- 2023-01-12 Feature has been withdrawn and will be removed from the code
 
 ## Drawbacks
 

--- a/keps/sig-network/2943-networkpolicy-status/kep.yaml
+++ b/keps/sig-network/2943-networkpolicy-status/kep.yaml
@@ -15,7 +15,7 @@ approvers:
   - "@thockin"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: 
+stage: alpha 
 
 see-also:
   - "/keps/sig-network/2079-network-policy-port-range"
@@ -23,15 +23,20 @@ see-also:
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: 
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha:
+  alpha: "v1.24"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
-feature-gates: [] 
+feature-gates:
+  - name: NetworkPolicyStatus
+    components:
+      - kube-apiserver
+disable-supported: true
 
 # The following PRR answers are required at beta release
-metrics: []
+metrics:
+  - network_policy_status

--- a/keps/sig-network/2943-networkpolicy-status/kep.yaml
+++ b/keps/sig-network/2943-networkpolicy-status/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 2943
 authors:
   - "@rikatz"
 owning-sig: sig-network
-status: implementable
+status: withdrawn
 creation-date: 2021-09-06
 reviewers:
   - "@thockin"
@@ -15,7 +15,7 @@ approvers:
   - "@thockin"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha 
+stage: 
 
 see-also:
   - "/keps/sig-network/2079-network-policy-port-range"
@@ -23,20 +23,15 @@ see-also:
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: 
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.24"
+  alpha:
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
-feature-gates:
-  - name: NetworkPolicyStatus
-    components:
-      - kube-apiserver
-disable-supported: true
+feature-gates: [] 
 
 # The following PRR answers are required at beta release
-metrics:
-  - network_policy_status
+metrics: []


### PR DESCRIPTION
- One-line PR description: Withdraw Network Policy Status

- Issue link: https://github.com/kubernetes/enhancements/issues/2943

- Other comments: Per sig-network meeting on 05/Jan/2023, we are removing this feature. We need to make sure that the protobuf names used to persist on etcd are documented, so in a future if we decide to reimplement this feature a new name should be used to avoid conflicts.