### PR TITLE
[KEP-2853] Update: Changing kubernetes/kubernetes default branch name to main

### DIFF
--- a/keps/sig-release/2853-k-core-branch-rename/kep.yaml
+++ b/keps/sig-release/2853-k-core-branch-rename/kep.yaml
@@ -14,9 +14,11 @@ creation-date: 2021-11-19
 reviewers:
   - "@saschagrunert"
   - "@justaugustus"
+  - "@BenTheElder"
 approvers:
   - "@saschagrunert"
   - "@justaugustus"
+  - "@BenTheElder"
 
 status: provisional
 
@@ -32,11 +34,11 @@ status: provisional
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.27"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  stable: "v1.25"
+  stable: "v1.27"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Changing kubernetes/kubernetes default branch name to main

Reopening the KEP to update and more discussions



<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: