### PR TITLE
update release for GA for KEP 1699

### DIFF
--- a/keps/sig-network/1669-proxy-terminating-endpoints/kep.yaml
+++ b/keps/sig-network/1669-proxy-terminating-endpoints/kep.yaml
@@ -12,7 +12,7 @@ reviewers:
 approvers:
   - "@thockin"
 creation-date: 2020-04-07
-last-updated: 2023-02-02
+last-updated: 2023-05-04
 status: implementable
 see-also:
   - "/keps/sig-network/1672-tracking-terminating-endpoints/README.md"
@@ -24,13 +24,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.26"
-  stable: "v1.27"
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
It skipped 1.27 but it will go GA for 1.28