### PR TITLE
KEP-1287: Keep in-place pod resize KEP alpha/implementatle for v1.28

### DIFF
--- a/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
+++ b/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
@@ -32,7 +32,7 @@ replaces:
 
 stage: "alpha"
 
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 milestone:
   alpha: "v1.27"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This PR keeps in-place pod resize KEP in implementable/alpha state for v1.28 as per request from release management.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1287

<!-- other comments or additional information -->
- Other comments: