### PR TITLE
KEP-3705: fix beta/GA releases for CloudDualStackNodeIPs

### DIFF
--- a/keps/sig-network/3705-cloud-node-ips/kep.yaml
+++ b/keps/sig-network/3705-cloud-node-ips/kep.yaml
@@ -27,13 +27,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
-  beta: "v1.28"
-  stable: "v1.29"
+  beta: "v1.29"
+  stable: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: fix release versions for KEP-3705, which didn't actually go beta in 1.28

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3705

<!-- other comments or additional information -->
- Other comments:
#3975 bumped this to beta for 1.28, but after that we discovered that alpha had been broken (https://github.com/kubernetes/kubernetes/issues/118315) so we extended alpha for another release, but didn't revert the KEP. This just syncs the KEP to the current plan.

/assign @thockin