### PR TITLE
KEP-3762: graduate PersistentVolumeLastPhaseTransitionTime to beta in v1.29

### DIFF
--- a/keps/prod-readiness/sig-storage/3762.yaml
+++ b/keps/prod-readiness/sig-storage/3762.yaml
@@ -1,3 +1,5 @@
 kep-number: 3762
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-storage/3762-persistent-volume-last-phase-transition-time/kep.yaml
+++ b/keps/sig-storage/3762-persistent-volume-last-phase-transition-time/kep.yaml
@@ -6,7 +6,7 @@ owning-sig: sig-storage
 participating-sigs:
 status: implementable
 creation-date: 2023-01-20
-last-updated: 2023-06-01
+last-updated: 2023-12-06
 reviewers:
   - "@jsafrane"
 approvers:
@@ -16,12 +16,12 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -35,7 +35,6 @@ feature-gates:
   - name: PersistentVolumeLastPhaseTransitionTime
     components:
       - kube-apiserver
-      - kube-controller-manager
 disable-supported: true
 
 # The following PRR answers are required at beta release


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: update KEP for PersistentVolumeLastPhaseTransitionTime feature to match actual implementation and graduate to beta

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3762

<!-- other comments or additional information -->
- Other comments:
This is a followup for discussed changes:
    - https://github.com/kubernetes/kubernetes/pull/116469#discussion_r1244625032
    - https://github.com/kubernetes/kubernetes/pull/116469#discussion_r1244617872