### PR TITLE
keps/../kubeadm: 4214: revisit test plan and risks/mitigations

### DIFF
--- a/keps/sig-cluster-lifecycle/kubeadm/4214-separate-super-user-kubeconfig/kep.yaml
+++ b/keps/sig-cluster-lifecycle/kubeadm/4214-separate-super-user-kubeconfig/kep.yaml
@@ -7,7 +7,7 @@ participating-sigs:
   - sig-cluster-lifecycle
 status: implementable
 creation-date: 2023-9-18
-last-updated: 2023-10-10
+last-updated: 2023-10-19
 reviewers:
   - "@SataQiu"
   - "@pacoxu"


### PR DESCRIPTION
Update notes about Risk and Mitigations:
- As a mistaken existing implementation detail "admin.conf" is not shared across control plane nodes, by using the "kubeadm-certs" Secret. Instead on "kubeadm join --control-plane" a new "admin.conf" is signed by using the shared in "kubeadm-certs" CA.
- Re-place upgrade clusters must apply the "kubeadm:cluster-admins" ClusterRoleBinding if they wish the "admin.conf" files on joining control plane nodes to have "cluster-admin" level access.

Update Test Plan:
- Don't add integration tests, instead add an e2e test using kinder that will do kubeadm init/join/upgrade and verify certificates stored in kubeconfig files nad RBAC.

- Issue link:
https://github.com/kubernetes/enhancements/issues/4214
