### PR TITLE
KEP-127: Fix user namespaces feature gate name

### DIFF
--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -678,7 +678,7 @@ well as the [existing list] of feature gates.
 -->
 
 - [x] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: UserNamespacesSupport
+  - Feature gate name: UserNamespacesStatelessPodsSupport
   - Components depending on the feature gate: kubelet, kube-apiserver
 
 ###### Does enabling the feature change any default behavior?

--- a/keps/sig-node/127-user-namespaces/kep.yaml
+++ b/keps/sig-node/127-user-namespaces/kep.yaml
@@ -21,7 +21,7 @@ milestone:
   alpha: "v1.25"
 
 feature-gates:
-  - name: UserNamespacesSupport
+  - name: UserNamespacesStatelessPodsSupport
     components:
       - kubelet
       - kube-apiserver


### PR DESCRIPTION

- One-line PR description: The actual feature gate name is `UserNamespacesStatelessPodsSupport`, which should be reflected in the KEP as well.


<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/127

<!-- other comments or additional information -->
- Other comments: cc @mrunalp @rata @giuseppe 