### PR TITLE
Drop version() from CEL Secondary Authz, clarify that authz uses GVR

### DIFF
--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1377,7 +1377,7 @@ authorization attributes.
 
 Example expressions using `authorizer`:
 
-- `authorizer.resource('signers').group('certificates.k8s.io', '*').name(oldObject.spec.signerName).check('approve').allowed()`
+- `authorizer.resource('signers').group('certificates.k8s.io').name(oldObject.spec.signerName).check('approve').allowed()`
 - `authorizer.path('/metrics').denied('get')`
 
 Note that this API:

--- a/keps/sig-api-machinery/3488-cel-admission-control/README.md
+++ b/keps/sig-api-machinery/3488-cel-admission-control/README.md
@@ -1363,8 +1363,8 @@ time to an Authorizer object supporting receiver-style function overloads:
 |-------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
 | path        | Authorizer.(path string) -> PathCheck                                   | Defines a check for an non-resource request path (e.g. /healthz)                                |
 | check       | PathCheck.(httpRequestVerb string) -> Decision                          | Checks if the user is authorized for the HTTP request verb on the path                          |
-| resource    | Authorizer.(resource string) -> ResourceCheck                           | Defines a check for an API resource                                                             |
-| group       | ResourceCheck.(group string) -> ResourceCheck                           | Specifies the group for the API resource check                                                  |
+| group       | Authorizer.(group string) -> GroupCheck                                 | Defines a check for a API group, core is identified by ''                                       |
+| resource    | GroupCheck.(resource string) -> ResourceCheck                           | Defines a check for an API resource                                                             |
 | subresource | ResourceCheck.(subresource string) -> ResourceCheck                     | Specifies that the check is for a subresource                                                   |
 | namespace   | ResourceCheck.(namespace string) -> ResourceCheck                       | Specifies that the check is for a namespace (if not called, the check is for the cluster scope) |
 | name        | ResourceCheck.(name string) -> ResourceCheck                            | Specifies that the check is for a specific resource name                                        |


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Clean up some details about Secondary Authz for CEL

Fixes are:
- Clarify that authz uses GVR, not GVK
- Add rationale for why `version()` will not be included in CEL's authz check API
- Note that "*" will always be sent for version

cc @liggitt @benluddy @tallclair 

/sig api-machinery