### PR TITLE
KEP-3178: Bump 'IPTables Ownership' to GA

### DIFF
--- a/keps/prod-readiness/sig-network/3178.yaml
+++ b/keps/prod-readiness/sig-network/3178.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-network/3178-iptables-cleanup/kep.yaml
+++ b/keps/sig-network/3178-iptables-cleanup/kep.yaml
@@ -16,12 +16,12 @@ see-also:
   - "/keps/sig-node/2221-remove-dockershim"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Move to GA in 1.28

- Issue link: https://github.com/kubernetes/enhancements/issues/3178
