### PR TITLE
KEP-1441: Update netadmin profile to add CAP_NET_RAW and remove privileged

### DIFF
--- a/keps/sig-cli/1441-kubectl-debug/README.md
+++ b/keps/sig-cli/1441-kubectl-debug/README.md
@@ -401,11 +401,11 @@ Probes and labels are be stripped from Pod copies.
 
 #### Profile: netadmin
 
-| Journey             | Debug Container Behavior                                                   |
-| ------------------- | -------------------------------------------------------------------------- |
-| Node                | sets `NET_ADMIN` and privileged; uses host namespaces                      |
-| Pod Copy            | sets `NET_ADMIN` on debugging container                                    |
-| Ephemeral Container | sets `NET_ADMIN` on ephemeral container                                    |
+| Journey             | Debug Container Behavior                                                          |
+| ------------------- | --------------------------------------------------------------------------------- |
+| Node                | sets `NET_ADMIN` and `NET_RAW`; uses host namespaces                              |
+| Pod Copy            | sets `NET_ADMIN` and `NET_RAW` on debugging container; sets shareProcessNamespace |
+| Ephemeral Container | sets `NET_ADMIN` and `NET_RAW` on ephemeral container                             |
 
 This profile offers elevated privileges for network debugging.
 


### PR DESCRIPTION
 - One-line PR description: As discussed [#1441](https://github.com/kubernetes/enhancements/issues/1441#issuecomment-1484966305) and [k/k #118962](https://github.com/kubernetes/kubernetes/issues/118962), I've update netadmin profile to add CAP_NET_RAW and remove privileged.

- Issue link: https://github.com/kubernetes/enhancements/issues/1441

- Other comments: