### PR TITLE
KEP-2433: Bumping stable target to 1.30

### DIFF
--- a/keps/sig-network/2433-topology-aware-hints/kep.yaml
+++ b/keps/sig-network/2433-topology-aware-hints/kep.yaml
@@ -28,13 +28,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.29"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.21"
   beta: "v1.23"
-  stable: "v1.29"
+  stable: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: As @npolshakova pointed out, our metadata for this KEP is out of date, this fixes that.

- Issue link: #2433

- Other comments: We're not making any changes to the KEP in this cycle, just trying to get the implementation to catch up to the KEP.

/sig network
/assign @thockin 