### PR TITLE
KEP-3726: Add 'kubernetes.io/raw' as a standard app protocol

### DIFF
--- a/keps/sig-network/3726-standard-application-protocols/README.md
+++ b/keps/sig-network/3726-standard-application-protocols/README.md
@@ -146,6 +146,7 @@ Those common protocols will be well defined strings prefixed with ‘kubernetes.
 - 'kubernetes.io/h2c'
 - 'kubernetes.io/ws'
 - 'kubernetes.io/wss'
+- 'kubernetes.io/raw'
 
 ### Risks and Mitigations
 
@@ -180,6 +181,7 @@ type ServicePort struct {
   //   * 'kubernetes.io/h2c' - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
   //   * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
   //   * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+  //   * 'kubernetes.io/raw' - Traffic to this port is the protocol value defined by this port's `protocol` field. (ie. TCP/UDP/SCTP)
   //
   // * Other protocols should use implementation-defined prefixed names such as
   // mycompany.com/my-custom-protocol.
@@ -210,9 +212,6 @@ The proposed followup work might address this problem also when we turn the fiel
 - To support implementations interoperability with different domain prefixed protocols (or a mix domain prefixed and non prefixed protocol) for the same port we need to turn `AppProtocol` to a list.
 
 It is likely to be an API change but design details TBD.
-
-- Some implementations are trying to guess the application protocol in absence of `appProtocol`. We should consider adding a new protocol like `kubernetes.io/raw` to the collection that would instructs implementations to process requests as raw.
-We need to look at combination of `appProtocol: kubernetes.io/raw` and the different supported port protocols (TCP, UDP, SCTP).  
 
 ### Documentation change
 

--- a/keps/sig-network/3726-standard-application-protocols/README.md
+++ b/keps/sig-network/3726-standard-application-protocols/README.md
@@ -181,7 +181,7 @@ type ServicePort struct {
   //   * 'kubernetes.io/h2c' - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
   //   * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
   //   * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-  //   * 'kubernetes.io/raw' - Traffic to this port is the protocol value defined by this port's `protocol` field. (ie. TCP/UDP/SCTP)
+  //   * 'kubernetes.io/raw' - Opaque application traffic; implementations should not apply special processing
   //
   // * Other protocols should use implementation-defined prefixed names such as
   // mycompany.com/my-custom-protocol.


### PR DESCRIPTION
This PR is a continuation of https://github.com/kubernetes/enhancements/pull/3996 - simplified diff is here https://github.com/kubernetes/enhancements/pull/4106/commits/93d0269c2c30692e8283a8a4bee1b272def1f718

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This defines `kubernetes.io/raw` as a standard app protocol


<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3726

<!-- other comments or additional information -->


This is completing the follow up work outlined in the KEP-3726 update introduce here - https://github.com/kubernetes/enhancements/pull/3912

Specifically

> Some implementations are trying to guess the application protocol in absence of `appProtocol`. We should consider adding a new protocol like `kubernetes.io/raw` to the collection that would instructs implementations to process requests as raw. We need to look at combination of `appProtocol: kubernetes.io/raw` and the different supported port protocols (TCP, UDP, SCTP).  


## Motivation

Gateway API GEP - https://github.com/kubernetes-sigs/gateway-api/issues/1911

Problem: How can users specify their traffic to a service/endpointslice port is exactly what's specified in protocol and automatic detection should be turned off.

I saw that the standard protocol KEP had a clause about raw - but it wasn't added.