### PR TITLE
KEP-4112: Pass down resources to CRI

### DIFF
--- a/keps/prod-readiness/sig-node/4112.yaml
+++ b/keps/prod-readiness/sig-node/4112.yaml
@@ -1,0 +1,7 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 4112
+alpha:
+  approver: TBD
+

--- a/keps/prod-readiness/sig-node/4112.yaml
+++ b/keps/prod-readiness/sig-node/4112.yaml
@@ -3,5 +3,4 @@
 # of http://git.k8s.io/enhancements/OWNERS_ALIASES
 kep-number: 4112
 alpha:
-  approver: TBD
-
+  approver: "@johnbelamaric"

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -872,6 +872,15 @@ However, there might be changes in behavior if the underlying CRI runtime
 depends on this feature. For example, an NRI plugin relying on the feature may
 cause the application to behave differently.
 
+Long running pods that persist (without restart) over kubelet and CRI runtime
+update which enables the feature may experience version skew of the metadata.
+After enabling the feature, the CRI runtime does not have the aggregated
+information of all resources of the pod, provided with this feature, as the
+kubelet didn't restart these pods (didn't send the CreatePodSandbox CRI
+request). This may affect some scenarios e.g. NRI plugins. This "metadata skew"
+can be avoided by draining the node before updating the kubelet and the CRI
+runtime.
+
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
 <!--

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -335,12 +335,16 @@ requirements. This make it possible for the CRI runtime to detect any changes
 in the pod resources that happen between the Pod creation and container
 creation in e.g.  scenarios where in-place pod updates are involved.
 
-The UpdatePodSandboxResources CRI message is also updated when/if that is
-introduced by the [KEP-1287][kep-1287] Beta ([PR][kep-1287-beta-pr]).
+[KEP-1287][kep-1287] Beta ([PR][kep-1287-beta-pr]) proposes to add new
+UpdatePodSandboxResources rpc to the CRI API. If/when KEP-1287 is implemented
+as proposed, the UpdatePodSandboxResources CRI message is updated to include
+the resource information of all containers (aligning with
+UpdateContainerResourcesRequest).
 
-Information about the Pod-level resources are added when/if the Pod-level
-resources enhancement [KEP-2837][kep-2837] Alpha ([PR][kep-2837-alpha-pr]) is
-implemented.
+[KEP-2837][kep-2837] Alpha ([PR][kep-2837-alpha-pr]) proposes to add new
+Pod-level resource requirements field to the PodSpec. This information will be
+be added to the PodResourceConfig message, similar to the container resource
+information, if/when KEP-2837 is implemented as proposed.
 
 ### CRI API
 
@@ -402,7 +406,7 @@ request.
 +enum ContainerType {
 +    INIT_CONTAINER    = 0;
 +    SIDECAR_CONTAINER = 1;
-+    REGULAR_CONTAINER = 2;
++    CONTAINER = 2;
 +}
 ```
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -278,9 +278,9 @@ what the user requested to fairly allocate resources between applications.
 
 As a cluster administrator, I want to install an NRI plugin that does
 customized resource handling. I run kubelet with CPU manager and memory manager
-disabled. Instead I use my NRI plugin to do customized resource allocation
-(e.g. cpu and memory pinning). To do that properly I need the actual resource
-requests and limits requested by the user.
+disabled (CPU manager policy set to `none`). Instead I use my NRI plugin to do
+customized resource allocation (e.g. cpu and memory pinning). To do that
+properly I need the actual resource requests and limits requested by the user.
 
 ### Notes/Constraints/Caveats (Optional)
 
@@ -323,7 +323,8 @@ of the CRI API.
 
 With this information, the runtime can for example do detailed resource
 allocation so that CPU, memory and other resources for each container are
-optimally aligned.
+optimally aligned. This applies to scenarios where the kubelet CPU manager is
+disabled (by using the `none` CPU manager policy).
 
 The resource information is included in PodSandboxConfig so that the runtime
 can see the full picture of Pod's resource usage at Pod creation time, for

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -282,6 +282,8 @@ contain unmodified resource requests from the PodSpec.
 +    KubernetesResources kubernetes_resources = 18;
  }
  
++// KubernetesResources contains the resource requests and limits as specified
++// in the Kubernetes core API ResourceRequirements.
 +message KubernetesResources {
 +    // Requests and limits from the Kubernetes container config.
 +    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 1;
@@ -334,11 +336,15 @@ resources of all the containers of the Pod.
 +    PodResourceConfig pod_resources = 10;
  }
  
++// PodResourceConfig contains information of all resources requirements of
++// the containers of a pod.
 +message PodResourceConfig {
 +    repeated ContainerResourceConfig init_containers = 1;
 +    repeated ContainerResourceConfig containers = 2;
 +}
  
++// ContainerResourceConfig contains information of all resource requirements of
++// one container.
 +message ContainerResourceConfig {
 +    // Name of the container
 +    string name= 1;
@@ -346,11 +352,14 @@ resources of all the containers of the Pod.
 +    // Kubernetes resource spec of the container
 +    KubernetesResources kubernetes_resources = 2;
 +
-+    // CDI devices for the container.
-+    repeated CDIDevice CDI_devices = 3;
-+
 +    // Mounts for the container.
-+    repeated Mount mounts = 4;
++    repeated Mount mounts = 3;
++
++    // Devices for the container.
++    repeated Device devices = 4;
++
++    // CDI devices for the container.
++    repeated CDIDevice CDI_devices = 5;
 +}
 ```
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -882,9 +882,10 @@ Any change of default behavior may be surprising to users or break existing
 automations, so be extremely careful here.
 -->
 
