### PR TITLE
Beta update for ActiveDeadlineExceeded (1.28) "KEP-3329: Retriable and non-retriable Pod failures for Jobs"

### DIFF
--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/kep.yaml
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/kep.yaml
@@ -24,7 +24,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP update about ActiveDeadlineExceeded condition

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3329


<!-- other comments or additional information -->
- Other comments: POC implementation: https://github.com/kubernetes/kubernetes/pull/117973