### PR TITLE
KEP-2593: update risks and mitigation, rename object and target releases

### DIFF
--- a/keps/sig-network/2593-multiple-cluster-cidrs/README.md
+++ b/keps/sig-network/2593-multiple-cluster-cidrs/README.md
@@ -205,10 +205,18 @@ CIDRs (more details on this are discussed below).
 
 ### Risks and Mitigations
 
--   Racing kube-controller-managers. If multiples of the controller are running
+- Racing kube-controller-managers. If multiples of the controller are running
     (as in a HA control plane), how do they coordinate?
     -   The controllers will coordinate using the existing
         kube-controller-manager leader election.
+
+- API bad usage or misinterpretation. This KEPs introduces an API object to configure
+  the NodeIPAM controller that configures the node.Spec.PodCIDRs, so is absolutely
+  necessary for components that want to use this API object to configure the kcm with
+  --cidr-allocator-type=MultiCIDRRangeAllocator and not make any assumptions about the
+  IP ranges specified in the NodeIPAMConfig objects.
+    - Release notes will hightlight this problem and a blog post will be created to explain
+    the technical details and remove any possible ambiguity.
 
 ## Design Details
 

--- a/keps/sig-network/2593-multiple-cluster-cidrs/kep.yaml
+++ b/keps/sig-network/2593-multiple-cluster-cidrs/kep.yaml
@@ -23,8 +23,8 @@ latest-milestone: "v1.27"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.25"
-  beta: "v1.27"
-  stable: "v1.29"
+  beta: "v1.29"
+  stable: "v1.30"
 
 feature-gates:
   - name: MultiCIDRRangeAllocator


### PR DESCRIPTION
During the development of the [KEP 1880: Multiple Service CIDRs](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1880-multiple-service-cidrs#kep-1880-multiple-service-cidrs) the intersection with [KEP 2593: Enhanced NodeIPAM to support Discontiguous Cluster CIDR](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2593-multiple-cluster-cidrs) made the SIG Network to revisit the state of the Kubernetes networking configuration, specially the configuration of the Pod and Services networks.
This [triggered several discussion](https://groups.google.com/g/kubernetes-sig-network/c/A8hkgSrnUkQ/m/wu-SS4gRAgAJ) and [different alternatives were evaluated and discussed deeply]( https://docs.google.com/document/d/1B126qZc5DcI_kFlTTj1HRJvn7WrwJKoCx5RKbrh2bDU/edit#heading=h.rkh0f6t1c3vc) , concluding that all possible problems of the network intersection can not be mitigated, it will be very difficult (if not impossible) at this stage of the project to do any significant changes with backwards compatibility and without disrupting the whole ecosystem that depends on current state.

During these conversations some concerns were raised by the community about this KEP-2593:
- [x] It should be generic enough to not be tied to a single company/provider/vendor. IGoogle interest, promoter of the KEP,  is to use it with Cilium , a CNCF and OSS project; SUSE is already interested on this functionality and implemented it in flannel https://github.com/flannel-io/flannel/commit/243cf7ed4e4d8df5db4565fe3715ed54d558ec82, giving enough proof that this can not generate vendor lockin.
- [x] It should be clear that PodCIDRs is a network plugin responsability and the KEP is not authoritative about the pod network. The KEP is clear about this and both the Motivation, Goals and Non-Goals sections are explicit about it https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2593-multiple-cluster-cidrs#motivation

One part that may cause fiction is the name of the object used, `ClusterCIDR` , but there are several points that makes keeping the same object name preferrable as previously mentioned:
- there are several implementations that still use the existing API object , like flannel https://github.com/flannel-io/flannel/tree/master/Documentation/MultiClusterCIDR.
- the API object was already [renamed in 1.26](https://github.com/kubernetes/enhancements/commit/44828bdeb015cc92a83cfabd1c0d3c4276b5f58a) and another rename will need tp add another release delay, in a KEP that it's functionality was already implemented in 1.25 and that there is not additional work needed.
- The existing [kube-controller-manager flag name has the same name --cluster-cidr](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)

```
--cluster-cidr string
--
  | CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true
```

The proposal is to move forward to beta this KEP in 1.29 with current state

/sig network
/assign @thockin @danwinship 