### PR TITLE
KEP-2433: add new heuristic to topology routing

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/README.md
+++ b/keps/sig-network/2433-topology-aware-hints/README.md
@@ -298,7 +298,7 @@ implemented directly by kube-proxy.
 ### EndpointSlice Controller
 
 When the `TopologyAwareHints` feature gate is enabled and the annotation is set
-to `Auto` or `ProportionalByCore` for a Service, the EndpointSlice controller
+to `Auto` or `ProportionalZoneCPU` for a Service, the EndpointSlice controller
 will add hints to EndpointSlices. These hints will indicate where an endpoint
 should be consumed by proxy implementations to enable topology aware routing.
 
@@ -309,12 +309,12 @@ This KEP starts with the following heuristics:
 | Heuristic Name | Description |
 |-|-|
 | Auto | EndpointSlice controller and/or underlying dataplane can choose the heuristic used. |
-| ProportionalByCore | Endpoints will be allocated to each zone proportionally, based on the allocatable Node CPU cores in each zone. |
+| ProportionalZoneCPU | Endpoints will be allocated to each zone proportionally, based on the allocatable Node CPU cores in each zone. |
 | PreferZone | Hints are always populated to represent the zone the endpoint is in. |
 
 In the future, additional heuristics may be added. Until that point, "Auto" will
 be the only configurable value. In most clusters, that will translate to
-`ProportionalByCore` unless the underlying dataplane has a better approach
+`ProportionalZoneCPU` unless the underlying dataplane has a better approach
 available.
 
 ### Identifying Zones

--- a/keps/sig-network/2433-topology-aware-hints/kep.yaml
+++ b/keps/sig-network/2433-topology-aware-hints/kep.yaml
@@ -34,7 +34,7 @@ latest-milestone: "v1.27"
 milestone:
   alpha: "v1.21"
   beta: "v1.23"
-  stable: "v1.28"
+  stable: "v1.29"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
KEP-2433: add new heuristic to topology routing

- Issue link: https://github.com/kubernetes/enhancements/issues/2433

This simplify the existing heuristic that is based on CPUs cores because is difficult to get it working on deployments where the law of large numbers can not help with the statistics.

Add a new heuristic to only PreferZone, ie. traffic will be directed to the endpoints in the same zone if exist, or fall back to cluster wide routing if there are no endpoints in the zone

As a side benefit of this new heuristic, we can abstract the topology using an interface that will help with the KEP https://github.com/kubernetes/enhancements/issues/3685 to stage the endpointslice controller.