### PR TITLE
In-place-update-pod-resources should align with Pod Scheduling Readiness

### DIFF
--- a/keps/sig-node/1287-in-place-update-pod-resources/README.md
+++ b/keps/sig-node/1287-in-place-update-pod-resources/README.md
@@ -237,6 +237,8 @@ ResizeRestartPolicy - a list of named subobjects (new object) that supports
   (e.g.  Java process needs to change its Xmx flag) By using ResizePolicy, user
   can mark Containers as safe (or unsafe) for in-place resource update. Kubelet
   uses it to determine the required action.
+* GateRequired - place a verification field in a pod on resize, act like NotRequired
+  policy once the field is removed.
 
 Note: `NotRequired` restart policy for resize does not *guarantee* that a container
 won't be restarted. The runtime may choose to stop the container if it is unable to
@@ -858,6 +860,7 @@ TODO: Identify more cases
 - VPA alpha integration of feature completed and any bugs addressed,
 - E2E tests covering Resize Policy, LimitRanger, and ResourceQuota are added,
 - Negative tests are identified and added.
+- Add scaling readiness Gate for dynamic users needs.
 - A "/resize" subresource is defined and implemented.
 - Pod-scoped resources are handled if that KEP is past alpha
 - ContainerStatus API change tests are enforced and containerd runtime must comply.


### PR DESCRIPTION
to implement their custom resource quotas.
In-place-update-pod-resources should align with Pod
 Scheduling Readiness enabling users to define and
 apply their specific resourceQuota implementations.

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
The Pod Scheduling Readiness feature empowers users to implement their custom resource quotas.
In-place-update-pod-resources should align with Pod  Scheduling Readiness enabling users to define
and apply their specific resourceQuota implementations.
<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments:
For more details regading scheduling readiness:
https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/