### PR TITLE
Fix titles of 2 KEPs

### DIFF
--- a/keps/sig-api-machinery/1623-standardize-conditions/kep.yaml
+++ b/keps/sig-api-machinery/1623-standardize-conditions/kep.yaml
@@ -1,4 +1,4 @@
-title: KEP Template
+title: Standardize Conditions
 kep-number: 1623
 authors:
   - "@deads2k"

--- a/keps/sig-api-machinery/2887-openapi-enum-types/kep.yaml
+++ b/keps/sig-api-machinery/2887-openapi-enum-types/kep.yaml
@@ -1,4 +1,4 @@
-title: KEP Template
+title: OpenAPI Enum Types
 kep-number: 2887
 authors:
   - "@jiahuif"


### PR DESCRIPTION
Found this when using yq across multiple KEPs to gather some stats.

/sig api-machinery