### PR TITLE
Update KEP-383 graduation criterias

### DIFF
--- a/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md
+++ b/keps/sig-instrumentation/383-new-event-api-ga-graduation/README.md
@@ -25,7 +25,6 @@
     - [Deprecated Fields](#deprecated-fields)
     - [Beta to GA Graduation](#beta-to-ga-graduation)
     - [Load Test](#load-test)
-    - [Components Migration](#components-migration)
 - [Considerations](#considerations)
   - [Performance Impact](#performance-impact)
   - [Backward Compatibility](#backward-compatibility)
@@ -74,7 +73,7 @@ The KEP aims at fixing few issues in the current way Events are structured and i
 
 Most sections and design details are copied from the original design doc: [Make Kubernetes Events Useful and Safe](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/events-redesign.md).
 
-The new Event API has been promoted from v1beta1 to v1 in 1.19 and currently only scheduler was migrated to use it. This KEP proposes to graduate the new Event API by migrating all the remaining Kubernetes components to use the new Event API.
+The new Event API has been promoted from v1beta1 to v1 in 1.19 and currently only scheduler was migrated to use it.
 
 ## Motivation
 
@@ -370,7 +369,7 @@ Scalability and Performance:
 
 ### Graduation Criteria
 
-The new Event API is in v1 right now and scheduler has been migrated to use new API. The plan is to do a load test and migrate all the remaining components.
+The new Event API is in v1 right now and scheduler has been migrated to use new API. The plan is to do a load test before migrating all the remaining components.
 
 #### Deprecated Fields
 
@@ -383,26 +382,10 @@ This section lists the deprecated Event API fields that should be removed before
 
 - Remove deprecated fields listed above
 - Gather data from performance and scalability tests
-- Remove all in-tree use of the core/v1.Event API in favour of events.k8s.io/v1
 
 #### Load Test
 
 The idea is to use [ClusterLoader](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2) testing framework to do a load test to make sure events generated can be handled by etcd and there's no big performance reduction.
-
-#### Components Migration
-
-The list of components that need to be migrated is shown as follows:
-
-- kubelet
-- cloud-controller-manager
-- kube-controller-manager
-- leader election
-- node problem detector
-- gce ingress controller
-- event exporter
-
-(Note: there are more out-of-tree components that need to be migrated)
-
 
 ## Considerations
 

--- a/keps/sig-instrumentation/383-new-event-api-ga-graduation/kep.yaml
+++ b/keps/sig-instrumentation/383-new-event-api-ga-graduation/kep.yaml
@@ -17,7 +17,7 @@ prr-approvers:
   - "@wojtek-t"
 creation-date: 2019-01-31
 last-updated: 2021-02-03
-status: implementable
+status: implemented
 see-also:
 replaces:
 stage: stable


### PR DESCRIPTION
The issue for KEP-383 can't be closed although the KEP has graduated to stable because all the Kubernetes components haven't been migrated to use the new API. The actual migration is a big effort that needs to be properly planned and as such would be better handled in a seperate KEP. There are also some changes that needs to be considered in order to not break existing behaviors. As such, the plan is to remove the migration from KEP-383's scope and instead do it as part of [KEP-3728](https://github.com/kubernetes/enhancements/issues/3728).

Fixes #383 

/cc @logicalhan @ehashman 
/assign @wojtek-t 