### PR TITLE
KEP-2395: Removing in-tree cloud providers - Bump versions for Beta and GA

### DIFF
--- a/keps/prod-readiness/sig-cloud-provider/2395.yaml
+++ b/keps/prod-readiness/sig-cloud-provider/2395.yaml
@@ -1,3 +1,5 @@
 kep-number: 2395
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md
+++ b/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/README.md
@@ -123,9 +123,9 @@ For alpha, the feature gates will be used for testing purposes. When enabled, te
 disabled by default.
 
 For beta, the feature gates will be on by default, meaning core components will disallow use of in-tree cloud providers. This will act as a warning for users to migrate to external components. Users may
-choose to continue using the in-tree provider by explicitly disabling the feature gates. Beta is targeted for v1.26 with the caveat that a majority of our CI signal jobs across providers should have converted to use CCM by then.
+choose to continue using the in-tree provider by explicitly disabling the feature gates. Beta is targeted for v1.28 with the caveat that a majority of our CI signal jobs across providers should have converted to use CCM by then.
 
-For GA, the feature gate will be enabled by default and locked. Users at this point MUST migrate to external components and use of the in-tree cloud providers will be disallowed. GA is targeted for v1.27. One release after GA, the in-tree cloud providers can be safely removed. 
+For GA, the feature gate will be enabled by default and locked. Users at this point MUST migrate to external components and use of the in-tree cloud providers will be disallowed. GA is targeted for v1.29. One release after GA, the in-tree cloud providers can be safely removed. 
 
 NOTE: the removal of the code will depend on when we can remove the in-tree storage plugins, so the actual removal may end up in a later release.
 

--- a/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/kep.yaml
+++ b/keps/sig-cloud-provider/2395-removing-in-tree-cloud-providers/kep.yaml
@@ -22,15 +22,20 @@ approvers:
   - "@liggit"
 editor: TBD
 creation-date: 2018-12-18
-last-updated: 2019-04-11
+last-updated: 2023-04-20
 status: implementable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.21"
+latest-milestone: "v1.28"
 
-stage: alpha
+stage: beta
+
+milestone:
+  alpha: "v1.21"
+  beta: "v1.28"
+  stable: "v1.29"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bump versions as we shipped 1.27 already!

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2395

<!-- other comments or additional information -->
- Other comments: