### PR TITLE
Update WebSocket KEP (4006) to reflect latest understanding

### DIFF
--- a/keps/sig-api-machinery/4006-transition-spdy-to-websockets/kep.yaml
+++ b/keps/sig-api-machinery/4006-transition-spdy-to-websockets/kep.yaml
@@ -21,13 +21,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.28"
-  beta: "v1.29"
-  stable: "v1.30"
+  alpha: "v1.29"
+  beta: "v1.30"
+  stable: "v1.31"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
* Updates WebSockets KEP to reflect the latest understandings
  * Updates references from `v1.28` to `v1.29`
  * Updates description of new `RemoteCommand` version (`v5.channel.k8s.io`) to reflect the latest design.
  * Removes all mention of `PortForward` until the design is added.
