### PR TITLE
KEP-2570: Updating Memory QoS status to eventually deprecate the alpha feature 

### DIFF
--- a/keps/sig-node/2570-memory-qos/kep.yaml
+++ b/keps/sig-node/2570-memory-qos/kep.yaml
@@ -11,15 +11,14 @@ reviewers:
 approvers:
   - "@derekwaynecarr"
 owning-sig: sig-node
-status: implementable
+status: provisional
 editor: "@ndixita"
 creation-date: 2021-03-14
 last-updated: 2023-06-14
-stage: beta
-latest-milestone: "v1.28"
+stage: alpha
+latest-milestone: "v1.27"
 milestone:
   alpha: "v1.27"
-  beta: "v1.28"
 feature-gates:
   - name: MemoryQoS
     components:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Updating Memory QoS status to eventually deprecate the alpha feature  in K8s 1.30

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2570

