### PR TITLE
Improve validation for KEP metadata

### DIFF
--- a/keps/sig-auth/2907-secrets-store-csi-driver/kep.yaml
+++ b/keps/sig-auth/2907-secrets-store-csi-driver/kep.yaml
@@ -15,3 +15,9 @@ approvers:
   - "@mikedanese"
 status: implemented
 stage: stable
+
+latest-milestone: "v1.19"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  stable: "v1.22"

--- a/keps/sig-etcd/4326-downgrade/kep.yaml
+++ b/keps/sig-etcd/4326-downgrade/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 4326
 authors:
   - "@serathius"
 owning-sig: sig-etcd
-status: implementable
+status: provisional
 creation-date: yyyy-mm-dd
 reviewers:
 approvers:

--- a/keps/sig-etcd/4331-livez-readyz/kep.yaml
+++ b/keps/sig-etcd/4331-livez-readyz/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@siyuanfoundation"
   - "@chaochn47"
 owning-sig: sig-etcd
-status: implementable
+status: provisional
 creation-date: yyyy-mm-dd
 reviewers:
 approvers:

--- a/keps/sig-network/2829-gateway-api-to-k8s-io/kep.yaml
+++ b/keps/sig-network/2829-gateway-api-to-k8s-io/kep.yaml
@@ -17,3 +17,6 @@ approvers:
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
+
+# This is out-of-tree and we provide milestone just to pass validation.
+latest-milestone: "v1.22"

--- a/pkg/repo/validate.go
+++ b/pkg/repo/validate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package repo
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -63,11 +64,20 @@ func (r *Repo) Validate() (
 
 			metadataFilename := ProposalMetadataFilename
 			metadataFilepath := filepath.Join(dir, metadataFilename)
+
 			if _, err := os.Stat(metadataFilepath); err == nil {
 				// There is KEP metadata file in this directory, only that one should be processed.
 				if info.Name() == metadataFilename {
 					files = append(files, metadataFilepath)
 					return filepath.SkipDir
+				}
+			}
+
+			if info.Name() == ProposalFilename && dir != kepDir {
+				// There is a proposal, we require metadata file for it.
+				if _, err := os.Stat(metadataFilepath); os.IsNotExist(err) {
+					kepErr := fmt.Errorf("metadata file missing for KEP: %s", metadataFilepath)
+					valErrMap[metadataFilepath] = append(valErrMap[metadataFilepath], kepErr)
 				}
 			}
 


### PR DESCRIPTION
Improve validation of KEP metadata by ensuring that:
- implementable/implemented tests are providing stage and milestone
- KEPs has an associated metadata file
- fix few KEPs not passing improved validation

/assign @johnbelamaric @dims 