### PR TITLE
update stable milestone for KMSv2 to v1.29

### DIFF
--- a/keps/sig-auth/3299-kms-v2-improvements/kep.yaml
+++ b/keps/sig-auth/3299-kms-v2-improvements/kep.yaml
@@ -15,12 +15,12 @@ approvers:
 replaces:
   - "/keps/sig-auth/3130-kms-observability"
 stage: beta
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.25"
   beta: "v1.27"
-  stable: "v1.28"
+  stable: "v1.29"
 feature-gates:
   - name: KMSv2
     components:


### PR DESCRIPTION
- update stable milestone for KMSv2 to `v1.29`