### PR TITLE
KEP-961: Bump Statefulset maxUnavailable to beta

### DIFF
--- a/keps/prod-readiness/sig-apps/961.yaml
+++ b/keps/prod-readiness/sig-apps/961.yaml
@@ -1,3 +1,5 @@
 kep-number: 961
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/3335-statefulset-slice/README.md
+++ b/keps/sig-apps/3335-statefulset-slice/README.md
@@ -139,10 +139,10 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Design details are appropriately documented
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [X] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
 - [X] "Implementation History" section is up-to-date for milestone
@@ -390,7 +390,7 @@ In the main control loop, StatefulSet will attempt to create pod replicas `[k, N
 *   When scaling down pods: If ordinal `j` exists but is not in range `[k, N+k-1]`), pod `j` will be terminated.
 **RollingUpdate Partition Changes**
 
-Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid. 
+Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid.
 
 ### Test Plan
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -598,7 +598,6 @@ on feature enable and disabled
 A rollout or rollback of this feature can fail if there is a bug which causes the kube-apiserver or
 the kube-controller-manager to start crashing when the feature flag is enabled.
 
-
 Yes, it can impact already running workloads.
 
 If a rolling update is in progress for a StatefulSet, while this feature is being enabled in kube-apiserver
@@ -610,7 +609,8 @@ maxUnavailable pods with the same identity and never more than maxUnavailable be
 ###### What specific metrics should inform a rollback?
 
 When feature enabled but rolling update in a unexpected phenomenon like the update pods at a time is not equal to the
-`maxUnavailable` value or rolling update in a unexpected order.
+`maxUnavailable` value (we may have some other factors impacting this, but this should apply for most of the time) or
+rolling update in a unexpected order.
 
 Or we can refer to the `rolling-update-duration` metric for observation, if it didn't decrease when setting the `maxUnavailable`
 great than 1 or the duration increased abnormally, then we should rollback.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -2,30 +2,43 @@ title: Implement maxUnavailable for StatefulSets
 kep-number: 961
 authors:
   - "@krmayankk"
+  - "@kerthcet"
 owning-sig: sig-apps
-participating-sigs:
-  - sig-apps
+participating-sigs: []
+status: implementable
+creation-date: 2018-12-29
 reviewers:
   - "@janetkuo"
   - "@kow3ns"
 approvers:
   - "@janetkuo"
   - "@kow3ns"
-editor: TBD
-creation-date: 2018-12-29
-last-updated: 2022-01-01
-status: implementable
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
+
+see-also: []
+replaces: []
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.25"
-  stable: "v1.26"
-latest-milestone: "v1.24"
-stage: "alpha"
+  beta: "v1.28"
+  stable: TBD
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: MaxUnavailableStatefulSet
+    components:
+      - kube-controller-manager
+      - kube-apiserver
+
+# The following PRR answers are required at beta release
+metrics:
+  - rolling-update-duration

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -40,7 +40,8 @@ feature-gates:
     components:
       - kube-controller-manager
       - kube-apiserver
+disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - rolling-update-duration
+  - rolling-update-duration-seconds

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -10,9 +10,11 @@ creation-date: 2018-12-29
 reviewers:
   - "@janetkuo"
   - "@kow3ns"
+  - "@soltysh"
 approvers:
   - "@janetkuo"
   - "@kow3ns"
+  - "@soltysh"
 
 see-also: []
 replaces: []


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bump statefulset maxUnavailable to beta

<!-- link to the k/enhancements issue -->
- Issue link:  https://github.com/kubernetes/enhancements/issues/961

<!-- other comments or additional information -->
- Other comments:

No. 1 commit: adapt to the latest KEP template
No. 2 commit: what extra needed when bumping to beta.