### PR TITLE
Revive 2340 Consistent reads from cache KEP

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/2340.yaml
+++ b/keps/prod-readiness/sig-api-machinery/2340.yaml
@@ -1,0 +1,3 @@
+kep-number: 2340
+alpha:
+  approver: "@deads2k"

--- a/keps/prod-readiness/sig-api-machinery/2340.yaml
+++ b/keps/prod-readiness/sig-api-machinery/2340.yaml
@@ -1,3 +1,3 @@
 kep-number: 2340
 alpha:
-  approver: "@deads2k"
+  approver: "@wojtek-t"

--- a/keps/sig-api-machinery/2340-Consistent-reads-from-cache/README.md
+++ b/keps/sig-api-machinery/2340-Consistent-reads-from-cache/README.md
@@ -275,12 +275,13 @@ Benchmark consistent reads from cache against consistent reads from etcd for:
 
 #### Beta
 
-- Implement a per-request opt-out from quorum read
+- Implement a per-request opt-out [discussion](https://github.com/kubernetes/enhancements/pull/1404#discussion_r381528406)
 - Implement a fallback if user is running older/affected etcd version
+- Feature is enabled by default
 
 #### GA
 
-- Feature is enabled by default
+TBD
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-api-machinery/2340-Consistent-reads-from-cache/kep.yaml
+++ b/keps/sig-api-machinery/2340-Consistent-reads-from-cache/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 2340
 authors:
   - "@jpbetz"
   - "@wojtek-t"
+  - "@serathius"
 owning-sig: sig-api-machinery
 participating-sigs:
   - sig-scalability
@@ -16,7 +17,16 @@ approvers:
 editor: TBD
 creation-date: 2019-12-10
 last-updated: 2020-02-19
-status: provisional
+status: implementable
 see-also:
+  -  "/keps/sig-api-machinery/3157-watch-list"
 replaces:
 superseded-by:
+stage: alpha
+latest-milestone: "v1.28"
+milestone:
+  alpha: "v1.28"
+feature-gates:
+- name: WatchCacheConsistentReads
+  components:
+  - kube-apiserver


### PR DESCRIPTION
cc @wojtek-t @deads2k @mborsz @logicalhan 

Reviving the KEP and picking up previously abandoned approach to use `WatchProgressRequest`. Reason is that it allows us to drop the dependency on etcd configuration. This leaves us with problem of making apiserver aware of etcd version.

Issue https://github.com/kubernetes/enhancements/issues/2340
Original proposal: https://github.com/kubernetes/enhancements/pull/1404