### PR TITLE
KEP-3895: Promote interactive flag in delete command to beta

### DIFF
--- a/keps/prod-readiness/sig-cli/3895.yaml
+++ b/keps/prod-readiness/sig-cli/3895.yaml
@@ -4,3 +4,5 @@
 kep-number: 3895
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
@@ -472,6 +472,7 @@ in back-to-back releases.
 #### Beta
 
 - Gather feedback from developers and surveys
+- KUBECTL_INTERACTIVE_DELETE environment variable is removed and interactive flag is enabled by default
 
 #### GA
 
@@ -865,6 +866,7 @@ N/A
 
 ## Implementation History
 The KEP was proposed on 2023-03-01
+The KEP was promoted to beta on 2023-10-02
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.
 Major milestones might include:

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
@@ -472,7 +472,7 @@ in back-to-back releases.
 #### Beta
 
 - Gather feedback from developers and surveys
-- KUBECTL_INTERACTIVE_DELETE environment variable is removed and interactive flag is enabled by default
+- KUBECTL_INTERACTIVE_DELETE environment variable is removed and interactive flag is available by default
 
 #### GA
 

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/kep.yaml
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/kep.yaml
@@ -19,17 +19,17 @@ see-also:
   - "https://github.com/kubernetes/enhancements/pull/2777"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.28"
-  beta: "TBD"
+  beta: "v1.29"
   stable: "TBD"
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
- One-line PR description: Promote `--interactive` flag in kubectl delete command to beta

- Issue link: https://github.com/kubernetes/enhancements/issues/3895

- Other comments: