### PR TITLE
add GA requirement for extending metrics stability

### DIFF
--- a/keps/prod-readiness/sig-instrumentation/3498.yaml
+++ b/keps/prod-readiness/sig-instrumentation/3498.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-instrumentation/3498-extending-stability/README.md
+++ b/keps/sig-instrumentation/3498-extending-stability/README.md
@@ -288,6 +288,7 @@ For the beta version of this KEP, we begin permitting metrics to be promoted to 
 
 - We will allow bake time before promoting this feature to GA
 - At this stage, we will promote our meta-metric for registered metrics to Stable
+- We also require an update to the prometheus golang client such that we can add process start time to a header, so that scraping clients do not have to parse the entire metrics payload in order to properly process counter metrics. Please see [this PR](https://github.com/prometheus/client_golang/pull/1278) for more details.
 
 #### Deprecation
 

--- a/keps/sig-instrumentation/3498-extending-stability/kep.yaml
+++ b/keps/sig-instrumentation/3498-extending-stability/kep.yaml
@@ -26,7 +26,7 @@ latest-milestone: "v1.27"
 milestone:
   alpha: "v1.26"
   beta: "v1.27"
-  stable: "v1.29"
+  stable: "v1.28"
 
 feature-gates:
   - name: "n/a"


### PR DESCRIPTION
- One-line PR description:
  - We are going to graduate "extending metrics stability" to GA.

- Issue link:
  - https://github.com/kubernetes/enhancements/issues/3498
