### PR TITLE
KEP-1287: Keep in-place pod resize KEP alpha/implementable for v1.29

### DIFF
--- a/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
+++ b/keps/sig-node/1287-in-place-update-pod-resources/kep.yaml
@@ -32,12 +32,12 @@ replaces:
 
 stage: "alpha"
 
-latest-milestone: "v1.28"
+latest-milestone: "v1.29"
 
 milestone:
   alpha: "v1.27"
-  beta: "v1.29"
-  stable: "v1.30"
+  beta: "v1.30"
+  stable: "v1.31"
 
 feature-gates:
   - name: InPlacePodVerticalScaling


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This PR keeps in-place pod resize KEP in implementable/alpha state for v1.29 as per request from release management.

Issue link: https://github.com/kubernetes/enhancements/issues/1287

- Other comments:
We build a list to work on here. https://github.com/kubernetes/enhancements/issues/1287#issuecomment-1738222727 and will update the KEP if needed.