### PR TITLE
KEP-1487: Mark AWS EBS CSI migration as done

### DIFF
--- a/keps/sig-storage/1487-csi-migration-aws/kep.yaml
+++ b/keps/sig-storage/1487-csi-migration-aws/kep.yaml
@@ -12,9 +12,9 @@ approvers:
   - "@msau42"
 editor: "@Jiawei0227"
 creation-date: 2022-01-05
-last-updated: 2022-01-05
+last-updated: 2023-02-14
 disable-supported: true
-status: implementable
+status: implemented
 see-also:
   - "https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md"
 replaces:


### PR DESCRIPTION
- One-line PR description: Mark the feature as `implemented`

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1487

<!-- other comments or additional information -->
- Other comments: