### PR TITLE
KEP-3063: dra: pre-scheduled pods

### DIFF
--- a/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
+++ b/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
@@ -24,7 +24,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: pods with `spec.nodeName` set while claims are not reserved is an error scenario, but dealing with it automatically when it arises is still useful and not too hard, so it should be worthwhile.

- Issue link: https://github.com/kubernetes/enhancements/issues/3063

- Other comments:
  See https://github.com/kubernetes/kubernetes/pull/118209 for the kube-controller-manager implementation

/cc @alculquicondor 