### PR TITLE
KEP-1965: Fix the broken KEP link

### DIFF
--- a/keps/sig-api-machinery/1965-kube-apiserver-identity/README.md
+++ b/keps/sig-api-machinery/1965-kube-apiserver-identity/README.md
@@ -68,7 +68,7 @@ list of IDs for living kube-apiservers in the cluster.
 
 ## Motivation
 
-The [dynamic coordinated storage version API](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190802-dynamic-coordinated-storage-version.md#curating-a-list-of-participating-api-servers-in-ha-master)
+The [dynamic coordinated storage version API](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2339-storageversion-api-for-ha-api-servers/README.md#curating-a-list-of-participating-api-servers-in-ha-master)
 needs such a list to garbage collect stale records. The
 [API priority and fairness feature](https://github.com/kubernetes/kubernetes/pull/91389)
 needs a unique identifier for an apiserver reporting its concurrency limit.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Fix the broken KEP link because the target KEP file is renamed by [This PR]( https://github.com/kubernetes/enhancements/pull/2460)

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: