### PR TITLE
node: podresources: GA in 1.28

### DIFF
--- a/keps/sig-node/606-compute-device-assignment/README.md
+++ b/keps/sig-node/606-compute-device-assignment/README.md
@@ -362,6 +362,7 @@ N/A
 - 2019-04-30: Agreement in sig-node to move feature to beta in 1.15
 - 2020-06-17: Agreement in sig-node to move feature to G.A in 1.19 or 1.20
 - 2023-01-27: KEP translate to the most recent template
+- 2023-05-23: KEP GA moved to 1.28
 
 ## Drawbacks
 

--- a/keps/sig-node/606-compute-device-assignment/kep.yaml
+++ b/keps/sig-node/606-compute-device-assignment/kep.yaml
@@ -24,13 +24,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.13"
   beta: "v1.15"
-  stable: "v1.27"
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: move GA version from 1.27 to 1.28 to address the few pending work items
- Issue link: https://github.com/kubernetes/enhancements/issues/3743
- Other comments: 