### PR TITLE
KEP-3705: update CloudDualStackNodeIPs to beta

### DIFF
--- a/keps/prod-readiness/sig-network/3705.yaml
+++ b/keps/prod-readiness/sig-network/3705.yaml
@@ -4,3 +4,5 @@
 kep-number: 3705
 alpha:
   approver: "wojtek-t"
+beta:
+  approver: "wojtek-t"

--- a/keps/sig-network/3705-cloud-node-ips/kep.yaml
+++ b/keps/sig-network/3705-cloud-node-ips/kep.yaml
@@ -16,19 +16,18 @@ reviewers:
   - "@thockin"
 approvers:
   - "@thockin"
-  - TBD from sig-cloud-provider
 
 see-also:
   - "https://github.com/kubernetes/enhancements/issues/1664"
   - "https://github.com/kubernetes/enhancements/pull/1665"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: update KEP-3705 `CloudDualStackNodeIPs` to beta, dropping the parts that were not implemented in alpha

- Issue link: https://github.com/kubernetes/enhancements/issues/3705

- Other comments:
This drops the parts of the KEP that weren't implemented for alpha (`--node-ip IPv4` / `--node-ip IPv6`, and renaming the `alpha.kubernetes.io/provided-node-ip` annotation), and moves some of the old text to the "Alternatives" section explaining what we didn't do and why.

/assign @thockin