### PR TITLE
seccomp: updated text clarifying that enabled by default doesn't mean the flag will be enabled, only feature gate

### DIFF
--- a/keps/sig-node/2413-seccomp-by-default/README.md
+++ b/keps/sig-node/2413-seccomp-by-default/README.md
@@ -186,7 +186,9 @@ configuration.
 #### Beta to GA Graduation
 
 - [x] Allowing time for feedback (3 releases)
-- [x] Enabling the Kubelet feature flag by default
+- [x] Lock the Kubelet feature gate to be locked to the default value `true`
+      Note, the enablement of a feature gate doesn't mean the default
+      behavior will change. No default profile will be applied unless configured.
 - [x] Risks have been addressed by every common container runtime
 - [x] Documenting the seccomp performance impact on k/website as well as its
       workarounds (disabling the feature completely, turning off spectre


### PR DESCRIPTION
- One-line PR description: Reaction on https://github.com/kubernetes/enhancements/issues/2413#issuecomment-1429969732

Reading this again I think it was clear from original text. Clarifying anyway to make it clear from the first read =).

- Issue link: #2413 

/sig node
