### PR TITLE
fix: typo in Story 5 Stabilization before scaling down

### DIFF
--- a/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
+++ b/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
@@ -207,7 +207,7 @@ behavior:
     policies:
     - type: Pods
       value: 5
-      periodSeconds: 600
+      periodSeconds: 60
 ```
 
 i.e., the algorithm will:


### PR DESCRIPTION
fix: typo in Story 5 Stabilization before scaling down

- One-line PR description: In the description of Story 5, it is mentioned that the scale down takes one minute instead of 600 seconds. I fixed this typo in the HPA declaration.

- Issue link: n/a

- Other comments: n/a