### PR TITLE
KEP-3705: update CloudNodeIPs to implementable

### DIFF
--- a/keps/prod-readiness/sig-network/3705.yaml
+++ b/keps/prod-readiness/sig-network/3705.yaml
@@ -1,0 +1,6 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group 
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 3705
+alpha:
+  approver: "wojtek-t"

--- a/keps/sig-network/3705-cloud-node-ips/kep.yaml
+++ b/keps/sig-network/3705-cloud-node-ips/kep.yaml
@@ -6,15 +6,17 @@ owning-sig: sig-network
 participating-sigs:
   - sig-node
   - sig-cloud-provider
-status: provisional
+status: implementable
 creation-date: 2022-11-29
 reviewers:
+  - "@aojea"
+  - "@JoelSpeed"
   - "@mdbooth"
   - "@khenidak"
   - "@thockin"
-  - TBD
 approvers:
-  - TBD
+  - "@thockin"
+  - TBD from sig-cloud-provider
 
 see-also:
   - "https://github.com/kubernetes/enhancements/issues/1664"
@@ -45,4 +47,3 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - my_feature_metric


### PR DESCRIPTION
- One-line PR description: update KEP-3705 to implementable, including addressing a few comments Tim left while approving the original PR

- Issue link: https://github.com/kubernetes/enhancements/issues/3705

- Other comments:
I think this still needs a sig-cloud-provider approver. @andrewsykim ?
(I don't think it necessarily needs a sig-node approval though even though it involves changes to kubelet?)

/sig network
/assign @thockin 