### PR TITLE
KEP-3726: Add WebSocket as a standard protocol

### DIFF
--- a/keps/sig-network/3726-standard-application-protocols/README.md
+++ b/keps/sig-network/3726-standard-application-protocols/README.md
@@ -144,8 +144,8 @@ Those common protocols will be well defined strings prefixed with ‘kubernetes.
 
 ### New Standard Protocols
 - 'kubernetes.io/h2c'
-- 'kubernetes.io/websocket'
-- 'kubernetes.io/websocket-secure'
+- 'kubernetes.io/ws'
+- 'kubernetes.io/wss'
 
 ### Risks and Mitigations
 
@@ -178,8 +178,8 @@ type ServicePort struct {
   //
   // * Kubernetes-defined prefixed names:
   //   * 'kubernetes.io/h2c' - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
-  //   * 'kubernetes.io/websocket' - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
-  //   * 'kubernetes.io/websocket-secure' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+  //   * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+  //   * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
   //
   // * Other protocols should use implementation-defined prefixed names such as
   // mycompany.com/my-custom-protocol.

--- a/keps/sig-network/3726-standard-application-protocols/README.md
+++ b/keps/sig-network/3726-standard-application-protocols/README.md
@@ -144,6 +144,8 @@ Those common protocols will be well defined strings prefixed with ‘kubernetes.
 
 ### New Standard Protocols
 - 'kubernetes.io/h2c'
+- 'kubernetes.io/websocket'
+- 'kubernetes.io/websocket-secure'
 
 ### Risks and Mitigations
 
@@ -176,6 +178,8 @@ type ServicePort struct {
   //
   // * Kubernetes-defined prefixed names:
   //   * 'kubernetes.io/h2c' - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
+  //   * 'kubernetes.io/websocket' - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+  //   * 'kubernetes.io/websocket-secure' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
   //
   // * Other protocols should use implementation-defined prefixed names such as
   // mycompany.com/my-custom-protocol.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This defines websocket (`ws`) and websocket secure (`wss`) as standard protocols


<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3726

<!-- other comments or additional information -->
- Other comments: 
  - RFC: https://www.rfc-editor.org/rfc/rfc6455
