### PR TITLE
KEP-3299: Update KMSv2 kep stage to stable

### DIFF
--- a/keps/sig-auth/3299-kms-v2-improvements/kep.yaml
+++ b/keps/sig-auth/3299-kms-v2-improvements/kep.yaml
@@ -14,7 +14,7 @@ approvers:
   - "@smarterclayton"
 replaces:
   - "/keps/sig-auth/3130-kms-observability"
-stage: beta
+stage: stable
 latest-milestone: "v1.29"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- Update [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3299-kms-v2-improvements) for GA
- Issue link: https://github.com/kubernetes/enhancements/issues/3299

/sig auth
/triage accepted
/assign enj