### PR TITLE
add new template question to KEP-3453 and KEP-3705

### DIFF
--- a/keps/sig-network/3453-minimize-iptables-restore/README.md
+++ b/keps/sig-network/3453-minimize-iptables-restore/README.md
@@ -474,6 +474,10 @@ usage, since kube-proxy will be waking up to resync more often. But
 this is a CPU usage increase that the administrator is more-or-less
 explicitly requesting.)
 
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+No
+
 ### Troubleshooting
 
 ###### How does this feature react if the API server and/or etcd is unavailable?

--- a/keps/sig-network/3705-cloud-node-ips/README.md
+++ b/keps/sig-network/3705-cloud-node-ips/README.md
@@ -703,6 +703,10 @@ No
 
 No
 
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+No
+
 ### Troubleshooting
 
 <!--


### PR DESCRIPTION
- One-line PR description:
Update KEP-3453 (MinimizeIPTablesRestore) and KEP-3705 (CloudNodeIPs) with the new "resource leak" PRR question from the template. Neither KEP does anything especially different with sockets/PIDs/inodes relative to the current state, so it's an easy "No" for both of them.

- Issue link:
  - https://github.com/kubernetes/enhancements/issues/3453
  - https://github.com/kubernetes/enhancements/issues/3705

/sig network
/priority important-soon
/assign @thockin 