### PR TITLE
KEP-1281: Clarify beta status.

### DIFF
--- a/keps/sig-api-machinery/1281-network-proxy/kep.yaml
+++ b/keps/sig-api-machinery/1281-network-proxy/kep.yaml
@@ -22,7 +22,7 @@ approvers:
   - "@bowei - For networking/proxy portion of KEP"
 editor: "@calebamiles"
 creation-date: 2019-02-25
-last-updated: 2020-01-15
+last-updated: 2023-05-22
 status: implementable
 see-also:
   - "https://goo.gl/qiARUK - Network Proxy design proposal"
@@ -31,5 +31,5 @@ see-also:
 replaces:
 superseded-by:
 
-latest-milestone: "1.16"
-stage: "alpha"
+latest-milestone: "1.18"
+stage: "beta"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Clarify that status is beta; introduce GA criteria.


<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1281

<!-- other comments or additional information -->
- Other comments:

This KEP has been a bit dormant, but the Konnectivity Proxy has had several rounds of bugfixes, and recent [releases](https://github.com/kubernetes-sigs/apiserver-network-proxy/tags) have a good operational track record. We should graduate it from beta to GA, especially since ssh tunnels support is removed.