### PR TITLE
update kubelet parallel image pull limit for v1.29

### DIFF
--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/README.md
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/README.md
@@ -110,6 +110,7 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Troubleshooting](#troubleshooting)
 - [Implementation History](#implementation-history)
   - [Alpha](#alpha-1)
+  - [Beta](#beta-1)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
 - [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
@@ -381,8 +382,8 @@ https://storage.googleapis.com/k8s-triage/index.html
 We expect no non-infra related flakes in the last month as a GA graduation criteria.
 -->
 
-A new node_e2e test with  `serialize-image-pulls==false` will be added test parallel image pull limits. 
-1. When maxParallelImagePulls is reached, all further image pulls will be blocked. 
+A new node_e2e test with  `serialize-image-pulls==false` will be added test parallel image pull limits.
+1. When maxParallelImagePulls is reached, all further image pulls will be blocked.
 2. Verify the behavior when the same image is pulled in parallel, which will happen when image pull policy is `Always`.
 
 - <test>: <link to test coverage>
@@ -905,7 +906,15 @@ Major milestones might include:
 
 ### Alpha
 
-Alpha feature was implemented in 1.27.
+Alpha feature was implemented in 1.27: <https://github.com/kubernetes/kubernetes/pull/115220>
+
+### Beta
+
+Add e2e tests(WIP):
+
+1. A new node_e2e test to confirm image pull will be blocked if maxParallelImagePulls is reached.
+2. Verfiy behavior of image pull in parallel for same image using `imagePullPolicy:Always`.
+3. Check the waiting period of image pull for pods with `MaxParallelImagePulls: 1` and `MaxParallelImagePulls: 5`.
 
 ## Drawbacks
 

--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
@@ -6,6 +6,7 @@ authors:
 owning-sig: sig-node
 status: implementable
 creation-date: 2023-01-05
+last-updated: 2023-09-08
 reviewers:
   - "@SergeyKanzhelev"
 approvers:
@@ -17,10 +18,10 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
-  beta: "v1.28"
-  stable: "v1.29"
+  beta: "v1.29"
+  stable: "v1.30"


### PR DESCRIPTION
xref https://github.com/kubernetes/enhancements/issues/3673

this is planned to be promoted to beta in v1.28.

We have no time to add the e2e test cases, and so we postponed to promote to beta to v1.29

- The PRR review was already passed in https://github.com/kubernetes/enhancements/pull/4036 by @wojtek-t 