### PR TITLE
KEP-3453: MinimizeIPTablesRestore to GA for 1.28

### DIFF
--- a/keps/prod-readiness/sig-network/3453.yaml
+++ b/keps/prod-readiness/sig-network/3453.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-network/3453-minimize-iptables-restore/README.md
+++ b/keps/sig-network/3453-minimize-iptables-restore/README.md
@@ -236,11 +236,11 @@ appropriate code for that.
 - No new bugs
 - Feature actually improves performance (eg, in the `gce-5000Nodes`
   periodic job).
-- Additional metrics to distinguish partial and full resync times
 
 #### GA
 
 - No new bugs
+- Additional metrics to distinguish partial and full resync times
 
 ### Upgrade / Downgrade Strategy
 
@@ -498,7 +498,8 @@ modes.
 - 2022-10-04: Initial KEP merged
 - 2022-11-01: Code PR merged
 - 2022-11-10: Testing PRs merged; 5000Nodes test begins enabling the feature
-- 2022-12-08: Kubernetes 1.26 released
+- 2022-12-08: Alpha in Kubernetes 1.26
+- 2023-04-11: Beta in Kubernetes 1.27
 
 ## Drawbacks
 

--- a/keps/sig-network/3453-minimize-iptables-restore/kep.yaml
+++ b/keps/sig-network/3453-minimize-iptables-restore/kep.yaml
@@ -12,18 +12,18 @@ approvers:
   - "@thockin"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.26"
   beta: "v1.27"
-  stable: 
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: update KEP-3453 to GA

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3453

<!-- other comments or additional information -->
- Other comments: no changes other than metadata/administrivia

/assign @thockin