### PR TITLE
Update kep.yaml for 1.27

### DIFF
--- a/keps/sig-api-machinery/3488-cel-admission-control/kep.yaml
+++ b/keps/sig-api-machinery/3488-cel-admission-control/kep.yaml
@@ -38,7 +38,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.26"
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Update kep.yaml for CEL admission control (ValidatingAdmissionPolicy) to reflect that alpha work will continue to be merged in 1.27

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3488

<!-- other comments or additional information -->
- Other comments:

Work planned for 1.27:

- https://github.com/kubernetes/enhancements/pull/3732
- https://github.com/kubernetes/enhancements/pull/3669
- https://github.com/kubernetes/enhancements/pull/3697
- https://github.com/kubernetes/enhancements/pull/3812
- https://github.com/kubernetes/enhancements/pull/3736

