### PR TITLE
KEP-3762: Graduate to beta in 1.28

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/3716.yaml
+++ b/keps/prod-readiness/sig-api-machinery/3716.yaml
@@ -4,3 +4,5 @@
 kep-number: 3716
 alpha:
   approver: "@deads2k"
+beta:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/3716-admission-webhook-match-conditions/README.md
+++ b/keps/sig-api-machinery/3716-admission-webhook-match-conditions/README.md
@@ -374,10 +374,7 @@ cases outlined above will be added.
 
 - Add E2E test coverage
 - Resolve resource constraints validation
-
-<<[UNRESOLVED resource constraints ]>>
-Additional beta requirements TBD
-<<[/UNRESOLVED]>>
+- Webhook Accessors smart recompilation
 
 #### GA
 

--- a/keps/sig-api-machinery/3716-admission-webhook-match-conditions/kep.yaml
+++ b/keps/sig-api-machinery/3716-admission-webhook-match-conditions/kep.yaml
@@ -7,6 +7,7 @@ participating-sigs:
   - sig-auth
 status: implementable
 creation-date: 2023-01-09
+last-updated: 2023-06-07
 reviewers:
   - jpbetz
   - cici37
@@ -30,17 +31,17 @@ see-also:
   - https://github.com/kubernetes/enhancements/pull/3694
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
-  beta: "TBD"
+  beta: "v1.28"
   stable: "TBD"
 
 # The following PRR answers are required at alpha release
@@ -53,4 +54,4 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - TBD
+  - webhook_admission_match_condition_exclusions_total


### PR DESCRIPTION
One-line PR description: graduate admission webhooks match conditions to Beta.

Issue link: https://github.com/kubernetes/enhancements/issues/3762

Other comments: N/A