### PR TITLE
KEP-3638: Rename KEP-3638

### DIFF
--- a/keps/sig-cli/3638-built-in-command-shadowing/README.md
+++ b/keps/sig-cli/3638-built-in-command-shadowing/README.md
@@ -1,4 +1,4 @@
-# KEP-3638: Enable built-in command shadowing by plugins 
+# KEP-3638: Improve kubectl plugin resolution for non-shadowing subcommands 
 <!--
 A table of contents is helpful for quickly jumping to sections of a KEP and for
 highlighting any additional information provided beyond the standard KEP


### PR DESCRIPTION
This PR renames KEP-3638 to `Improve kubectl plugin resolution for non-shadowing subcommands` to make it more descriptive.

/cc @soltysh 