### PR TITLE
KEP-1040: update GA graduation criteria

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/README.md
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/README.md
@@ -2834,11 +2834,11 @@ Beta:
 
 GA:
 
-- Satisfaction with LIST and WATCH support.
-- API annotations properly support strategic merge patch.
-- APF allows us to disable client-side rate limiting without causing the apiservers to wedge/crash.  Note that there is another level of concern that APF does not attempt to address, which is mismatch between the throughput that various controllers can sustain.
-- Design and implement borrowing between priority levels.
-- Satisfaction that the API is sufficient to support auto-tuning of capacity and resource costs.
+- [x] API annotations properly support strategic merge patch.
+- [x] Design and implement borrowing between priority levels.
+- [ ] Satisfaction with LIST and WATCH support.
+- [ ] APF allows us to disable client-side rate limiting without causing the apiservers to wedge/crash.  Note that there is another level of concern that APF does not attempt to address, which is mismatch between the throughput that various controllers can sustain.
+- [ ] Satisfaction that the interface is sufficient to support tuning of capacity and resource costs.
 
 ## Production Readiness Review Questionnaire
 


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Update GA graduation criteria: sort, make check-list, refine tuning item.

<!-- link to the k/enhancements issue -->

<!-- other comments or additional information -->
- Other comments:
- 1. Convert to check list.
- 2. Re-order so that completed items come first.
- 3. Update tuning item to refer to the whole interface (e.g, including logs and metrics) rather than just the API.
- 4. Update the tuning item to replace "auto-tuning" with simply "tuning".  The thinking is that the proper focus is on observability and controllabiility; automation of the tuning was always intended to be a matter for later consideration.

/cc @wojtek-t 
/cc @lavalamp 
/cc @deads2k 
/cc @tkashem 
/cc @marseel 
