### PR TITLE
Update HTTP/2 RFC - be specific about using http/2 prior

### DIFF
--- a/keps/sig-network/3726-standard-application-protocols/README.md
+++ b/keps/sig-network/3726-standard-application-protocols/README.md
@@ -177,7 +177,7 @@ type ServicePort struct {
   // RFC-6335 and https://www.iana.org/assignments/service-names).
   //
   // * Kubernetes-defined prefixed names:
-  //   * 'kubernetes.io/h2c' - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
+  //   * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
   //   * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
   //   * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
   //


### PR DESCRIPTION
- One-line PR description: Update Standard Protocol KEP with latest HTTP/2 RFC - 

<!-- link to the k/enhancements issue -->
- Issue link: N/A

<!-- other comments or additional information -->
- Other comments: Since H2C upgrade flow is [deprecated](https://datatracker.ietf.org/doc/html/rfc9113#:~:text=The%20%22h2c%22%20string,%C2%B6) be more specific that we want to support HTTP/2 prior knowledge