-There might be changes in behavior if the underlying CRI runtime depends on
-this feature. For example, an NRI plugin relying on the feature may cause the
-application to behave differently.
+Yes. The kubelet will start passing the extra information to the CRI runtime
+for every container it creates. Whether this has any effect depends on if the
+underlying CRI runtime supports this feature. For example, an NRI plugin
+relying on the feature may cause the application to behave differently.
 
 Long running pods that persist (without restart) over kubelet and CRI runtime
 update which enables the feature may experience version skew of the metadata.

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -764,7 +764,6 @@ in back-to-back releases.
 - Feature gate enabled by default
 - containerd and CRI-O runtimes have released versions that have adopted the
   new CRI API changes
-- The [NRI API](https://github.com/containerd/nri) has adopted the feature
 
 #### GA
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -330,6 +330,11 @@ can see the full picture of Pod's resource usage at Pod creation time, for
 example enabling more holistic resource allocation and thus better
 interoperability between containers inside the Pod.
 
+Also the CreateContainer request is extended to include the unmodified resource
+requirements. This make it possible for the CRI runtime to detect any changes
+in the pod resources that happen between the Pod creation and container
+creation in e.g.  scenarios where in-place pod updates are involved.
+
 The UpdatePodSandboxResources CRI message is also updated when/if that is
 introduced by the [KEP-1287][kep-1287] Beta ([PR][kep-1287-beta-pr]).
 
@@ -451,6 +456,17 @@ contain unmodified resource requests from the PodSpec.
 
 Note that mounts, devices, CDI devices are part of the ContainerConfig message
 but are left out of the diff snippet above.
+
+Including the KubernetesResources in the ContainerConfig message serves
+multiple purposes:
+
+1. Catch changes that happen between pod sandbox creation and container
+   creation. For example, in-place pod updates might change the container
+   before it was created.
+2. Catch changes that happen over container restarts in in-place pod update
+   scenarios
+3. Consistency/completeness. Have enough information to make consistent action
+   based only on information present in this rpc caal.
 
 The resources (mounts, devices, CDI devices, Kubernetes resources) in the
 CreateContainer request should be identical to what was (pre-)informed in the

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -951,9 +951,13 @@ What signals should users be paying attention to when the feature is young
 that might indicate a serious problem?
 -->
 
-Alpha: No new metrics are planned. Non-ready pods with CreatePodSandboxError
-status is one indicator. The error message will contain details if the CRI
-failure is related to the feature.
+Alpha: No new metrics are planned. Increase in the existing
+`kubelet_started_pods_errors_total` metric can indicate a problem caused by
+this feature.
+
+Generally, non-ready pods with CreatePodSandboxError status (reflected by the
+`kubelet_started_pods_errors_total` metric) is a possible indicator. The error
+message will contain details if the CRI failure is related to the feature.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
@@ -990,8 +994,9 @@ checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
 
-By examing the kubelet configuration (feature gate) and the version of the
-kubelet and the CRI runtime.
+By examing the kubelet feature gate and the version of the CRI runtime. The
+enablement of the kubelet feature gate can be determined from the
+`kubernetes_feature_enabled` metric.
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -1030,15 +1035,18 @@ These goals will help you determine what you need to measure (SLIs) in the next
 question.
 -->
 
-N/A.
+No increase in the `kubelet_started_pods_errors_total` rate.
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
-<!--
-Pick one more of these and delete the rest.
--->
+- [x] Metrics
+  - Metric name: `kubelet_started_pods_errors_total`
+  - Components exposing the metric: kubelet
 
-N/A.
+> NOTE: The `kubelet_started_pods_errors_total` metric is a general metric for
+> any errors that occur when starting pods. The error message (Pod events,
+> kubelet logs) will contain details if the CRI failure is related to the
+> feature.
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -1,0 +1,956 @@
+<!--
+**Note:** When your KEP is complete, all of these comment blocks should be removed.
+
+To get started with this template:
+
+- [ ] **Pick a hosting SIG.**
+  Make sure that the problem space is something the SIG is interested in taking
+  up. KEPs should not be checked in without a sponsoring SIG.
+- [ ] **Create an issue in kubernetes/enhancements**
+  When filing an enhancement tracking issue, please make sure to complete all
+  fields in that template. One of the fields asks for a link to the KEP. You
+  can leave that blank until this KEP is filed, and then go back to the
+  enhancement and add the link.
+- [ ] **Make a copy of this template directory.**
+  Copy this template into the owning SIG's directory and name it
+  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
+  leading-zero padding) assigned to your enhancement above.
+- [ ] **Fill out as much of the kep.yaml file as you can.**
+  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
+  "Status", and date-related fields.
+- [ ] **Fill out this file as best you can.**
+  At minimum, you should fill in the "Summary" and "Motivation" sections.
+  These should be easy if you've preflighted the idea of the KEP with the
+  appropriate SIG(s).
+- [ ] **Create a PR for this KEP.**
+  Assign it to people in the SIG who are sponsoring this process.
+- [ ] **Merge early and iterate.**
+  Avoid getting hung up on specific details and instead aim to get the goals of
+  the KEP clarified and merged quickly. The best way to do this is to just
+  start with the high-level sections and fill out details incrementally in
+  subsequent PRs.
+
+Just because a KEP is merged does not mean it is complete or approved. Any KEP
+marked as `provisional` is a working document and subject to change. You can
+denote sections that are under active debate as follows:
+
+```
+<<[UNRESOLVED optional short context or usernames ]>>
+Stuff that is being argued.
+<<[/UNRESOLVED]>>
+```
+
+When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
+focused. If you disagree with what is already in a document, open a new PR
+with suggested changes.
+
+One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
+You do not need a new KEP to move from beta to GA, for example. If
+new details emerge that belong in the KEP, edit the KEP. Once a feature has become
+"implemented", major changes should get new KEPs.
+
+The canonical place for the latest set of instructions (and the likely source
+of this file) is [here](/keps/NNNN-kep-template/README.md).
+
+**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
+it is marked `implementable`, must be approved by each of the KEP approvers.
+If none of those approvers are still appropriate, then changes to that list
+should be approved by the remaining approvers and/or the owning SIG (or
+SIG Architecture for cross-cutting KEPs).
+-->
+# [KEP-4112](https://github.com/kubernetes/enhancements/issues/4112): Pass down resources to CRI
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1](#story-1)
+    - [Story 2](#story-2)
+    - [Story 3](#story-3)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [CRI API](#cri-api)
+    - [ContainerConfig](#containerconfig)
+    - [UpdateContainerResourcesRequest](#updatecontainerresourcesrequest)
+    - [PodSandboxConfig](#podsandboxconfig)
+  - [kubelet](#kubelet)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+  - [Container annotations](#container-annotations)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge code into a release, there must be an
+issue in [kubernetes/enhancements] referencing this KEP and targeting a release
+milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
+of the targeted release**.
+
+For enhancements that make changes to code or processes/procedures in core
+Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
+Signoff checklist to be completed.
+
+Check these off as they are completed for the Release Team to track. These
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+The kubelet does not provide complete information about the container
+resources specification (requests and limits) to CRI. However, various use
+cases have been identified where detailed knowledge of all the resources can be
+utilized in container runtimes for more optimal resource allocation to improve
+application performance and reduce cross-application interference.
+
+This KEP proposes a CRI API extension for disclosing container resource
+requests and limits to container runtimes.
+
+## Motivation
+
+Kubelet manages the native resources (CPU and memory) and communicates
+resource parameters over the CRI API to the runtime. However, the original
+details of the resource spec are lost as they get translated (within kubelet)
+to platform-specific (i.e. Linux or Windows) resource controller parameters
+like cpu shares, memory limits etc. Non-native resources such as extended
+resources and the device plugin resources are not visible to container runtimes
+at all.
+
+However, VM-based runtimes such as
+[Kata containers](https://katacontainers.io/), platform-optimized container
+runtimes,
+[OCI hooks](https://github.com/opencontainers/runtime-spec/blob/master/config.md),
+[runC](https://github.com/opencontainers/runc) wrappers,
+[NRI](https://github.com/containerd/nri) plugins or in some cases even
+applications themselves would benefit on getting full resource information,
+e.g. for reserving all required resources at pod sandbox creation (as it might
+be hard to impossible after that) or doing customized resource optimization.
+Extending the CRI API in to include the resource information would provide a
+comprehensive view of all resource usage of containers, allowing improved
+resource allocation without breaking any existing use cases.
+
+### Goals
+
+- make container resource spec transparently visible to CRI (the container
+  runtime)
+
+### Non-Goals
+
+- change kubelet resource management
+- change existing behavior of CRI
+
+## Proposal
+
+### User Stories
+
+#### Story 1
+
+As a VM-based container runtime developer, I want to allocate/expose enough
+RAM, hugepages, GPU memory, protected memory sections and other resources for
+the VM to ensure that all containers in the pod are guaranteed to get the
+resources they require.
+
+#### Story 2
+
+As a platform-optimized CRI runtime developer, I want to know detailed
+container resource requests to be able to make optimal, platform specific,
+resource allocations. Some of the resources may be handled outside cgroups and
+be container runtime specific details.
+
+#### Story 3
+
+As a cluster administrator, I want to install an OCI hook/runc wrapper/NRI
+plugin that does customized resource handling.
+
+### Notes/Constraints/Caveats (Optional)
+
+<!--
+What are the caveats to the proposal?
+What are some important details that didn't come across above?
+Go in to as much detail as necessary here.
+This might be a good place to talk about core concepts and how they relate.
+-->
+
+### Risks and Mitigations
+
+<!--
+What are the risks of this proposal, and how do we mitigate? Think broadly.
+For example, consider both security and how this will impact the larger
+Kubernetes ecosystem.
+
+How will security be reviewed, and by whom?
+
+How will UX be reviewed, and by whom?
+
+Consider including folks who also work outside the SIG or subproject.
+-->
+
+The proposal only adds new informantional data to the CRI API between kubelet
+and the container runtime with no user-visible changes which mitigates possible
+risks considerably.
+
+Data duplication/inconsistency with native resources could be considered a risk
+as those are passed down to CRI both as "raw" requests and limits and as
+"translated" resource control parameters (like cpu shares oom scoring etc). But
+this should be largely mitigated by code reviews and unit tests.
+
+## Design Details
+
+The proposal is that kubelet discloses full resources information from the
+PodSpec to the container runtime. This is accomplished by extending the
+ContainerConfig, UpdateContainerResourcesRequest and PodSandboxConfig messages
+of the CRI API.
+
+With this information, the runtime can for example do detailed resource
+allocation so that CPU, memory and other resources for each container are
+optimally aligned.
+
+The resource information is included in PodSandboxConfig so that the runtime
+can see the full picture of Pod's resource usage at Pod creation time, for
+example enabling more holistic resource allocation and thus better
+interoperability between containers inside the Pod.
+
+### CRI API
+
+#### ContainerConfig
+
+The ContainerConfig message (used in CreateContainer request) is extended to
+contain unmodified resource requests from the PodSpec.
+
+```diff
++import "k8s.io/apimachinery/pkg/api/resource/generated.proto";
+
+ message ContainerConfig {
+ 
+ ...
+ 
+     // Configuration specific to Windows containers.
+     WindowsContainerConfig windows = 16;
+ 
+     // CDI devices for the container.
+     repeated CDIDevice CDI_devices = 17;
++
++    // Kubernetes resource spec of the container
++    repeated ContainerResourceConfig container_resources = 18;
+ }
+ 
++message ContainerResourceConfig {
++    // Name of the container
++    string name= 1;
++    // Requests and limits hold corresponding container resources data.
++    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;
++    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 3;
++}
+```
+
+#### UpdateContainerResourcesRequest
+
+The UpdateContainerResourcesRequest message is extended to pass down unmodified
+resource requests from the PodSpec.
+
+```diff
+ message UpdateContainerResourcesRequest {
+     // ID of the container to update.
+     string container_id = 1;
+     // Resource configuration specific to Linux containers.
+     LinuxContainerResources linux = 2;
+     // Resource configuration specific to Windows containers.
+     WindowsContainerResources windows = 3;
+     // Unstructured key-value map holding arbitrary additional information for
+     // container resources updating. This can be used for specifying experimental
+     // resources to update or other options to use when updating the container.
+     map<string, string> annotations = 4;
++
++    // Kubernetes resource spec of the container
++    ContainerResourceConfig container_resources = 5;
+ }
+```
+
+#### PodSandboxConfig
+
+The PodSandboxConfig message (part of the RunPodSandbox request) will be
+extended to contain information about resources of all its containers known at
+the pod creation time. The container resources here are non-binding and only
+informational, e.g. for the runtime to prepare for optimal allocation of
+resources of all the containers of the Pod.
+
+```diff
+ message PodSandboxConfig {
+ 
+ ...
+ 
+     // Optional configurations specific to Linux hosts.
+     LinuxPodSandboxConfig linux = 8;
+     // Optional configurations specific to Windows hosts.
+     WindowsPodSandboxConfig windows = 9;
++
++    // Kubernetes resource spec of the containers in the pod.
++    PodResourceConfig pod_resources = 10;
+ }
+ 
++message PodResourceConfig {
++    repeated ContainerResourceConfig init_containers = 1;
++    repeated ContainerResourceConfig containers = 2;
++}
+```
+
+### kubelet
+
+Kubelet will be be extended to pass down the unmodified resource requests and
+limits to the container runtime in all related CRI requests, i.e.
+RunPodSandbox, CreateContainer and UpdateContainerResources.
+
+For example, take a PodSpec:
+
+```yaml
+apiVersion: v1
+kind: Pod
+...
+spec:
+  containers:
+    - name: cnt-1
+      ...
+      resources:
+        requests:
+          cpu: 1
+          memory: 1G
+        limits:
+          cpu: 2
+          memory: 2G
+    - name: cnt-2
+      ...
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100M
+          vendor.com/xpu: 1
+        limits:
+          cpu: 200m
+          memory: 200M
+          vendor.com/xpu: 1
+```
+
+Then kubelet will send the following RunPodSandboxRequest when creating the Pod
+(represented here in yaml format):
+
+```yaml
+RunPodSandboxRequest:
+  config:
+  ...
+    podResources:
+      containers:
+        - name: cnt-1
+          requests:
+            cpu: 1
+            memory: 1G
+          limits:
+           cpu: 2
+           memory: 2G
+        - name: cnt-2
+          requests:
+            cpu: 100m
+            memory: 100M
+            vendor.com/xpu: 1
+          limits:
+            cpu: 200m
+            memory: 200M
+            vendor.com/xpu: 1
+```
+
+### Test Plan
+
+<!--
+**Note:** *Not required until targeted at a release.*
+The goal is to ensure that we don't accept enhancements with inadequate testing.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
+when drafting this test plan.
+
+[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+
+[ ] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+<!--
+Based on reviewers feedback describe what additional tests need to be added prior
+implementing this enhancement to ensure the enhancements have also solid foundations.
+-->
+
+##### Unit tests
+
+<!--
+In principle every added code should have complete unit test coverage, so providing
+the exact set of tests will not bring additional value.
+However, if complete unit test coverage is not possible, explain the reason of it
+together with explanation why this is acceptable.
+-->
+
+<!--
+Additionally, for Alpha try to enumerate the core package you will be touching
+to implement this enhancement and provide the current unit coverage for those
+in the form of:
+- <package>: <date> - <current test coverage>
+The data can be easily read from:
+https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
+
+This can inform certain test coverage improvements that we want to do before
+extending the production code to implement this enhancement.
+-->
+
+- `<package>`: `<date>` - `<test coverage>`
+
+##### Integration tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+-->
+
+- <test>: <link to test coverage>
+
+##### e2e tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+
+We expect no non-infra related flakes in the last month as a GA graduation criteria.
+-->
+
+- <test>: <link to test coverage>
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+
+#### Alpha
+
+- Feature implemented behind a feature flag
+- Initial e2e tests completed and enabled
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Complete features A, B, C
+- Additional tests are in Testgrid and linked in KEP
+
+#### GA
+
+- N examples of real-world usage
+- N installs
+- More rigorous forms of testing—e.g., downgrade tests and scalability tests
+- Allowing time for feedback
+
+**Note:** Generally we also wait at least two releases between beta and
+GA/stable, because there's no opportunity for user feedback, or even bug reports,
+in back-to-back releases.
+
+**For non-optional features moving to GA, the graduation criteria must include
+[conformance tests].**
+
+[conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
+
+#### Deprecation
+
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+
+### Upgrade / Downgrade Strategy
+
+<!--
+If applicable, how will the component be upgraded and downgraded? Make sure
+this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to maintain previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to make use of the enhancement?
+-->
+
+### Version Skew Strategy
+
+<!--
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- Does this enhancement involve coordinating behavior in the control plane and
+  in the kubelet? How does an n-2 kubelet without this feature available behave
+  when this feature is used?
+- Will any other components on the node change? For example, changes to CSI,
+  CRI or CNI may require updating that component before the kubelet.
+-->
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+<!--
+This section must be completed when targeting alpha to a release.
+-->
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+<!--
+Pick one of these and delete the rest.
+
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
+
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
+
+- [ ] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name:
+  - Components depending on the feature gate:
+- [ ] Other
+  - Describe the mechanism:
+  - Will enabling / disabling the feature require downtime of the control
+    plane?
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node?
+
+###### Does enabling the feature change any default behavior?
+
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+
+### Rollout, Upgrade and Rollback Planning
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
+
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
+
+###### What specific metrics should inform a rollback?
+
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+### Monitoring Requirements
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### How can an operator determine if the feature is in use by workloads?
+
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
+
+###### How can someone using this feature know that it is working for their instance?
+
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [ ] Events
+  - Event Reason: 
+- [ ] API .status
+  - Condition name: 
+  - Other field: 
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+- [ ] Metrics
+  - Metric name:
+  - [Optional] Aggregation method:
+  - Components exposing the metric:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+### Dependencies
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+### Scalability
+
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
+
+For beta, this section is required: reviewers must answer these questions.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### Will enabling / using this feature result in any new API calls?
+
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
+
+###### Will enabling / using this feature result in introducing new API types?
+
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+### Troubleshooting
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+###### What are other known failure modes?
+
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of a KEP should be tracked in this section.
+Major milestones might include:
+- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
+- the `Proposal` section being merged, signaling agreement on a proposed design
+- the date implementation started
+- the first Kubernetes release where an initial version of the KEP was available
+- the version of Kubernetes where the KEP graduated to general availability
+- when the KEP was retired or superseded
+-->
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+## Alternatives
+
+<!--
+What other approaches did you consider, and why did you rule them out? These do
+not need to be as detailed as the proposal, but should include enough
+information to express the idea and why it was not acceptable.
+-->
+
+### Container annotations
+
+Container annotations could be used as an alternative way to pass down the
+resource requests and limits to the container runtime.
+
+## Infrastructure Needed (Optional)
+
+<!--
+Use this section if you need things from the project/SIG. Examples include a
+new subproject, repos requested, or GitHub details. Listing these here allows a
+SIG to get the process for these resources started right away.
+-->

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -253,8 +253,6 @@ breaking any existing use cases.
 
 - change kubelet resource management
 - change existing behavior of CRI
-- add UpdatePodSandboxResources CRI rpc (this is covered by [KEP-1287][kep-1287], [PR][kep-1287-beta-pr])
-- add pod-level resource requirements (this is covered by [KEP-2837][kep-2837], [PR][kep-2837-alpha-pr])
 
 ## Proposal
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -284,6 +284,8 @@ contain unmodified resource requests from the PodSpec.
  
 +message ContainerResourceConfig {
 +    // Name of the container
++    // Note: name is redundant for container-specific requests (UpdateContainerResourcesRequest)
++    // but needed for pod-specific requests (PodSandboxConfig).
 +    string name= 1;
 +    // Requests and limits hold corresponding container resources data.
 +    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -279,17 +279,13 @@ contain unmodified resource requests from the PodSpec.
      repeated CDIDevice CDI_devices = 17;
 +
 +    // Kubernetes resource spec of the container
-+    repeated ContainerResourceConfig container_resources = 18;
++    KubernetesResources kubernetes_resources = 18;
  }
  
-+message ContainerResourceConfig {
-+    // Name of the container
-+    // Note: name is redundant for container-specific requests (UpdateContainerResourcesRequest)
-+    // but needed for pod-specific requests (PodSandboxConfig).
-+    string name= 1;
-+    // Requests and limits hold corresponding container resources data.
-+    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 2;
-+    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 3;
++message KubernetesResources {
++    // Requests and limits from the Kubernetes container config.
++    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> requests = 1;
++    map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> limits = 2;
 +}
 ```
 
@@ -312,7 +308,7 @@ resource requests from the PodSpec.
      map<string, string> annotations = 4;
 +
 +    // Kubernetes resource spec of the container
-+    ContainerResourceConfig container_resources = 5;
++    KubernetesResources kubernetes_resources = 18;
  }
 ```
 
@@ -341,6 +337,20 @@ resources of all the containers of the Pod.
 +message PodResourceConfig {
 +    repeated ContainerResourceConfig init_containers = 1;
 +    repeated ContainerResourceConfig containers = 2;
++}
+ 
++message ContainerResourceConfig {
++    // Name of the container
++    string name= 1;
++
++    // Kubernetes resource spec of the container
++    KubernetesResources kubernetes_resources = 2;
++
++    // CDI devices for the container.
++    repeated CDIDevice CDI_devices = 3;
++
++    // Mounts for the container.
++    repeated Mount mounts = 4;
 +}
 ```
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -334,16 +334,15 @@ requirements. This make it possible for the CRI runtime to detect any changes
 in the pod resources that happen between the Pod creation and container
 creation in e.g.  scenarios where in-place pod updates are involved.
 
-[KEP-1287][kep-1287] Beta ([PR][kep-1287-beta-pr]) proposes to add new
-UpdatePodSandboxResources rpc to the CRI API. If/when KEP-1287 is implemented
-as proposed, the UpdatePodSandboxResources CRI message is updated to include
-the resource information of all containers (aligning with
-UpdateContainerResourcesRequest).
+[KEP-1287][kep-1287] ([Issue][kep-1287-issue]) Beta in Kubernetes v1.32
+introduced UpdatePodSandboxResources rpc to the CRI API. The
+UpdatePodSandboxResources CRI message is updated to include the resource
+information of all containers (aligning with UpdateContainerResourcesRequest).
 
-[KEP-2837][kep-2837] Alpha ([PR][kep-2837-alpha-pr]) proposes to add new
-Pod-level resource requirements field to the PodSpec. This information will be
-be added to the PodResourceConfig message, similar to the container resource
-information, if/when KEP-2837 is implemented as proposed.
+[KEP-2837][kep-2837] ([Issue][kep-2837-issue]) Alpha in Kubernetes v1.32
+introduced Pod-level resource requirements field to the PodSpec. The
+PodResourceConfig message in the CRI API is updated to include the Pod-level
+resource requirements.
 
 ### CRI API
 
@@ -359,6 +358,12 @@ operate as they did (before this enhancement). That is, it can ignore
 the resource information presented here and allocate resources for each
 container separately at container creation time with the `CreateContainer`
 request.
+
+The Pod-level resources enhancement [KEP-2837][kep-2837]
+([Issue][kep-2837-issue]) Alpha in Kubernetes v1.32 added new Pod-level
+resource requirements field to the PodSpec. This information will is included
+in the PodResourceConfig message, similar to the container-level resource
+information.
 
 ```diff
  message PodSandboxConfig {
@@ -377,7 +382,13 @@ request.
 +// PodResourceConfig contains information of all resources requirements of
 +// the containers of a pod.
 +message PodResourceConfig {
++    // Resource configuration of all containers in the pod.
 +    repeated ContainerResourceConfig containers = 1;
++ 
++    // Kubernetes resource spec of the pod-level resource requirements.
++    // This is the pod-level resource requirements introduced in KEP-2837
++    // (alpha in v1.32).
++    KubernetesResources kubernetes_resources = 2;
 +}
  
 +// ContainerResourceConfig contains information of all resource requirements of
@@ -408,23 +419,6 @@ request.
 +    CONTAINER = 2;
 +}
 ```
-
-The Pod-level resources enhancement [KEP-2837][kep-2837]
-([alpha PR][kep-2837-alpha-pr]) proposes to add new Pod-level resource
-requirements fields to the PodSpec. This information will be be added to the
-PodResourceConfig message, similar to the container resource information.
-
-```diff
- message PodResourceConfig {
-     repeated ContainerResourceConfig containers = 1;
-+
-+    // Kubernetes resource spec of the pod-level resource requirements.
-+    KubernetesResources kubernetes_resources = 2;
- }
-```
-
-The implementation if adding the KubernetesResources field to the
-PodResourceConfig is synced with [KEP-2837][kep-2837].
 
 #### CreateContainer
 
@@ -506,9 +500,9 @@ adding them.
 
 #### UpdatePodSandboxResources
 
-The In-Place Update of Pod Resources ([KEP-1287][kep-1287]) Beta
-([PR][kep-1287-beta-pr]) proposes to add new UpdatePodSandboxResources rpc to
-inform the CRI runtime about the changes in the pod resources.
+The In-Place Update of Pod Resources ([KEP-1287][kep-1287]) Beta in Kubernetes
+v1.32 introduced new UpdatePodSandboxResources rpc to inform the CRI runtime
+about the changes in the pod resources.
 
 The UpdatePodSandboxResourcesRequest message is extended similarly to the
 [PodSandboxConfig](#podsandboxconfig) message to contain information about
@@ -1297,7 +1291,7 @@ SIG to get the process for these resources started right away.
 
 <!-- References -->
 
-[kep-1287]: https://github.com/kubernetes/enhancements/issues/1287
-[kep-1287-beta-pr]: https://github.com/kubernetes/enhancements/pull/4704
-[kep-2837]: https://github.com/kubernetes/enhancements/issues/2837
-[kep-2837-alpha-pr]: https://github.com/kubernetes/enhancements/pull/4678
+[kep-1287]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
+[kep-1287-issue]: https://github.com/kubernetes/enhancements/issues/1287
+[kep-2837]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2837-pod-level-resource-spec
+[kep-2837-issue]: https://github.com/kubernetes/enhancements/issues/2837

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -71,6 +71,7 @@ SIG Architecture for cross-cutting KEPs).
     - [Story 1](#story-1)
     - [Story 2](#story-2)
     - [Story 3](#story-3)
+    - [Story 4](#story-4)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -866,11 +866,9 @@ Any change of default behavior may be surprising to users or break existing
 automations, so be extremely careful here.
 -->
 
-The default behavior in Kubernetes is unchanged.
-
-However, there might be changes in behavior if the underlying CRI runtime
-depends on this feature. For example, an NRI plugin relying on the feature may
-cause the application to behave differently.
+There might be changes in behavior if the underlying CRI runtime depends on
+this feature. For example, an NRI plugin relying on the feature may cause the
+application to behave differently.
 
 Long running pods that persist (without restart) over kubelet and CRI runtime
 update which enables the feature may experience version skew of the metadata.

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -308,7 +308,7 @@ resource requests from the PodSpec.
      map<string, string> annotations = 4;
 +
 +    // Kubernetes resource spec of the container
-+    KubernetesResources kubernetes_resources = 18;
++    KubernetesResources kubernetes_resources = 5;
  }
 ```
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -616,6 +616,10 @@ We expect no non-infra related flakes in the last month as a GA graduation crite
 
 For alpha, no new e2e tests are planned.
 
+For Beta: a suite of NRI tests will be added to verify that the runtime
+receives the resource information correctly and passes it down to the NRI
+plugins.
+
 ### Graduation Criteria
 
 <!--
@@ -696,8 +700,6 @@ in back-to-back releases.
 #### GA
 
 - No bugs reported in the previous cycle
-- N examples of real-world usage
-- N installs
 
 ### Upgrade / Downgrade Strategy
 
@@ -784,15 +786,10 @@ well as the [existing list] of feature gates.
 [existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 -->
 
-- [ ] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name:
+- [X] Feature gate
+  - Feature gate name: KubeletContainerResourcesInPodSandbox
   - Components depending on the feature gate:
-- [ ] Other
-  - Describe the mechanism:
-  - Will enabling / disabling the feature require downtime of the control
-    plane?
-  - Will enabling / disabling the feature require downtime or reprovisioning
-    of a node?
+    - kubelet
 
 ###### Does enabling the feature change any default behavior?
 

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -78,6 +78,7 @@ SIG Architecture for cross-cutting KEPs).
     - [PodSandboxConfig](#podsandboxconfig)
     - [CreateContainer](#createcontainer)
     - [UpdateContainerResourcesRequest](#updatecontainerresourcesrequest)
+    - [UpdatePodSandboxResources](#updatepodsandboxresources)
   - [kubelet](#kubelet)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)

--- a/keps/sig-node/4112-passdown-resources-to-cri/README.md
+++ b/keps/sig-node/4112-passdown-resources-to-cri/README.md
@@ -280,6 +280,13 @@ disabled (CPU manager policy set to `none`). Instead I use my NRI plugin to do
 customized resource allocation (e.g. cpu and memory pinning). To do that
 properly I need the actual resource requests and limits requested by the user.
 
+#### Story 4
+
+As a cluster administrator, I want to install an NRI plugin that does limits
+enforcement for extended resources that the kubelet does not know about (e.g.,
+`misc` cgroup settings). These extended resources are consumed either via the
+pod spec or indirectly via Pod overhead.
+
 ### Notes/Constraints/Caveats (Optional)
 
 <!--

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -1,0 +1,39 @@
+title: Pass down resources to CRI
+kep-number: 4112
+authors:
+  - "@marquiz"
+  - "@askervin"
+owning-sig: sig-node
+participating-sigs: []
+status: provisional
+creation-date: 2023-06-28
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+see-also: []
+replaces: []
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.29"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v1.29"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: TBD
+    components:
+      - kubelet
+disable-supported: true
+
+# The following PRR answers are required at beta release
+metrics: []

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -21,11 +21,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.33"
+  alpha: "v1.34"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -21,11 +21,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.30"
+  alpha: "v1.31"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -21,11 +21,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.29"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.29"
+  alpha: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -21,11 +21,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.31"
+  alpha: "v1.32"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -5,7 +5,7 @@ authors:
   - "@askervin"
 owning-sig: sig-node
 participating-sigs: []
-status: provisional
+status: implementable
 creation-date: 2023-06-28
 reviewers:
   - "@mikebrow"

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -8,9 +8,9 @@ participating-sigs: []
 status: provisional
 creation-date: 2023-06-28
 reviewers:
-  - TBD
+  - "@mikebrow"
 approvers:
-  - TBD
+  - "@haircommander"
 
 see-also: []
 replaces: []
@@ -30,7 +30,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: TBD
+  - name: KubeletContainerResourcesInPodSandbox
     components:
       - kubelet
 disable-supported: true

--- a/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
+++ b/keps/sig-node/4112-passdown-resources-to-cri/kep.yaml
@@ -21,11 +21,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.32"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.32"
+  alpha: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP for extending the CRI API to pass down unmodified resource information from the kubelet to the CRI runtime.

<!-- link to the k/enhancements issue -->
- Issue link: #4112

<!-- other comments or additional information -->
- Other comments: