### PR TITLE
[v1.29] ephemeral-storage-quotas: repromote to beta

### DIFF
--- a/keps/sig-node/1029-ephemeral-storage-quotas/README.md
+++ b/keps/sig-node/1029-ephemeral-storage-quotas/README.md
@@ -50,6 +50,7 @@
   - [Version 1.15](#version-115)
   - [Version 1.24](#version-124)
   - [Version 1.25](#version-125)
+  - [Version 1.27](#version-127)
 - [Drawbacks [optional]](#drawbacks-optional)
 - [Alternatives [optional]](#alternatives-optional)
   - [Alternative quota-based implementation](#alternative-quota-based-implementation)
@@ -940,6 +941,11 @@ If the metrics shows some problems, we can check the log and quota dir with belo
 - Promote `LocalStorageCapacityIsolationFSMonitoring` to Beta, but there is a regression and we revert it to alpha.
 
 ConfigMap rendering [issue](https://github.com/kubernetes/kubernetes/issues/112081) was found in the 1.25.0 release. When ConfigMaps get updated within the API, they do not get rendered to the resulting pod's filesystem by the Kubelet. The feature has been [reverted to alpha](https://github.com/kubernetes/kubernetes/pull/112078) in the 1.25.1 release.
+
+### Version 1.27
+
+- Fix the blocking issue that caused the revert to alpha: [fsquota: only generate pod uuid is nil #112624](https://github.com/kubernetes/kubernetes/pull/112624)
+
 
 ## Drawbacks [optional]
 

--- a/keps/sig-node/1029-ephemeral-storage-quotas/README.md
+++ b/keps/sig-node/1029-ephemeral-storage-quotas/README.md
@@ -33,7 +33,7 @@
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Graduation Criteria](#graduation-criteria)
   - [Phase 1: Alpha (1.15)](#phase-1-alpha-115)
-  - [Phase 2: Beta](#phase-2-beta)
+  - [Phase 2: Beta (v1.29)](#phase-2-beta-v129)
   - [Phase 3: GA](#phase-3-ga)
 - [Performance Benchmarks](#performance-benchmarks)
   - [Elapsed Time](#elapsed-time)
@@ -51,7 +51,7 @@
   - [Version 1.24](#version-124)
   - [Version 1.25](#version-125)
   - [Version 1.27](#version-127)
-  - [Version 1.28](#version-128)
+  - [Version 1.29](#version-129)
 - [Drawbacks [optional]](#drawbacks-optional)
 - [Alternatives [optional]](#alternatives-optional)
   - [Alternative quota-based implementation](#alternative-quota-based-implementation)
@@ -679,7 +679,7 @@ The following criteria applies to
 - Unit test coverage
 - Node e2e test
 
-### Phase 2: Beta
+### Phase 2: Beta (v1.29)
 
 - User feedback
 - Benchmarks to determine latency and overhead of using quotas
@@ -948,9 +948,12 @@ ConfigMap rendering [issue](https://github.com/kubernetes/kubernetes/issues/1120
 - Fix the blocking issue that caused the revert to alpha: <https://github.com/kubernetes/kubernetes/pull/112624> and <https://github.com/kubernetes/kubernetes/pull/115314>.
 - Add test in sig-node test grid for this feature <https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-fsquota-ubuntu>: <https://github.com/kubernetes/test-infra/pull/28616>
 
-### Version 1.28
+### Version 1.29
 
-- Promote `LocalStorageCapacityIsolationFSMonitoring` to Beta
+Promote `LocalStorageCapacityIsolationFSMonitoring` to Beta
+
+- [x] [E2E tests](#e2e-tests)
+- [x] add VolumeStatCalDuration metrics for fsquato monitoring benchmark [#107201](https://github.com/kubernetes/kubernetes/pull/107201)
 
 ## Drawbacks [optional]
 

--- a/keps/sig-node/1029-ephemeral-storage-quotas/README.md
+++ b/keps/sig-node/1029-ephemeral-storage-quotas/README.md
@@ -51,6 +51,7 @@
   - [Version 1.24](#version-124)
   - [Version 1.25](#version-125)
   - [Version 1.27](#version-127)
+  - [Version 1.28](#version-128)
 - [Drawbacks [optional]](#drawbacks-optional)
 - [Alternatives [optional]](#alternatives-optional)
   - [Alternative quota-based implementation](#alternative-quota-based-implementation)
@@ -944,8 +945,12 @@ ConfigMap rendering [issue](https://github.com/kubernetes/kubernetes/issues/1120
 
 ### Version 1.27
 
-- Fix the blocking issue that caused the revert to alpha: [fsquota: only generate pod uuid is nil #112624](https://github.com/kubernetes/kubernetes/pull/112624)
+- Fix the blocking issue that caused the revert to alpha: <https://github.com/kubernetes/kubernetes/pull/112624> and <https://github.com/kubernetes/kubernetes/pull/115314>.
+- Add test in sig-node test grid for this feature <https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-fsquota-ubuntu>: <https://github.com/kubernetes/test-infra/pull/28616>
 
+### Version 1.28
+
+- Promote `LocalStorageCapacityIsolationFSMonitoring` to Beta
 
 ## Drawbacks [optional]
 

--- a/keps/sig-node/1029-ephemeral-storage-quotas/kep.yaml
+++ b/keps/sig-node/1029-ephemeral-storage-quotas/kep.yaml
@@ -14,10 +14,10 @@ approvers:
   - "@derekwaynecarr"
 editor: TBD
 creation-date: 2018-09-06
-last-updated: 2023-04-04
+last-updated: 2023-08-31
 status: implementable
-latest-milestone: "1.28"
+latest-milestone: "1.29"
 stage: "beta"
 milestone:
   alpha: "1.15"
-  beta: "1.28"
+  beta: "1.29"

--- a/keps/sig-node/1029-ephemeral-storage-quotas/kep.yaml
+++ b/keps/sig-node/1029-ephemeral-storage-quotas/kep.yaml
@@ -14,10 +14,10 @@ approvers:
   - "@derekwaynecarr"
 editor: TBD
 creation-date: 2018-09-06
-last-updated: 2022-08-30
+last-updated: 2023-02-02
 status: implementable
-latest-milestone: "1.15"
-stage: "alpha"
+latest-milestone: "1.27"
+stage: "beta"
 milestone:
   alpha: "1.15"
-  
+  beta: "1.27"

--- a/keps/sig-node/1029-ephemeral-storage-quotas/kep.yaml
+++ b/keps/sig-node/1029-ephemeral-storage-quotas/kep.yaml
@@ -14,10 +14,10 @@ approvers:
   - "@derekwaynecarr"
 editor: TBD
 creation-date: 2018-09-06
-last-updated: 2023-02-02
+last-updated: 2023-04-04
 status: implementable
-latest-milestone: "1.27"
+latest-milestone: "1.28"
 stage: "beta"
 milestone:
   alpha: "1.15"
-  beta: "1.27"
+  beta: "1.28"


### PR DESCRIPTION
#1029: Quotas for Ephemeral Storage

- One-line PR description: re-promote LocalStorageCapacityIsolationFSQuotaMonitoring feature to beta

- Issue link: https://github.com/kubernetes/enhancements/issues/1029

- Other comments: https://github.com/kubernetes/enhancements/issues/1029#issuecomment-1413045741

This is discussed in recent sig-node meetings.

- The last promote PR: https://github.com/kubernetes/enhancements/pull/2697, and I think this feature is almost meets the beta bar. 
- https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-fsquota-ubuntu : test grid was added.
- -  the blocker is fixed in https://github.com/kubernetes/kubernetes/pull/115314.

**Pros:** 
- without this feature, du in some scenarios will hang or take too much time. 
- metrics were added https://github.com/kubernetes/kubernetes/pull/107201
- https://github.com/kubernetes/kubernetes/pull/107490
- the blocking issue mentioned is fixed as above.

**Cons:**
-  if quota id is changed in the kernel layer, is there any potential security problem? 


I prefer to promote this if there is no new issue raising about this feature. The last promotion helped us find the bug https://github.com/kubernetes/kubernetes/pull/112624 and https://github.com/kubernetes/kubernetes/pull/115314 that we fixed recently.
- If there are still other concerns about promoting the feature, we may postpone deciding whether to promote it in v1.28.