### PR TITLE
KEP-3488: CEL admission: Add graceful rollout, warning and audit support

### DIFF
--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1054,7 +1054,7 @@ below "Audit Events" for details.
 
 For singleton policies, since there is no separate binding resource, the
 `validationActions` field will be set on the policy definition in the same way
-that other binding fields.
+that other binding fields are.
 
 Metrics will include validation action so that cluster administrators can monitor the
 validation failures of a binding before setting `validationActions` to `Deny`.

--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1043,6 +1043,7 @@ The enum options will be:
 - `warn`: Validation failures are reported as warnings to the client. (xref: [Admisssion Webhook Warnings](https://kubernetes.io/blog/2020/09/03/warnings/#admission-webhooks))
 - `audit`: Validation failures are published as audit events (see below Audit
   Annotations section for details).
+- `log`: The apiserver handling the admission request logs the validation failure.
 
 Systems that need to aggregate validation failures may implement an [audit
 webhook
@@ -1075,11 +1076,16 @@ This enables the following use cases:
 
 Future work:
 
-ValidatingAdmissionPolicy resources might, in the future, add a `warnings` field
-adjacent to the `validations` and `auditAnnotations` fields to declare
-expressions only ever result in warnings. This would allow
-ValidatingAdmissionPolicy authors to declare a expression as non-enforcing
-regardless of `validationActions`.
+- ValidatingAdmissionPolicy resources might, in the future, add a `warnings`
+  field adjacent to the `validations` and `auditAnnotations` fields to declare
+  expressions only ever result in warnings. This would allow
+  ValidatingAdmissionPolicy authors to declare a expression as non-enforcing
+  regardless of `validationActions`.
+
+- ValidatingAdmissionPolicy resources, might, in the future, offer per-expression
+  enforcement actions (instead of a separate `warnings` field) and combine these
+  enforcement actions with the ValidatingAdmissionPolicyBinding enforcement action
+  to determine the effective enforcement.
 
 #### Audit Annotations
 

--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1044,7 +1044,7 @@ The enum options will be:
   Annotations section for details).
 
 If, in the future, `ValidatingAdmissionPolicy` also introduces enforcement
-action fields, this effective enforcement will be the set intersection of the
+action fields, this effective enforcement will be the set to the intersection of the
 the policy enforcement actions and the binding enforcement actions.
 
 Systems that need to aggregate validation failures may implement an [audit

--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1115,6 +1115,9 @@ spec:
 `auditAnnotations` are independent of `validations`. A `ValidatingAdmissionPolicy`
 may contain only `validations`, only `auditAnnotations` or both.
 
+Auudit annotations are recorded regardless of whether a
+ValidatingAdmissionPolicyBinding's `validationActions` include `Audit`.
+
 The published annotation key will be of the form `<ValidatingPolicyDefinition
 name>/<auditAnnotation key>` and will be validated as a
 [QualifiedName](https://github.com/kubernetes/kubernetes/blob/dfa4143086bf504c6c72d5eee8a2210b8ed41b9a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L43).


### PR DESCRIPTION
- One-line PR description: Update the CEL admission KEP to support graceful policy rollout by adding ability to report validation failures only as warnings or audit annotations and for enhancing metrics to container the information needed to monitor a rollout.

<!-- link to the k/enhancements issue -->
- Issue link: #3492 
