### PR TITLE
[v1.27] update etcd-learner-mode KEP status

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/3614-etcd-learner-mode/README.md
+++ b/keps/sig-cluster-lifecycle/kubeadm/3614-etcd-learner-mode/README.md
@@ -517,6 +517,8 @@ Major milestones might include:
 -->
 
 - 2022-05-10: KEP draft created
+- 2022-12-17(v1.27): add the experimental (alpha) feature gate EtcdLearnerMode and initial implementation <https://github.com/kubernetes/kubernetes/pull/113318>
+- 2023-01-28(v1.27): add e2e test for etcd learner mode <https://github.com/kubernetes/kubeadm/pull/2807>
 
 ## Drawbacks
 


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3614

<!-- other comments or additional information -->
- Other comments: the implemented PR was merged early in v1.27 release cycle. Just update the status to align.

/sig cluster-lifecycle