### PR TITLE
bump probe termination to ga for 1.28 (missed 1.27)

### DIFF
--- a/keps/sig-node/2238-liveness-probe-grace-period/kep.yaml
+++ b/keps/sig-node/2238-liveness-probe-grace-period/kep.yaml
@@ -21,13 +21,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.21"
   beta: "v1.22"
-  stable: "v1.27"
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: ProbeTerminationGracePeriod missed 1.27. Changing to 1.28

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2238

<!-- other comments or additional information -->
- Other comments:
- GA PR: https://github.com/kubernetes/kubernetes/pull/114307