### PR TITLE
KEP-2718 Client exec proxy alpha in 1.27

### DIFF
--- a/keps/sig-auth/2718-20210511-client-exec-proxy/kep.yaml
+++ b/keps/sig-auth/2718-20210511-client-exec-proxy/kep.yaml
@@ -6,7 +6,7 @@ owning-sig: sig-auth
 participating-sigs:
   - sig-cli
   - sig-api-machinery
-status: provisional
+status: implementable
 creation-date: 2021-05-11
 reviewers:
   - "@mikedanese"
@@ -28,13 +28,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.26"
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.26"
-  beta: "v1.27"
-  stable: "v1.28"
+  alpha: "v1.27"
+  beta: TBD
+  stable: TBD
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Client exec proxy KEP alpha in 1.27

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/pull/2693

<!-- other comments or additional information -->
- Other comments: