### PR TITLE
Update the release for alpha2

### DIFF
--- a/keps/sig-node/2400-node-swap/kep.yaml
+++ b/keps/sig-node/2400-node-swap/kep.yaml
@@ -23,13 +23,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.26"
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
-  beta: "v1.27"
-  stable: "v1.28"
+  beta: "v1.28"
+  stable: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
/sig node

- One-line PR description: NodeSwap feature update for 1.27 release - target alpha2.

No changes in scope, last time the KEP was scheduled we didn't have enough people to work on it.

- Issue link: #2400 

Issue is already tracked for milestone 1.27

/assign @dchen1107 