### PR TITLE
KEP-4004: change from provisional to implementable

### DIFF
--- a/keps/prod-readiness/sig-network/4004.yaml
+++ b/keps/prod-readiness/sig-network/4004.yaml
@@ -1,0 +1,6 @@
+# The KEP must have an approver from the
+# "prod-readiness-approvers" group 
+# of http://git.k8s.io/enhancements/OWNERS_ALIASES
+kep-number: 4004
+alpha:
+  approver: "@wojtek-t"

--- a/keps/sig-network/4004-deprecate-kube-proxy-version/kep.yaml
+++ b/keps/sig-network/4004-deprecate-kube-proxy-version/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-network
 participating-sigs:
   - sig-node
-status: provisional
+status: implementable
 creation-date: 2023-05-15
 reviewers:
   - "@danwinship"


### PR DESCRIPTION
- One-line PR description: KEP-4004 (deprecating `node.status.kubeProxyVersion`) got merged as "provisional" rather than "implementable". This just fixes that. (Meaning it needs PRR approval now.)

<!-- link to the k/enhancements issue -->
- Issue link: #4004
- KEP text link: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/4004-deprecate-kube-proxy-version

<!-- other comments or additional information -->
- Other comments:

/assign @wojtek-t 