### PR TITLE
2258: Update node log query

### DIFF
--- a/keps/sig-windows/2258-node-log-query/kep.yaml
+++ b/keps/sig-windows/2258-node-log-query/kep.yaml
@@ -1,4 +1,4 @@
-title: Node service log viewer
+title: Node log query
 kep-number: 2258
 authors:
   - "@aravindhp"
@@ -11,12 +11,12 @@ participating-sigs:
 status: implementable
 reviewers:
   - "@marosset"
-  - "@immuzz"
+  - "@liggit"
   - "@thockin"
 approvers:
   - "@marosset"
 creation-date: 2021-01-14
-last-updated: 2022-06-06
+last-updated: 2023-05-02
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
 


### PR DESCRIPTION
- One-line PR description: Update node  log query

- Issue link: https://github.com/kubernetes/enhancements/issues/2258

- Other comments:
  - Update the kep to reflect the decisions made at the sig-archictecture call on Feb 9th, 2023 and the current implementation status.
  - Rename the KEP to reflect the name of the feature