### PR TITLE
KEP-1748: update to stable

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/1748.yaml
+++ b/keps/prod-readiness/sig-instrumentation/1748.yaml
@@ -1,3 +1,5 @@
 kep-number: 1748
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-instrumentation/1748-pod-resource-metrics/README.md
+++ b/keps/sig-instrumentation/1748-pod-resource-metrics/README.md
@@ -513,6 +513,16 @@ collector.
 Administrators and visualization tools are the primary target of these metrics and
 so polling and canvassing of Kube distributions is one source of feedback.
 
+* **How can someone using this feature know that it is working for their instance?**
+
+- [ ] Events
+  - Event Reason:
+- [ ] API .status
+  - Condition name:
+  - Other field:
+- [x] Other (treat as last resort)
+  - Details: By scraping the /metrics/resources endpoint of the scheduler and getting metrics about pods resource requests and limits.
+
 * **What are the SLIs (Service Level Indicators) an operator can use to determine
 the health of the service?**
   - [ ] Metrics
@@ -580,6 +590,10 @@ resource usage (CPU, RAM, disk, IO, ...) in any components?**
 
 Negligible CPU use is expected and some increase in network transmit when the scheduler
 is scraped.
+
+* **Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?**
+
+No.
 
 ### Troubleshooting
 

--- a/keps/sig-instrumentation/1748-pod-resource-metrics/kep.yaml
+++ b/keps/sig-instrumentation/1748-pod-resource-metrics/kep.yaml
@@ -18,9 +18,9 @@ approvers:
   - "@ahg-g"
 see-also:
 replaces:
-latest-milestone: "v1.21"
+latest-milestone: "v1.27"
 milestone:
   alpha: "v1.20"
   beta: "v1.21"
-  stable: "v1.22"
-stage: "beta"
+  stable: "v1.27"
+stage: "stable"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

This PR update the state of KEP-1748 to stable and set the milestone to 1.27.

We won't be able to update the status of the KEP to `implemented` until metrics are updated to Stable, but they first need to be BETA.

<!-- link to the k/enhancements issue -->
- Issue link: #1748

<!-- other comments or additional information -->
- Other comments:

The graduation criteria from BETA to GA is:
> Stability over two releases demonstrating cardinality is reasonable and the metrics remain valuable

The metrics have been in Kubernetes since 1.20 so although there are not exposed on the main kube-scheduler endpoint, they've been around for 7 releases already. During that period of time no cardinality explosion has been reported and the metrics are starting to be more widely used:
- https://github.com/kubernetes/kube-state-metrics/pull/1849
- https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/815

Unit tests for the test plan have been added in https://github.com/kubernetes/kubernetes/pull/94866.