### PR TITLE
KEP 2593: withdrawn cluster-cidr kep

### DIFF
--- a/keps/sig-network/2593-multiple-cluster-cidrs/README.md
+++ b/keps/sig-network/2593-multiple-cluster-cidrs/README.md
@@ -100,6 +100,11 @@ release*.
 
 ## Summary
 
+
+IMPORTANT: THIS KEP HAS BEEN WITHDRAWN AND THIS FEATURE WILL BE DEVELOPED OUT OF TREE
+Ref: https://groups.google.com/g/kubernetes-sig-network/c/nts1xEZ--gQ/m/2aTOUNFFAAAJ
+
+
 Today, when Kubernetes' NodeIPAM controller allocates IP ranges for podCIDRs for
 nodes, it uses a single range allocated to the cluster (cluster CIDR). Each node
 gets a range of a fixed size from the overall cluster CIDR. The size is

--- a/keps/sig-network/2593-multiple-cluster-cidrs/kep.yaml
+++ b/keps/sig-network/2593-multiple-cluster-cidrs/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@rahulkjoshi"
   - "@sdmodi"
 owning-sig: sig-network
-status: implementable
+status: withdrawn
 creation-date: 2021-03-22
 reviewers:
   - "@mskrocki"
@@ -18,13 +18,10 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.25"
-  beta: "v1.27"
-  stable: "v1.29"
 
 feature-gates:
   - name: MultiCIDRRangeAllocator


### PR DESCRIPTION
- One-line PR description: https://groups.google.com/g/kubernetes-sig-network/c/nts1xEZ--gQ/m/2aTOUNFFAAAJ

- Issue link: https://github.com/kubernetes/enhancements/issues/2593
