### PR TITLE
remove unused OWNER_ALIAS for provider-gcp

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -210,8 +210,6 @@ aliases:
     - craiglpeters
     - feiskyer
     - khenidak
-  provider-gcp:
-    - abgworrall
   provider-ibmcloud:
     - spzala
   provider-openstack:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

This owner alias is unsued and stale. GCP has enough representation as part of SIG Cloud Provider and there is no need for a provider-specific owner alias anymore.

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: