### PR TITLE
KEP-3063: DRA: 1.30 update

### DIFF
--- a/keps/prod-readiness/sig-node/3063.yaml
+++ b/keps/prod-readiness/sig-node/3063.yaml
@@ -4,5 +4,3 @@
 kep-number: 3063
 alpha:
   approver: "@johnbelamaric"
-beta:
-  approver: "@johnbelamaric"

--- a/keps/prod-readiness/sig-node/3063.yaml
+++ b/keps/prod-readiness/sig-node/3063.yaml
@@ -4,3 +4,5 @@
 kep-number: 3063
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/3063-dynamic-resource-allocation/README.md
+++ b/keps/sig-node/3063-dynamic-resource-allocation/README.md
@@ -1974,6 +1974,16 @@ progress.
 
 ### Cluster Autoscaler
 
+-<<[UNRESOLVED pohly]>>
+The entire autoscaler section is tentative. Key opens:
+- Are DRA driver authors able and willing to provide implementations of
+  the simulation interface if needed for their driver?
+- Is the simulation interface generic enough to work across a variety
+  of autoscaler forks and/or implementations? What about Karpenter?
+- Is the suggested deployment approach (rebuild binary) workable?
+- Can we really not do something else, ideally RPC-based?
+-<<[/UNRESOLVED]>>
+
 When [Cluster
 Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#cluster-autoscaler)
 encounters a pod that uses a resource claim for node-local resources, the autoscaler needs assistance by

--- a/keps/sig-node/3063-dynamic-resource-allocation/README.md
+++ b/keps/sig-node/3063-dynamic-resource-allocation/README.md
@@ -2830,7 +2830,8 @@ Why should this KEP _not_ be implemented?
 
 ### Semantic Parameters instead of PodSchedulingContext
 
-When a DRA driver uses semantic parameters, there is no DRA driver controller
+When a DRA driver uses semantic parameters, there is no need for a DRA driver controller
+which allocates the claim
 and no need for communication between scheduler and such a controller. The
 PodSchedulingContext object and the associated support in the scheduler then
 aren't needed. Once semantic parameters are mature enough and confirmed to be

--- a/keps/sig-node/3063-dynamic-resource-allocation/README.md
+++ b/keps/sig-node/3063-dynamic-resource-allocation/README.md
@@ -141,6 +141,7 @@ SIG Architecture for cross-cutting KEPs).
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
+  - [Semantic Parameters instead of PodSchedulingContext](#semantic-parameters-instead-of-podschedulingcontext)
   - [ResourceClaimTemplate](#resourceclaimtemplate)
   - [Reusing volume support as-is](#reusing-volume-support-as-is)
   - [Extend volume support](#extend-volume-support)

--- a/keps/sig-node/3063-dynamic-resource-allocation/README.md
+++ b/keps/sig-node/3063-dynamic-resource-allocation/README.md
@@ -1910,7 +1910,7 @@ At the moment, the claim plugin has no information that might enable it to
 prioritize which resource to deallocate first. Future extensions of this KEP
 might attempt to improve this.
 
-This is currently using blocking API calls. They are unlikely because this
+This is currently using blocking API calls. It's quite rare because this
 situation can only arise when there are multiple claims per pod and allocation
 for one of them fails despite all drivers agreeing that a node should be
 suitable, or when reusing a claim for multiple pods (not a common use case) and

--- a/keps/sig-node/3063-dynamic-resource-allocation/README.md
+++ b/keps/sig-node/3063-dynamic-resource-allocation/README.md
@@ -664,7 +664,7 @@ allocation also may turn out to be insufficient. Some risks are:
   captured yet (like limited number of nodes that they can be attached to).
 
 - Cluster autoscaling will not work as expected unless the DRA driver
-  uses [numeric parameters](https://github.com/kubernetes/enhancements/issues/4381).
+  uses [semantic parameters](https://github.com/kubernetes/enhancements/issues/4381).
 
 All of these risks will have to be evaluated by gathering feedback from users
 and resource driver developers.
@@ -1841,6 +1841,11 @@ like "drivers have provided information" occurs, instead of forcing the pod to
 go through the backoff queue and the usually 5 second long delay associated
 with that.
 
+Queuing hints are an optional feature of the scheduler, with (as of Kubernetes
+1.29) their own `SchedulerQueueingHints` feature gate that defaults to
+off. When turned off, performance of scheduling pods with resource claims is
+slower compared to a cluster configuration where they are turned on.
+
 #### PreEnqueue
 
 This checks whether all claims referenced by a pod exist. If they don't,
@@ -1992,11 +1997,11 @@ to simulate the effect of allocating claims as part of scheduling and of
 creating or removing nodes.
 
 This is not possible with opaque parameters as described in this KEP. If a DRA
-driver developer wants to support Cluster Autoscaler, they have to use numeric
-parameters. Numeric parameters are an extension of this KEP that is defined in
+driver developer wants to support Cluster Autoscaler, they have to use semantic
+parameters. Semantic parameters are an extension of this KEP that is defined in
 [KEP #4381](https://github.com/kubernetes/enhancements/issues/4381).
 
-Numeric parameters are not necessary for network-attached resources because
+Semantic parameters are not necessary for network-attached resources because
 adding or removing nodes doesn't change their availability and thus Cluster
 Autoscaler does not need to understand their parameters.
 
@@ -2465,7 +2470,7 @@ For beta:
 
 - In normal scenarios, scheduling pods with claims must not block scheduling of
   other pods by doing blocking API calls
-- Implement integration with Cluster Autoscaler through numeric parameters
+- Implement integration with Cluster Autoscaler through semantic parameters
 - Gather feedback from developers and surveys
 - Positive acknowledgment from 3 would-be implementors of a resource driver,
   from a diversity of companies or projects
@@ -2821,6 +2826,18 @@ Why should this KEP _not_ be implemented?
 -->
 
 ## Alternatives
+
+### Semantic Parameters instead of PodSchedulingContext
+
+When a DRA driver uses semantic parameters, there is no DRA driver controller
+and no need for communication between scheduler and such a controller. The
+PodSchedulingContext object and the associated support in the scheduler then
+aren't needed. Once semantic parameters are mature enough and confirmed to be
+sufficient for DRA drivers, it might become possible to remove the
+PodSchedulingContext API from this KEP.
+
+It might still be needed for other drivers and use cases, which then can be
+discussed in a new KEP which focuses specifically on those use cases.
 
 ### ResourceClaimTemplate
 

--- a/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
+++ b/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
@@ -24,7 +24,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
+++ b/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
@@ -24,7 +24,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.29"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
+++ b/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
@@ -29,8 +29,6 @@ latest-milestone: "v1.29"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.26"
-  beta: "v1.29"
-  stable: "v1.31"
 
 feature-gates:
   - name: DynamicResourceAllocation


### PR DESCRIPTION
- One-line PR description: This updates the README to reflect what has been done and fills in sections that were left out earlier. The next milestone is 1.30 where DRA will remain in alpha.

- Issue link: https://github.com/kubernetes/enhancements/issues/3063
