### PR TITLE
KEP-3705: simplify initial alpha, discuss possible changes to plan

### DIFF
--- a/keps/sig-network/3705-cloud-node-ips/kep.yaml
+++ b/keps/sig-network/3705-cloud-node-ips/kep.yaml
@@ -39,7 +39,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: CloudNodeIPs
+  - name: CloudDualStackNodeIPs
     components:
       - kubelet
       - cloud-controller-manager


### PR DESCRIPTION
- One-line PR description: Update KEP-3705 to simplify what we will do in 1.27.

- Issue link: https://github.com/kubernetes/enhancements/issues/3705

- Other comments:

While starting to implement the new dual-stack cloud `--node-ip` behavior, I realized that the constraint of preserving backward-compatible behavior for all existing `--node-ip` values means that you can't express certain things in some clusters, depending on the set of NodeAddresses provided by the cloud. (See the commit for an example.)

There are various things we could do about this, but it's too late to debate them in the 1.27 cycle. However, we know that we want to support explicit-dual-stack IPs on clouds; we know _how_ we want to support it (using the same syntax we use for bare metal); and we know there are already people waiting for this functionality who would be sad if it missed 1.27.

So this PR updates the KEP to indicate that we're doing _just_ that (explicit dual-stack `--node-ip` on external clouds, without the originally-proposed new `IPv4` and `IPv6` literals) for 1.27, and that we'll update the KEP again in the 1.28 cycle after reconsidering the plan.

(Where "update the KEP again" _could_ mean saying "ok, never mind, we'll just continue with what we originally planned", but I think I'm going to suggest reducing this KEP to _just_ the explicit-dual-stack-IPs part, and then file a new KEP proposing we deprecate `--node-ip` in favor of `--node-ips` with better semantics, and tie the annotation renaming to that as well.)

/sig network
/cc @thockin @aojea @mdbooth @JoelSpeed 