### PR TITLE
KEP-2923 Deprecation of intree CephFS driver in 1.28

### DIFF
--- a/keps/sig-storage/2924-csi-migration-cephfs/kep.yaml
+++ b/keps/sig-storage/2924-csi-migration-cephfs/kep.yaml
@@ -12,9 +12,9 @@ approvers:
   - "@msau42"
 editor: "@Jiawei0227"
 creation-date: 2022-01-27
-last-updated: 2022-01-27
+last-updated: 2023-05-28
 disable-supported: true
-status: implementable
+status: withdrawn
 see-also:
   - "https://github.com/kubernetes/design-proposals-archive/blob/master/storage/csi-migration.md"
 replaces:
@@ -25,7 +25,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.26"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: updating milestone 

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2924

<!-- other comments or additional information -->
- Other comments: [Deprecation of intree CephFS driver in 1.28](https://groups.google.com/g/kubernetes-sig-storage/c/IlHnIpwTbEg)