### PR TITLE
KEP-127: Support userns in stateless pods with idmap mounts

### DIFF
--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -123,7 +123,6 @@ Here we use UIDs, but the same applies for GIDs.
 - Increase pod to pod isolation by allowing to use non-overlapping mappings
   (UIDs/GIDs) whenever possible. IOW, if two containers runs as user X, they run
   as different UIDs in the node and therefore are more isolated than today.
-  See phase 3 for limitations.
 - Allow pods to have capabilities (e.g. `CAP_SYS_ADMIN`) that are only valid in
   the pod (not valid in the host).
 - Benefit from the security hardening that user namespaces provide against some
@@ -300,7 +299,7 @@ The picked range will be stored under a file named `userns` in the pod folder
 (by default it is usually located in `/var/lib/kubelet/pods/$POD/userns`). This
 way, the Kubelet can read all the allocated mappings if it restarts.
 
-During phase 1, to make sure we don't exhaust the host UID namespace, we will
+During alpha, to make sure we don't exhaust the host UID namespace, we will
 limit the number of pods using user namespaces to `min(maxPods, 1024)`. This
 leaves us plenty of host UID space free and this limits is probably never hit in
 practice. See UNRESOLVED for more some UNRESOLVED info we still have on this.
@@ -1036,14 +1035,6 @@ here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798760382
 
 For stateless pods with 64k mappings this is not an issue. This was considered
 something to discuss for pods with volumes (out of scope of this KEP).
-
-### Should phase 2 be automatic?
-
-Tim [raised this](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798766024): do
-we actually want to ship phase 2 as automatic thing? If we do, any workloads
-that use it can't ever switch to whatever we do in phase 3
-
-Phase 2 (support for pods with volumes) is out of scope.
 
 <!--
 What other approaches did you consider, and why did you rule them out? These do

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -258,7 +258,31 @@ message NamespaceOption {
     // do not set a user namespace.
     UserNamespace userns_options = 5;
 }
+```
 
+The Mount message will be modified to take the UID/GID mappings. The complete
+Mount is shown here:
+
+```
+// Mount specifies a host volume to mount into a container.
+message Mount {
+    // Path of the mount within the container.
+    string container_path = 1;
+    // Path of the mount on the host. If the hostPath doesn't exist, then runtimes
+    // should report error. If the hostpath is a symbolic link, runtimes should
+    // follow the symlink and mount the real destination to container.
+    string host_path = 2;
+    // If set, the mount is read-only.
+    bool readonly = 3;
+    // If set, the mount needs SELinux relabeling.
+    bool selinux_relabel = 4;
+    // Requested propagation mode.
+    MountPropagation propagation = 5;
+    // uid_mappings specifies the UID mappings for this mount.
+    repeated IDMapping uid_mappings = 6;
+    // gid_mappings specifies the GID mappings for this mount.
+    repeated IDMapping gid_mappings = 7;
+}
 ```
 
 ### Support for stateless pods

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -18,13 +18,13 @@
 - [Design Details](#design-details)
   - [Pod.spec changes](#podspec-changes)
   - [CRI changes](#cri-changes)
-  - [Phases](#phases)
-    - [Phase 1: pods &quot;without&quot; volumes](#phase-1-pods-without-volumes)
-      - [pkg/volume changes for phase I](#pkgvolume-changes-for-phase-i)
-    - [Phase 2: pods with volumes](#phase-2-pods-with-volumes)
-    - [Phase 3: TBD](#phase-3-tbd)
-    - [Unresolved](#unresolved)
-  - [Summary of the Proposed Changes](#summary-of-the-proposed-changes)
+  - [Support for stateless pods](#support-for-stateless-pods)
+  - [Handling of stateless volumes](#handling-of-stateless-volumes)
+    - [Example of how idmap mounts work](#example-of-how-idmap-mounts-work)
+      - [Example without idmap mounts](#example-without-idmap-mounts)
+      - [Example with idmap mounts](#example-with-idmap-mounts)
+    - [Regarding the previous implementation for volumes](#regarding-the-previous-implementation-for-volumes)
+  - [Unresolved](#unresolved)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
@@ -47,6 +47,9 @@
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
+  - [Don't use idmap mounts and rely chown all the files correctly](#dont-use-idmap-mounts-and-rely-chown-all-the-files-correctly)
+  - [64k mappings?](#64k-mappings)
+  - [Allow runtimes to pick the mapping?](#allow-runtimes-to-pick-the-mapping)
 - [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
 <!-- /toc -->
 
@@ -406,9 +409,9 @@ In other words, we can make sure the pod can read files instead of chowning them
 all using the host IDs the pod is mapped to, by just using an idmap mount that
 has the same mapping that we use for the pod user namespace.
 
-##### Regarding the previous implementation for volumes
-We previously added to the [KubeletVolumeHost
-interface][kubeletVolumeHost-interface] the following method:
+#### Regarding the previous implementation for volumes
+We previously added to the [KubeletVolumeHost interface][kubeletVolumeHost-interface]
+the following method:
 
 ```
 GetHostIDsForPod(pod *v1.Pod, containerUID, containerGID *int64) (hostUID, hostGID *int64, err error)
@@ -419,7 +422,7 @@ components that implement the interface.
 
 [kubeletVolumeHost-interface]: https://github.com/kubernetes/kubernetes/blob/36450ee422d57d53a3edaf960f86b356578fe996/pkg/volume/plugins.go#L322
 
-#### Unresolved
+### Unresolved
 
 Here is a list of considerations raised in PRs discussion that hasn't yet
 settle. This list is not exhaustive, we are just trying to put the things that

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -543,8 +543,6 @@ use container runtime versions that have the needed changes.
 
 ### Graduation Criteria
 
-Note this section is a WIP yet.
-
 ##### Alpha
 - Support with idmap mounts
 
@@ -554,8 +552,12 @@ Note this section is a WIP yet.
 - Should we reconsider making the mappings smaller by default?
 - Should we allow any way for users to for "more" IDs mapped? If yes, how many more and how?
 - Should we allow the user to ask for specific mappings?
+- Get review from VM container runtimes maintainers
+- Gather and address feedback from the community
 
 ##### GA
+
+- Gather and address feedback from the community
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -1060,8 +1060,7 @@ For stateless pods this is of course not an issue.
 Tim suggested that we might want to allow the container runtimes to choose the
 mapping and have different runtimes pick different mappings. While KEP authors
 disagree on this, we still need to discuss it and settle on something.  This was
-[raised
-here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798760382)
+[raised here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798760382)
 
 For stateless pods with 64k mappings this is not an issue. This was considered
 something to discuss for pods with volumes (out of scope of this KEP).

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -421,6 +421,19 @@ In other words, we can make sure the pod can read files instead of chowning them
 all using the host IDs the pod is mapped to, by just using an idmap mount that
 has the same mapping that we use for the pod user namespace.
 
+##### Regarding the previous implementation for volumes
+We previously added to the [KubeletVolumeHost
+interface][kubeletVolumeHost-interface] the following method:
+
+```
+GetHostIDsForPod(pod *v1.Pod, containerUID, containerGID *int64) (hostUID, hostGID *int64, err error)
+```
+
+As this is not needed anymore, it will be deleted from the interface and all
+components that implement the interface.
+
+[kubeletVolumeHost-interface]: https://github.com/kubernetes/kubernetes/blob/36450ee422d57d53a3edaf960f86b356578fe996/pkg/volume/plugins.go#L322
+
 #### Unresolved
 
 Here is a list of considerations raised in PRs discussion that hasn't yet

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -413,28 +413,6 @@ we don't want to forget or want to highlight it. Some things that are obvious we
 need to tackle are not listed. Let us know if you think it is important to add
 something else to this list:
 
