### PR TITLE
KEP-3805: Server-side apply by default in kubectl

### DIFF
--- a/keps/prod-readiness/sig-cli/3805.yaml
+++ b/keps/prod-readiness/sig-cli/3805.yaml
@@ -1,0 +1,6 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 3805
+alpha:
+  approver: "@johnbelamaric"

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -1,0 +1,496 @@
+<!--
+
+# KEP-3805: Server-Side Apply default in Kubectl
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+    - [Story 2](#story-2)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+<!--
+This section is incredibly important for producing high-quality, user-focused
+documentation such as release notes or a development roadmap. It should be
+possible to collect this information before implementation begins, in order to
+avoid requiring implementors to split their attention between writing release
+notes and implementing the feature itself. KEP editors and SIG Docs
+should help to ensure that the tone and content of the `Summary` section is
+useful for a wide audience.
+
+A good summary is probably at least a paragraph in length.
+
+Both in this section and below, follow the guidelines of the [documentation
+style guide]. In particular, wrap lines to a reasonable length, to make it
+easier for reviewers to cite specific portions, and to minimize diff churn on
+updates.
+
+[documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
+-->
+
+## Motivation
+
+<!--
+This section is for explicitly listing the motivation, goals, and non-goals of
+this KEP.  Describe why the change is important and the benefits to users. The
+motivation section can optionally provide links to [experience reports] to
+demonstrate the interest in a KEP within the wider Kubernetes community.
+
+[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
+-->
+
+### Goals
+
+<!--
+List the specific goals of the KEP. What is it trying to achieve? How will we
+know that this has succeeded?
+-->
+
+### Non-Goals
+
+<!--
+What is out of scope for this KEP? Listing non-goals helps to focus discussion
+and make progress.
+-->
+
+## Proposal
+
+<!--
+This is where we get down to the specifics of what the proposal actually is.
+This should have enough detail that reviewers can understand exactly what
+you're proposing, but should not include things like API designs or
+implementation. What is the desired outcome and how do we measure success?.
+The "Design Details" section below is for the real
+nitty-gritty.
+-->
+
+### User Stories (Optional)
+
+<!--
+Detail the things that people will be able to do if this KEP is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+-->
+
+#### Story 1
+
+#### Story 2
+
+### Notes/Constraints/Caveats (Optional)
+
+<!--
+What are the caveats to the proposal?
+What are some important details that didn't come across above?
+Go in to as much detail as necessary here.
+This might be a good place to talk about core concepts and how they relate.
+-->
+
+### Risks and Mitigations
+
+<!--
+What are the risks of this proposal, and how do we mitigate? Think broadly.
+For example, consider both security and how this will impact the larger
+Kubernetes ecosystem.
+
+How will security be reviewed, and by whom?
+
+How will UX be reviewed, and by whom?
+
+Consider including folks who also work outside the SIG or subproject.
+-->
+
+## Design Details
+
+<!--
+This section should contain enough information that the specifics of your
+change are understandable. This may include API specs (though not always
+required) or even code snippets. If there's any ambiguity about HOW your
+proposal will be implemented, this is the place to discuss them.
+-->
+
+### Test Plan
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Consider the following in developing a test plan for this enhancement:
+- Will there be e2e and integration tests, in addition to unit tests?
+- How will it be tested in isolation vs with other components?
+
+No need to outline all of the test cases, just the general strategy. Anything
+that would count as tricky in the implementation, and anything particularly
+challenging to test, should be called out.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
+when drafting this test plan.
+
+[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, or as something else. The KEP
+should keep this high-level with a focus on what signals will be looked at to
+determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+
+#### Alpha
+
+- Feature implemented behind a feature flag
+- Initial e2e tests completed and enabled
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Complete features A, B, C
+- Additional tests are in Testgrid and linked in KEP
+
+#### GA
+
+- N examples of real-world usage
+- N installs
+- More rigorous forms of testing—e.g., downgrade tests and scalability tests
+- Allowing time for feedback
+
+**Note:** Generally we also wait at least two releases between beta and
+GA/stable, because there's no opportunity for user feedback, or even bug reports,
+in back-to-back releases.
+
+**For non-optional features moving to GA, the graduation criteria must include
+[conformance tests].**
+
+[conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
+
+#### Deprecation
+
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+
+### Upgrade / Downgrade Strategy
+
+<!--
+If applicable, how will the component be upgraded and downgraded? Make sure
+this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to maintain previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to make use of the enhancement?
+-->
+
+### Version Skew Strategy
+
+<!--
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- Does this enhancement involve coordinating behavior in the control plane and
+  in the kubelet? How does an n-2 kubelet without this feature available behave
+  when this feature is used?
+- Will any other components on the node change? For example, changes to CSI,
+  CRI or CNI may require updating that component before the kubelet.
+-->
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+- [x] Other
+  - Describe the mechanism:
+
+People can actively use the `--server-side=false` flag to disable the
+feature entirely and go back to the former behavior.
+
+  - Will enabling / disabling the feature require downtime of the control
+    plane?
+
+Feature is client-side only, no.
+
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node? (Do not assume `Dynamic Kubelet Config` feature is enabled).
+
+Feature is client-side only, no.
+
+###### Does enabling the feature change any default behavior?
+
+Yes. The feature is a change to the default behavior, which can be
+reverted by using the former value of the flag.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+No. kubectl is distributed and we have no control over how it's used or
+way to configure it's default value.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+Toggling the flag value can have impact, but that's already the case.
+Changing the default to an automatic detection will actually help with
+that.
+
+###### Are there any tests for feature enablement/disablement?
+
+Since enablement is not done through a feature gate, tests are fairly
+easy to implement.
+
+### Rollout, Upgrade and Rollback Planning
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+In the context of this change, a rollback would possibly be someone
+switching from server-side apply to client-side apply and vice-versa.
+This problem isn't new and is one of the reason that motivates this
+change. It mostly works well when the default fieldmanager is being
+used.
+
+<<[UNRESOLVED bad description of the problems here ]>>
+We could certainly make a much better analysis of the problems we have
+migrating from server-side to client-side and vice-versa here.
+<<[/UNRESOLVED]>>
+
+###### What specific metrics should inform a rollback?
+
+People should inform their decision based on the direct error they get
+from kubectl as they are trying to apply their resources.
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+We have a series of tests for that.
+
+<<[UNRESOLVED find the tests ]>>
+I need to add the tests here.
+<<[/UNRESOLVED]>>
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+This will change the default behavior of `kubectl apply` in possibly
+surprising way. `kubectl apply` can now fail because of a conflict,
+which it wouldn't before on newly created objects. Another surprising
+behavior is that since fields can be owned by multiple actors, removing
+a field will not necessarily remove the field from the cluster's
+resource.
+
+### Monitoring Requirements
+
+N/A. No monitoring in place.
+
+###### How can an operator determine if the feature is in use by workloads?
+
+`kubectl apply -V8` can help identify what type of apply is used. Also
+checking the presence of the last applied annotation on the cluster
+resource indicates whether the resource was client-side or server-side
+applied.
+
+###### How can someone using this feature know that it is working for their instance?
+
+- [x] Other (treat as last resort)
+  - Details: Kubectl will fail with an error right away.
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+N/A.
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+N/A.
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+N/A.
+
+### Dependencies
+
+###### Does this feature depend on any specific services running in the cluster?
+
+Feature depends on server-side apply being enabled in the cluster, but
+the feature has been GA since 1.22 and is now guaranteed to be present
+in all clusters supported by the kubectl version (1 version schew).
+
+### Scalability
+
+###### Will enabling / using this feature result in any new API calls?
+
+For now, we will continue to get resources before server-side applying,
+which means that the number of requests will be similar (one GET, one
+PATCH). This is done because we need to verify if the resource needs to
+be client-side applied or server-side applied.
+
+It's important to note that server-side apply ALWAYS sends a patch while
+client-side could by-pass the send. This has an impact on the apiserver
+since all the requests need to be processed, including by webhooks which
+can increase the cluster load.
+
+###### Will enabling / using this feature result in introducing new API types?
+
+No.
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+No.
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+This should reduce the size of api objects since the last applied
+annotation is not going to be introduced in new objects.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+PATCH requests are going to be more frequent since all the applied
+objects will be sent to the server.
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+API Server might have to process more requests, leading to increased CPU
+and RAM usage. Non-changes should continue to be skipped by etcd, which
+shouldn't result in a major disk/IO increase.
+
+### Troubleshooting
+
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+N/A.
+
+###### What are other known failure modes?
+
+Main failure mode is if kubectl fails to apply the resource, which will
+lead to a direct error to the user.
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+## Implementation History
+
+N/A
+
+## Drawbacks
+
+Mainly two drawbacks to this KEP:
+1. Resource usage will increase on apiservers since patch requests will
+   have to be processed everytime.
+2. This will change the default behavior of kubectl apply which might
+   surprise some users.
+
+## Alternatives
+
+There are basically three different alternatives to the current design:
+1. Status-quo: we keep client-side as the default for everything,
+   offering the `--server-side=true` flag for who wants to use it.
+   Drawback is that this situation is still confusing for users, and
+   users are missing out on the new features of server-side apply.
+2. Make `--server-side=auto` continue to client-side apply by default,
+   but automatically server-side objects that have been previously
+   server-side applied. The drawback of this approach is that the baby
+   step doens't really get us anywhere close to where we want: having
+   server-side apply enabled by default.
+3. Enable `--server-side=true` by default, this is what we're aiming for
+   in GA, but we think we should ease things by first going with
+   `--server-side=auto` to help the transition.
+
+## Infrastructure Needed (Optional)
+
+N/A

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -1,5 +1,3 @@
-<!--
-
 # KEP-3805: Server-Side Apply default in Kubectl
 
 <!-- toc -->
@@ -16,6 +14,10 @@
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
@@ -41,7 +43,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [ ] (R) Design details are appropriately documented
 - [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [ ] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
@@ -164,23 +166,65 @@ proposal will be implemented, this is the place to discuss them.
 
 ### Test Plan
 
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
 <!--
-**Note:** *Not required until targeted at a release.*
-
-Consider the following in developing a test plan for this enhancement:
-- Will there be e2e and integration tests, in addition to unit tests?
-- How will it be tested in isolation vs with other components?
-
-No need to outline all of the test cases, just the general strategy. Anything
-that would count as tricky in the implementation, and anything particularly
-challenging to test, should be called out.
-
-All code is expected to have adequate tests (eventually with coverage
-expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
-when drafting this test plan.
-
-[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+Based on reviewers feedback describe what additional tests need to be added prior
+implementing this enhancement to ensure the enhancements have also solid foundations.
 -->
+
+##### Unit tests
+
+<!--
+In principle every added code should have complete unit test coverage, so providing
+the exact set of tests will not bring additional value.
+However, if complete unit test coverage is not possible, explain the reason of it
+together with explanation why this is acceptable.
+-->
+
+<!--
+Additionally, for Alpha try to enumerate the core package you will be touching
+to implement this enhancement and provide the current unit coverage for those
+in the form of:
+- <package>: <date> - <current test coverage>
+The data can be easily read from:
+https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
+
+This can inform certain test coverage improvements that we want to do before
+extending the production code to implement this enhancement.
+-->
+
+- `<package>`: `<date>` - `<test coverage>`
+
+##### Integration tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+-->
+
+- <test>: <link to test coverage>
+
+##### e2e tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+
+We expect no non-infra related flakes in the last month as a GA graduation criteria.
+-->
+
+- <test>: <link to test coverage>
 
 ### Graduation Criteria
 
@@ -189,12 +233,13 @@ when drafting this test plan.
 
 Define graduation milestones.
 
-These may be defined in terms of API maturity, or as something else. The KEP
-should keep this high-level with a focus on what signals will be looked at to
-determine graduation.
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
 
 Consider the following in developing the graduation criteria for this enhancement:
 - [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
 - [Deprecation policy][deprecation-policy]
 
 Clearly define what graduation means by either linking to the [API doc
@@ -204,6 +249,7 @@ or by redefining what graduation means.
 In general we try to use the same stages (alpha, beta, GA), regardless of how the
 functionality is accessed.
 
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
 [maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
 [deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
 

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -300,7 +300,7 @@ This can inform certain test coverage improvements that we want to do before
 extending the production code to implement this enhancement.
 -->
 
-- `<package>`: `<date>` - `<test coverage>`
+- `k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/apply`: `2023-01-24` - `76.5%`
 
 ##### Integration tests
 
@@ -312,7 +312,7 @@ For Beta and GA, add links to added tests together with links to k8s-triage for 
 https://storage.googleapis.com/k8s-triage/index.html
 -->
 
-- <test>: <link to test coverage>
+CLI tests will be added to both `test/cmd/diff.sh` and `test/cmd/apply.sh`.
 
 ##### e2e tests
 
@@ -326,7 +326,10 @@ https://storage.googleapis.com/k8s-triage/index.html
 We expect no non-infra related flakes in the last month as a GA graduation criteria.
 -->
 
-- <test>: <link to test coverage>
+e2e tests will be added to check that:
+- Migration from `auto` to `true` or `false` works as expected
+- Auto behaves properly both on client-side applied and server-side applied objects
+- As we add the deprecation, it is exposed given the right circumstances
 
 ### Graduation Criteria
 

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -135,8 +135,8 @@ The meaning of `auto` goes as follows:
   annotation, the resource is server-side applied
 
 We are also planning on switch the `--server-side` flag to `true` in
-three releases, by adding a warning message (and a blog-post) in kubectl
-1.27 to let people know that the change will happen.
+three releases, and while we would like to add a warning and blog-post
+as early as 1.27, we have not agreed on all the terms of the change yet.
 
 <<[UNRESOLVED What default value for --force-conflict]>>
 We're not entirely sure what the value of `--force-conflict` should be
@@ -149,7 +149,14 @@ but arguably a much smaller set of people.
 
 We don't know yet, but I'll assume we don't flip the force-conflict
 switch (keep it to false) in the rest of the document since that
-use-case is more complicated. <<[/UNRESOLVED]>>
+use-case is more complicated.
+<<[/UNRESOLVED]>>
+
+<<[UNRESOLVED Can we add the flag if we agree on terms before
+code-freeze?]>> We know we want a warning, but since we don't know what
+value of force-conflict we want yet, we don't know what the warning will
+look like, we would still love to insert the warning in 1.27 if we can.
+<<[/UNRESOLVED]>>
 
 <<[UNRESOLVED Removal of CSA]>>
 We considered removing the

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -134,9 +134,15 @@ The meaning of `auto` goes as follows:
 - If the resource already exists but doesn't have the `last-applied`
   annotation, the resource is server-side applied
 
-We are also planning on switch the `--server-side` flag to `true` in
-three releases, and while we would like to add a warning and blog-post
-as early as 1.27, we have not agreed on all the terms of the change yet.
+For the alpha phase, the auto value will only be visible and usable if
+the `KUBECTL_AUTO_SERVER_SIDE` is set. That variable will later be
+removed once the flag is available for everyone, without breaking any
+compatibility.
+
+Our ultimate goal is to switch the `--server-side` flag to `true` as
+early as permissible by Kubernetes deprecation policies. If the terms of
+the change are finalized in time for code freeze, we will add a warning
+and blog-post about this as part of the 1.27 release.
 
 <<[UNRESOLVED What default value for --force-conflict]>>
 We're not entirely sure what the value of `--force-conflict` should be
@@ -152,10 +158,10 @@ switch (keep it to false) in the rest of the document since that
 use-case is more complicated.
 <<[/UNRESOLVED]>>
 
-<<[UNRESOLVED Can we add the flag if we agree on terms before
-code-freeze?]>> We know we want a warning, but since we don't know what
-value of force-conflict we want yet, we don't know what the warning will
-look like, we would still love to insert the warning in 1.27 if we can.
+<<[UNRESOLVED Can we add the flag if we agree on terms before code-freeze?]>>
+We know we want a warning, but since we don't know what value of
+force-conflict we want yet, we don't know what the warning will look
+like, we would still love to insert the warning in 1.27 if we can.
 <<[/UNRESOLVED]>>
 
 <<[UNRESOLVED Removal of CSA]>>

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -147,9 +147,9 @@ trade-off: Are conflicts worth breaking people? We would also have to
 change the value of `--force-conflict`, which will break some people,
 but arguably a much smaller set of people.
 
-We don't know yet, but I'll assume we don't flip the switch in the rest
-of the document since that use-case is more complicated.
-<<[/UNRESOLVED]>>
+We don't know yet, but I'll assume we don't flip the force-conflict
+switch (keep it to false) in the rest of the document since that
+use-case is more complicated. <<[/UNRESOLVED]>>
 
 <<[UNRESOLVED Removal of CSA]>>
 We considered removing the

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -102,8 +102,11 @@ For maintainers:
   mechanisms. Removing the feature can greatly reduce the complexity of
   kubectl
 - Removes some ugly server-side code meant to deal with transition from
-  client-side apply to server-side apply (see
-  https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/)
+  client-side apply to server-side apply
+
+A lot of the benefits of using server-side apply has already been
+discussed in blog-posts, see
+https://kubernetes.io/blog/2022/10/20/advanced-server-side-apply/.
 
 ### Goals
 

--- a/keps/sig-cli/3805-ssa-default/README.md
+++ b/keps/sig-cli/3805-ssa-default/README.md
@@ -376,7 +376,8 @@ N/A.
 - [x] Other
   - Describe the mechanism:
 
-Feature is enabled on-demand, and can stop using it at any time.
+Feature is enabled on-demand, and can stop using it at any time. It also
+requires the `KUBECTL_AUTO_SERVER_SIDE` environment variable to be set.
 
   - Will enabling / disabling the feature require downtime of the control
     plane?
@@ -394,8 +395,7 @@ No, enabling the `auto` feature means actively selecting it.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-No. kubectl is distributed and we have no control over how it's used or
-way to configure it's default value.
+The feature can be disabled by unsetting the `KUBECTL_AUTO_SERVER_SIDE` environment variable.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 

--- a/keps/sig-cli/3805-ssa-default/kep.yaml
+++ b/keps/sig-cli/3805-ssa-default/kep.yaml
@@ -1,0 +1,26 @@
+title: Kubectl Server-Side Apply by default
+kep-number: 3805
+authors:
+  - "@apelisse"
+owning-sig: sig-cli
+participating-sigs:
+  - sig-api-machinery
+status: provisional
+creation-date: 2023-02-02
+reviewers:
+  - "@knverey"
+  - "@alexzielenski"
+approvers:
+  - "@knverey"
+see-also:
+  - "/keps/sig-api-machinery/555-server-side-apply"
+replaces:
+stage: beta
+latest-milestone: "v1.27"
+milestone:
+  alpha: "v1.22" # Feature is alpha since SSA is GA
+  beta: "v1.27"
+  stable: "v1.30" # Provisional
+feature-gates: # N/A
+disable-supported: false
+metrics: # N/A

--- a/keps/sig-cli/3805-ssa-default/kep.yaml
+++ b/keps/sig-cli/3805-ssa-default/kep.yaml
@@ -15,12 +15,12 @@ approvers:
 see-also:
   - "/keps/sig-api-machinery/555-server-side-apply"
 replaces:
-stage: beta
+stage: alpha
 latest-milestone: "v1.27"
 milestone:
-  alpha: "v1.22" # Feature is alpha since SSA is GA
-  beta: "v1.27"
-  stable: "v1.30" # Provisional
+  alpha: "v1.27"
+  beta: "v1.30" # Provisional
+  stable: "v1.32" # Provisional
 feature-gates: # N/A
 disable-supported: false
 metrics: # N/A


### PR DESCRIPTION
- One-line PR description: KEP attempts to provide a path toward having server-side apply enabled by default in kubectl.
- Issue link: https://github.com/kubernetes/enhancements/issues/3805
- Other comments: Very drafty for now, I haven't included any of the design, mostly went for the PRR section.
Also note that the "feature" doesn't quite fit the KEP process, we went with the KEP route as a good way to get tracking, discussion, risk, mitigation, test and design, but the alpha/beta/stable don't really make much sense for a client-side flag.