### PR TITLE
KEP-3488: Secondary authz for CEL admission control

### DIFF
--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1122,7 +1122,7 @@ authorization attributes.
 
 Example expressions using `authorizer`:
 
-- `authorizer.resource('signers', 'certificates.k8s.io', '*').name(oldObject.spec.signerName).allowed('approve')`
+- `authorizer.resource('signers', 'certificates.k8s.io', '*').name(oldObject.spec.signerName).check('approve').allowed()`
 - `authorizer.path('/metrics').denied('get')`
 
 Note that this API:

--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1100,9 +1100,10 @@ We will support admission control use cases requiring permission checks:
 - Validate that only a controller responsible for a finalizer can remove it from the finalizers
   field.
 
-To depend on an authz decision, validation expressions can reference the identifier `authorizer`,
-which will be bound at evaluation time to an Authorizer object supporting receiver-style function
-overloads:
+To depend on an authz decision, validation expressions can use the `authorizer`
+variable, which performs authz checks for the admission request user (the same
+use as identified by `request.userInfo`), and which will be bound at evaluation
+time to an Authorizer object supporting receiver-style function overloads:
 
 | Symbol      | Type                                                                    | Description                                                                                     |
 |-------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
@@ -1112,9 +1113,9 @@ overloads:
 | subresource | ResourceCheck.(subresource string) -> ResourceCheck                     | Specifies thath the check is for a subresource                                                  |
 | namespace   | ResourceCheck.(namespace string) -> ResourceCheck                       | Specifies that the check is for a namespace (if not called, the check is for the cluster scope) |
 | name        | ResourceCheck.(name string) -> ResourceCheck                            | Specifies that the check is for a specific resource name                                        |
-| check       | ResourceCheck.(apiVerb string) -> Decision                              | Checks if the user is authorized for the API verb on the resource                               |
-| allowed     | Decision.() -> bool                                                     | Is the user authorized?                                                                         |
-| denied      | Decision.() -> bool                                                     | Is the user denied authorization?                                                               |
+| check       | ResourceCheck.(apiVerb string) -> Decision                              | Checks if the admission request user is authorized for the API verb on the resource             |
+| allowed     | Decision.() -> bool                                                     | Is the admission request user authorized?                                                       |
+| denied      | Decision.() -> bool                                                     | Is the admission request user denied authorization?                                             |
 
 xref: https://kubernetes.io/docs/reference/access-authn-authz/authorization/#review-your-request-attributes for a details on
 authorization attributes.

--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1094,23 +1094,78 @@ repeated evaluations if they are shared across validations.
 
 #### Secondary Authz
 
-We have general agreement to include this as a feature, but need to provide
-a concrete design.
+TODO: background and motivation
 
-kube-apiserver authorizer checks (aka Secondary-authz checks) have been proposed
-as a way of doing things like:
-
-- Validate that only a user with a specific permission can set a particular
+- Validate that only a user with a specific permission can set a particular field.
+- Validate that only a controller responsible for a finalizer can remove it from the finalizers
   field.
-- Validate that only a controller responsible for a finalizer can remove it from
-  the finalizers field.
 
-This could be supported by matching criteria, or via CEL expression access, or both.
- 
-Use cases:
+To depend on an authz decision, validation expressions can reference the identifier `authorizer`,
+which will be bound at evaluation time to an Authorizer object supporting receiver-style function
+overloads:
+
+| Symbol      | Type                                                 | Description |
+|-------------|------------------------------------------------------|-------------|
+| path        | Authorizer.(string) -> PathCheck                     | todo        |
+| check       | PathCheck.(string) -> Decision                       | todo        |
+| resource    | Authorizer.(string, string, string) -> ResourceCheck | todo        |
+| subresource | ResourceCheck.(string) -> ResourceCheck              | todo        |
+| namespace   | ResourceCheck.(string) -> ResourceCheck              | todo        |
+| name        | ResourceCheck.(string) -> ResourceCheck              | todo        |
+| check       | ResourceCheck.(string) -> Decision                   | todo        |
+| allowed     | Decision.() -> bool                                  | todo        |
+| denied      | Decision.() -> bool                                  | todo        |
+
+Example expressions using `authorizer`:
+
+- `authorizer.resource('signers', 'certificates.k8s.io', '*').name(oldObject.spec.signerName).check('approve').allowed()`
+- `authorizer.path('/metrics').check('get').denied()`
+
+Note that this API:
+
+- Produces errors at compilation time when parameters are missing or improperly combined
+  (e.g. subresource with non-resource path, missing path or resource).
+- Is open to the addition of future knobs (e.g. impersonation).
+
+Other considerations:
+
+- Does there need to be a special limit on the number of authz checks generated during expression
+  evaluation, or is it sufficient to assign an appropriate fixed cost?
+- Since authorization decisions depend on an apiserver's authorizer, and the
+  ValidatingAdmissionPolicy plugin is supported on [aggregated API
+  servers](#aggregated-api-servers), the evaluation result of any validation expression involving
+  secondary authz inherently depends on which apiserver evalutes it.
+- A validation expression could be written such that it allows malicious clients to probe
+  permissions. Policy authors are responsible for careful use of client-provided inputs when
+  constructing authz checks.
+- Decisions can be stored either as a [variable](#variables) or as part of the implementation of the
+  object bound to the exposed `authorizer` object (i.e. caching decisions for identical checks
+  within a single policy evaluation) in order to prevent duplicate checks across multiple validation
+  expressions.
+
+Use cases in existing admission plugins:
 
 - PodSecurityPolicy (kube)
 - CertificateApproval (kube)
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "certificate-approval-policy.example.com"
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["certificates.k8s.io"]
+      apiVersions: ["*"]
+      operations:  ["UPDATE"]
+      resources:   ["certificatesigningrequests/approval"]
+  validations:
+  - expression: "authorizer.resource('signers', 'certificates.k8s.io', '*').name(oldObject.spec.signerName).check('approve').allowed() || authorizer.resource('signers', 'certificates.k8s.io', '*').name([oldObject.spec.signerName.split('/')[0], '*'].join('/')).check('approve').allowed()"
+    reason: Forbidden
+    messageExpression: "user not permitted to approve requests with signerName %q".format([oldObject.spec.signerName])"
+```
+
 - CertificateSigning (kube)
 - OwnerReferencesPermissionEnforcement (kube)
 - network.openshift.io/ExternalIPRanger


### PR DESCRIPTION
- One-line PR description: Add proposed design for secondary authz via CEL validation policies.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3488

<!-- other comments or additional information -->
- Other comments: This is a fork of https://github.com/kubernetes/enhancements/pull/3812