-- We will start with mappings of 64K. Tim Hockin, however, has expressed
-  concerns. See more info on [this Github discussion](https://github.com/kubernetes/enhancements/pull/3065#discussion_r781676224)
-  SergeyKanzhelev [suggested a nice alternative](https://github.com/kubernetes/enhancements/pull/3065#discussion_r807408134),
-  to limit the number of pods so we guarantee enough spare host UIDs in case we
-  need them for the future. There is no final decision yet on how to handle this.
-  For now we will limit the number of pods, so the wide mapping is not
-  problematic, but [there are downsides to this too](https://github.com/kubernetes/enhancements/pull/3065#discussion_r812806223)
-
-- Tim suggested we should try to not use the whole UID space. Something to keep
-  in mind for next revisions. More info [here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r797100081)
-
-Idem before, see Sergey idea from previous item.
-
-- Tim suggested that we might want to allow the container runtimes to choose
-  the mapping and have different runtimes pick different mappings. While KEP
-  authors disagree on this, we still need to discuss it and settle on something.
-  This was [raised here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798760382)
-
-- (will clarify later with Tim what he really means here). Tim [raised this](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798766024): do
-  we actually want to ship phase 2 as automatic thing? If we do, any workloads
-  that use it can't ever switch to whatever we do in phase 3
-
 - What about windows or VM container runtimes, that don't use linux namespaces?
   We need a review from windows maintainers once we have a more clear proposal.
   We can then adjust the needed details, we don't expect the changes (if any) to be big.
@@ -448,7 +426,6 @@ Idem before, see Sergey idea from previous item.
   allows). Same applies for VM runtimes.
   UPDATE: Windows maintainers reviewed and [this change looks good to them][windows-review].
 
-[windows-review]: https://github.com/kubernetes/enhancements/pull/3275#issuecomment-1121603308
 
 ### Test Plan
 
@@ -1033,6 +1010,40 @@ Why should this KEP _not_ be implemented?
 -->
 
 ## Alternatives
+
+Here is a list of considerations raised in PRs discussion that were considered.
+This list is not exhaustive.
+
+### 64k mappings?
+
+We will start with mappings of 64K. Tim Hockin, however, has expressed
+concerns. See more info on [this Github discussion](https://github.com/kubernetes/enhancements/pull/3065#discussion_r781676224)
+SergeyKanzhelev [suggested a nice alternative](https://github.com/kubernetes/enhancements/pull/3065#discussion_r807408134),
+to limit the number of pods so we guarantee enough spare host UIDs in case we
+need them for the future. There is no final decision yet on how to handle this.
+For now we will limit the number of pods, so the wide mapping is not
+problematic, but [there are downsides to this too](https://github.com/kubernetes/enhancements/pull/3065#discussion_r812806223)
+
+For stateless pods this is of course not an issue.
+
+### Allow runtimes to pick the mapping?
+
+Tim suggested that we might want to allow the container runtimes to choose the
+mapping and have different runtimes pick different mappings. While KEP authors
+disagree on this, we still need to discuss it and settle on something.  This was
+[raised
+here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798760382)
+
+For stateless pods with 64k mappings this is not an issue. This was considered
+something to discuss for pods with volumes (out of scope of this KEP).
+
+### Should phase 2 be automatic?
+
+Tim [raised this](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798766024): do
+we actually want to ship phase 2 as automatic thing? If we do, any workloads
+that use it can't ever switch to whatever we do in phase 3
+
+Phase 2 (support for pods with volumes) is out of scope.
 
 <!--
 What other approaches did you consider, and why did you rule them out? These do

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -61,7 +61,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Graduation criteria is in place
 - [X] (R) Production readiness review completed
 - [X] Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
+- [X] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
@@ -1016,6 +1016,10 @@ For each of them, fill in the following information by copying the below templat
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
 ## Implementation History
+
+2016: First iterations of this KEP, but code never landed upstream.
+Kubernetes 1.25: Support for stateless pods merged (alpha)
+Kubernetes 1.27: Support for stateless pods rework to rely on idmap mounts (alpha)
 
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -421,15 +421,10 @@ something else to this list:
   For now we will limit the number of pods, so the wide mapping is not
   problematic, but [there are downsides to this too](https://github.com/kubernetes/enhancements/pull/3065#discussion_r812806223)
 
-
 - Tim suggested we should try to not use the whole UID space. Something to keep
   in mind for next revisions. More info [here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r797100081)
 
 Idem before, see Sergey idea from previous item.
-
-- While we said that if support is not implemented we will throw a clear error,
-  we have not said if it will be API-rejected at admission time or what. I'd
-  like to see how that code looks like before promising something. Was raised [here](https://github.com/kubernetes/enhancements/pull/3065#discussion_r798730922)
 
 - Tim suggested that we might want to allow the container runtimes to choose
   the mapping and have different runtimes pick different mappings. While KEP

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -502,7 +502,6 @@ Tests are already written for that file.
 The rest of the changes are more about hooking it up so it is called.
 
 - `pkg/kubelet/kuberuntime/kuberuntime_container_linux.go`: 24.05.2022 - 90.8%
-- `pkg/volume/util/operationexecutor/operation_generator.go`: 24.05.2022 - 8.6%
 - `pkg/volume/configmap/configmap.go`: 24.05.2022 - 74.8%
 - `pkg/volume/downwardapi/downwardapi.go`: 24.05.2022 - 61.7%
 - `pkg/volume/secret/secret.go`: 24.05.2022 - 65.7%

--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -973,6 +973,33 @@ This through this both in small and large cases, again with respect to the
 [supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
 -->
 
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+The kubelet is spliting the host UID/GID space for different pods, to use for
+their user namespace mapping. The design allows for 65k pods per node, and the
+resource is limited in the alpha phase to the min between maxPods per node
+kubelet setting and 1024. This guarantees we are not inadvertly exhausting the
+resource.
+
+For container runtimes, they might use more disk space or inodes to chown the
+rootfs. This is if they chose to support this feature without relying on new
+Linux kernels (or supporting old kernels too), as new kernels allow idmap mounts
+and no overhead (space nor inodes) is added with that.
+
+For CRIO and containerd, we are working to incrementally support all variations
+(idmap mounts, no overhead;overlyafs metacopy param, that gives us just inode
+overhead; and a full rootfs chown, that has space overhead) and document them
+appropiately.
+
 ### Troubleshooting
 
 <!--

--- a/keps/sig-node/127-user-namespaces/kep.yaml
+++ b/keps/sig-node/127-user-namespaces/kep.yaml
@@ -15,7 +15,7 @@ approvers:
   - "@derekwaynecarr"
 
 stage: alpha
-latest-milestone: "v1.25"
+latest-milestone: "v1.27"
 milestone:
   alpha: "v1.25"
 


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Change the implementation to rely on idmap mounts. This simplifies the implementation in kubernetes and container runtimes and removes several limitations we hit before

<!-- link to the k/enhancements issue -->
- Issue link: #127 

<!-- other comments or additional information -->
- Other comments: We did a prototype implementation on container runtimes (containerd, runc, CRIO, crun) with @giuseppe and we didn't find anything unexpected.

The change to make this KEP about only stateless pods was discussed last year in sig-node and when we asked for an exception for the 1.25 release (https://groups.google.com/g/kubernetes-sig-release/c/ASWlhA-tIxE/m/mMWeXx_kAwAJ). The first commits of this PR just update the KEP to be about stateless pods, as was agreed, the rest of the commits re-work the KEP to rely on idmap mounts.

cc @thockin @mrunalp @derekwaynecarr @SergeyKanzhelev 