### PR TITLE
KEP-2876: Clear Graduation Criteria for CRD validation rules to stable

### DIFF
--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md
@@ -1134,8 +1134,10 @@ We plan to add e2e test under api-machinery for crd expression validation:
 
 #### GA
 
-- Formatted message. This targets in 1.27 and ideally should be in at least one release before going to GA.
-- Scalability evaluation. Evaluate CRD scalability with validation rules against [previous scale target](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/95-custom-resource-definitions/README.md#scale-targets-for-ga).
+- Formatted message. This has been added in 1.27.
+- Scalability evaluation. Evaluate CRD scalability with validation rules against [previous scale target](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/95-custom-resource-definitions/README.md#scale-targets-for-ga). The evaluation is available [here](https://docs.google.com/document/d/1gU8FfBhKnkmzJUC32NmXMdh4vzbLxb-gkf52O9Un7Cg/edit?usp=sharing)
+- Add optional fields reason and fieldPath into validation rules. 
+- Enable [CEL optional support](https://github.com/google/cel-spec/wiki/proposal-246) with proposed controlled rollout strategy. Ideally it should be in at least one release before going to GA.
 
 ## Production Readiness Review Questionnaire
 

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
@@ -22,17 +22,18 @@ see-also:
   - "/keps/sig-api-machinery/95-custom-resource-definitions"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.23"
   beta:  "v1.25"
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
+++ b/keps/sig-api-machinery/2876-crd-validation-expression-language/kep.yaml
@@ -22,7 +22,7 @@ see-also:
   - "/keps/sig-api-machinery/95-custom-resource-definitions"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: stable
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
@@ -33,7 +33,6 @@ latest-milestone: "v1.28"
 milestone:
   alpha: "v1.23"
   beta:  "v1.25"
-  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Promote CRD validation rules to stable

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2876

<!-- other comments or additional information -->
- Other comments: