### PR TITLE
KEP-1440: Promote kubectl events command to stable

### DIFF
--- a/keps/prod-readiness/sig-cli/1440.yaml
+++ b/keps/prod-readiness/sig-cli/1440.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-cli/1440-kubectl-events/README.md
+++ b/keps/sig-cli/1440-kubectl-events/README.md
@@ -178,7 +178,7 @@ Once the experimental kubectl events command is implemented, this can be rolled 
 
 ##### GA
 
-- [ ] Address all major issues and bugs raised by community members
+- [x] Address all major issues and bugs raised by community members
 
 ### Upgrade / Downgrade Strategy
 
@@ -336,6 +336,7 @@ None.
 - *2020-01-16* - Initial KEP draft
 - *2021-09-06* - Updated KEP with the new template and mark implementable for alpha implementation.
 - *2022-09-21* - Updated KEP for beta promotion.
+- *2023-05-17* - Updated KEP for stable promotion. 
 
 ## Alternatives
 

--- a/keps/sig-cli/1440-kubectl-events/README.md
+++ b/keps/sig-cli/1440-kubectl-events/README.md
@@ -311,6 +311,10 @@ No.
 
 No.
 
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+No.
+
 ### Troubleshooting
 
 ###### How does this feature react if the API server and/or etcd is unavailable?

--- a/keps/sig-cli/1440-kubectl-events/README.md
+++ b/keps/sig-cli/1440-kubectl-events/README.md
@@ -164,7 +164,7 @@ Before promoting to beta at least a single e2e test should also be added in
 
 ##### e2e tests
 
-- missing
+- kubectl events should show event when pod is created: [test grid](https://storage.googleapis.com/k8s-triage/index.html?sig=cli&test=kubectl%20events)
 
 ### Graduation Criteria
 

--- a/keps/sig-cli/1440-kubectl-events/kep.yaml
+++ b/keps/sig-cli/1440-kubectl-events/kep.yaml
@@ -2,7 +2,8 @@ title: Kubectl events
 kep-number: 1440
 authors:
   - "@hpandeycodeit"
-  - "soltysh"
+  - "@soltysh"
+  - "@ardaguclu"
 owning-sig: sig-cli
 participating-sigs:
   - sig-cli
@@ -20,14 +21,14 @@ see-also:
   - https://docs.google.com/document/d/1w-HRLtMncDAL_yQQJdHDasyCZRdJTOV1N6y22fGsKkY/edit#
 replaces: []
 
-stage: "beta"
+stage: "stable"
 
-latest-milestone: "1.26"
+latest-milestone: "1.28"
 
 milestone:
   alpha: "v1.23"
   beta: "v1.26"
-  stable: "v1.27"
+  stable: "v1.28"
 
 feature-gates: []
 disable-supported: false


### PR DESCRIPTION
- One-line PR description: promote kubectl events to stable

- Issue link: https://github.com/kubernetes/enhancements/issues/1440

- Other comments: none

/assign @soltysh @eddiezane 
for sig-cli review
/assign @wojtek-t 
for prr review