### PR TITLE
KEP-2268: move non-graceful node shutdown to GA

### DIFF
--- a/keps/prod-readiness/sig-storage/2268.yaml
+++ b/keps/prod-readiness/sig-storage/2268.yaml
@@ -2,4 +2,6 @@ kep-number: 2268
 alpha:
   approver: "@deads2k"
 beta:
+  approver: "@deads2k"
+stable:
   approver: "@deads2k" 

--- a/keps/sig-storage/2268-non-graceful-shutdown/README.md
+++ b/keps/sig-storage/2268-non-graceful-shutdown/README.md
@@ -409,13 +409,13 @@ Pick one more of these and delete the rest.
   - [X] Metrics
     - Metric name: 
       - New metrics are added in Pod GC Controller:
-        - `force_delete_pods_total`, the number of pods that are being forcefully deleted since the Pod GC Controller started.
-        - `force_delete_pod_errors_total`, the number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.
+        - `force_delete_pods_total{reason="out-of-service|terminated|orphaned|unscheduled"}`, the number of pods that are being forcefully deleted since the Pod GC Controller started.
+        - `force_delete_pod_errors_total{reason="out-of-service|terminated|orphaned|unscheduled"}`, the number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.
       - For Attach Detach Controller, there's already a metric:
         - `attachdetach_controller_forced_detaches`, the number of times the Attach Detach Controller performed a forced detach.
       - There is also a `kube_node_spec_taint` in [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/node-metrics.md) that is a metric for the taint of a Kubernetes cluster node.
     - [Optional] Aggregation method:
-    - Components exposing the metric:
+    - Components exposing the metric: kube-controller-manager
   - [X] Other (treat as last resort)
     - Details:
       - Check whether the workload moved to a different running node

--- a/keps/sig-storage/2268-non-graceful-shutdown/README.md
+++ b/keps/sig-storage/2268-non-graceful-shutdown/README.md
@@ -411,8 +411,8 @@ Pick one more of these and delete the rest.
       - New metrics are added in Pod GC Controller:
         - `force_delete_pods_total{reason="out-of-service|terminated|orphaned|unscheduled"}`, the number of pods that are being forcefully deleted since the Pod GC Controller started.
         - `force_delete_pod_errors_total{reason="out-of-service|terminated|orphaned|unscheduled"}`, the number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.
-      - For Attach Detach Controller, there's already a metric:
-        - `attachdetach_controller_forced_detaches`, the number of times the Attach Detach Controller performed a forced detach.
+      - For Attach Detach Controller, the following metric will be recorded if a force detach is performed because the node has the `out-of-service` taint or a timeout happens:
+        - `attachdetach_controller_forced_detaches{reason="out-of-service|timeout"}`, the number of times the Attach Detach Controller performed a forced detach.
       - There is also a `kube_node_spec_taint` in [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/node-metrics.md) that is a metric for the taint of a Kubernetes cluster node.
     - [Optional] Aggregation method:
     - Components exposing the metric: kube-controller-manager

--- a/keps/sig-storage/2268-non-graceful-shutdown/README.md
+++ b/keps/sig-storage/2268-non-graceful-shutdown/README.md
@@ -408,11 +408,12 @@ Pick one more of these and delete the rest.
 -->
   - [X] Metrics
     - Metric name: 
-      - We added new metrics `deleting_pods_total`, `deleting_pods_error_total`
-      in Pod GC Controller.
-      For Attach Detach Controller, there's already a metric:
-      `attachdetach_controller_forced_detaches`
-      There is also a `kube_node_spec_taint` in [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/node-metrics.md) that is a metric for the taint of a Kubernetes cluster node.
+      - New metrics are added in Pod GC Controller:
+        - `force_delete_pods_total`, the number of pods that are being forcefully deleted since the Pod GC Controller started.
+        - `force_delete_pod_errors_total`, the number of errors encountered when forcefully deleting the pods since the Pod GC Controller started.
+      - For Attach Detach Controller, there's already a metric:
+        - `attachdetach_controller_forced_detaches`, the number of times the Attach Detach Controller performed a forced detach.
+      - There is also a `kube_node_spec_taint` in [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/node-metrics.md) that is a metric for the taint of a Kubernetes cluster node.
     - [Optional] Aggregation method:
     - Components exposing the metric:
   - [X] Other (treat as last resort)
@@ -685,6 +686,7 @@ For each of them, fill in the following information by copying the below templat
 - 2021-12-03: Removed `SafeDetach` flag. Requires a user to add the `out-of-service` taint when he/she knows the node is shutdown.
 - Kubernetes v1.24: moved to alpha.
 - Kubernete v1.26: moved to beta.
+- Kubernete v1.28: moved to stable.
 
 ## Alternatives
 

--- a/keps/sig-storage/2268-non-graceful-shutdown/kep.yaml
+++ b/keps/sig-storage/2268-non-graceful-shutdown/kep.yaml
@@ -20,19 +20,28 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta 
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.26"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
   beta: "v1.26"
-  stable: "v1.27"
+  stable: "v1.28"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: NodeOutOfServiceVolumeDetach
+    components:
+      - kube-controller-manager
 disable-supported: true
+
+# The following PRR answers are required at beta release
+metrics:
+  - deleting_pods_total
+  - deleting_pods_error_total

--- a/keps/sig-storage/2268-non-graceful-shutdown/kep.yaml
+++ b/keps/sig-storage/2268-non-graceful-shutdown/kep.yaml
@@ -43,5 +43,5 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - deleting_pods_total
-  - deleting_pods_error_total
+  - force_delete_pods_total
+  - force_delete_pod_errors_total

--- a/keps/sig-storage/2268-non-graceful-shutdown/kep.yaml
+++ b/keps/sig-storage/2268-non-graceful-shutdown/kep.yaml
@@ -43,5 +43,5 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - force_delete_pods_total
-  - force_delete_pod_errors_total
+  - force_delete_pods_total{reason="out-of-service|terminated|orphaned|unscheduled"}
+  - force_delete_pod_errors_total{reason="out-of-service|terminated|orphaned|unscheduled"}


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
This PR moves non-graceful node shutdown feature to GA.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2268

<!-- other comments or additional information -->
- Other comments: