### PR TITLE
KEP-2307: add known failure modes

### DIFF
--- a/keps/sig-apps/2307-job-tracking-without-lingering-pods/README.md
+++ b/keps/sig-apps/2307-job-tracking-without-lingering-pods/README.md
@@ -672,7 +672,7 @@ Yes, see [Deprecation](#deprecation) for the full plan.
       Pods.
       There were some bugs that would cause this (examples:
       [#109485](https://github.com/kubernetes/kubernetes/issues/109485),
-      [119833](https://github.com/kubernetes/kubernetes/issues/119833),
+      [#119833](https://github.com/kubernetes/kubernetes/issues/119833),
       [#111646](https://github.com/kubernetes/kubernetes/pull/111646)).
       In newer versions, this can still happen if there is a buggy webhook
       that prevents pod updates to remove finalizers.

--- a/keps/sig-apps/2307-job-tracking-without-lingering-pods/README.md
+++ b/keps/sig-apps/2307-job-tracking-without-lingering-pods/README.md
@@ -666,12 +666,13 @@ Yes, see [Deprecation](#deprecation) for the full plan.
       - Before 1.26: Observe the behavior in pods.
       - After 1.26: Based on metric `job_terminated_pod_tracking_finalizer`
     - Mitigations:
-      Before 1.26, disable `JobTrackingWithFinalizers`.
+      - Update to latest patch version of supported Kubernetes versions.
     - Diagnostics:
       The job controller reports errors updating the Job status and/or patching
       Pods.
       There were some bugs that would cause this (examples:
       [#109485](https://github.com/kubernetes/kubernetes/issues/109485),
+      [119833](https://github.com/kubernetes/kubernetes/issues/119833),
       [#111646](https://github.com/kubernetes/kubernetes/pull/111646)).
       In newer versions, this can still happen if there is a buggy webhook
       that prevents pod updates to remove finalizers.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: add a known failure mode and mention that this feature is GA so disabling is not really an option.

<!-- link to the k/enhancements issue -->
- Issue link: #2307 

<!-- other comments or additional information -->
- Other comments: