### PR TITLE
1847: 1.27 beta update

### DIFF
--- a/keps/sig-apps/1847-autoremove-statefulset-pvcs/README.md
+++ b/keps/sig-apps/1847-autoremove-statefulset-pvcs/README.md
@@ -561,7 +561,7 @@ stateful set controller lives) should be examined and/or restarted.
 
   - 1.21, KEP created.
   - 1.23, alpha implementation.
-  - 1.26, graduation to beta.
+  - 1.27, graduation to beta.
 
 ## Drawbacks
 The StatefulSet field update is required.

--- a/keps/sig-apps/1847-autoremove-statefulset-pvcs/kep.yaml
+++ b/keps/sig-apps/1847-autoremove-statefulset-pvcs/kep.yaml
@@ -20,12 +20,12 @@ approvers:
 
 stage: beta
 
-latest-milestone: "v1.26"
+latest-milestone: "v1.27"
 
 milestone:
   alpha: "v1.23"
-  beta: "v1.26"
-  stable: "v1.27"
+  beta: "v1.27"
+  stable: "v1.28"
 
 feature-gates:
   - name: StatefulSetAutoDeletePVC


### PR DESCRIPTION
- Update KEP #1847 status for beta graduation

<!-- link to the k/enhancements issue -->
- Issue link: #1847 

<!-- other comments or additional information -->
- Other comments: No changes are necessary for beta. This KEP was almost ready for beta in 1.26, but needs more e2e test soak time as the statefulset e2e tests were not being run in alpha clusters since cloud provider extraction / CSI migration (see also https://github.com/kubernetes/kubernetes/issues/114955).

/cc @msau42 
/cc @johnbelamaric 