### PR TITLE
Updating SIG Cloud Provider leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,7 +27,10 @@ aliases:
     - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
+    - bridgetkromhout
     - cheftako
+    - elmiko
+    - nckturner
   sig-cluster-lifecycle-leads:
     - fabriziopandini
     - justinsb


### PR DESCRIPTION
This PR updates this owners file to match https://github.com/kubernetes/community/blob/master/sig-cloud-provider/README.md#leadership (which was updated in April in https://github.com/kubernetes/community/pull/7251)

- One-line PR description:
Updating SIG Cloud Provider leads

- Other comments: 
Lazy consensus back in April: https://groups.google.com/g/kubernetes-sig-cloud-provider/c/BAh7gGZhfvo

 
 /assign @mrbobbytables