### PR TITLE
KEP-1040: Push GA to release 1.28

### DIFF
--- a/keps/sig-api-machinery/1040-priority-and-fairness/kep.yaml
+++ b/keps/sig-api-machinery/1040-priority-and-fairness/kep.yaml
@@ -33,7 +33,7 @@ latest-milestone: "v1.27"
 milestone:
   alpha: "v1.18"
   beta: "v1.20"
-  stable: "v1.27"
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release.
 # List the feature gate name and the components for which it must be enabled.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update GA target for API Priority and Fairness to release 1.28

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: the reason is to allow time for feedback on the concurrency borrowing introduced in release 1.26.