### PR TITLE
fix: InPlacePodVerticalScaling typo

### DIFF
--- a/keps/sig-node/1287-in-place-update-pod-resources/README.md
+++ b/keps/sig-node/1287-in-place-update-pod-resources/README.md
@@ -888,7 +888,7 @@ A previous version of kubelet interprets mutation to Pod Resources as a Containe
 change and will restart the container with the new Resources. This could lead to Node resource
 over-subscription. In order to address this, the feature-gate will remain default false for
 atleast two versions after v1.27 alpha release. i.e: beta is planned for v1.29 and
-InPlacePodVeritcalScaling feature-gate will be true in versions v1.29+
+InPlacePodVerticalScaling feature-gate will be true in versions v1.29+
 
 kubelet: When feature-gate is disabled, if kubelet sees a Proposed resize, it rejects the
 resize as Infeasible.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: fix a typo in documentation on `InPlacePodVerticalScaling`

<!-- link to the k/enhancements issue -->
- Issue link: N/A

<!-- other comments or additional information -->
- Other comments: this a really, really small patch