### PR TITLE
Fix feature gate name of TranslateStreamCloseWebsocketRequests for 4006-transition-spdy-to-websockets.

### DIFF
--- a/keps/sig-api-machinery/4006-transition-spdy-to-websockets/kep.yaml
+++ b/keps/sig-api-machinery/4006-transition-spdy-to-websockets/kep.yaml
@@ -35,7 +35,7 @@ feature-gates:
   - name: KUBECTL_REMOTE_COMMAND_WEBSOCKETS
     components:
       - kubectl
-  - name: ClientRemoteCommandWebsockets
+  - name: TranslateStreamCloseWebsocketRequests
     components:
       - kube-apiserver
 disable-supported: true


### PR DESCRIPTION
Related: 
- https://github.com/kubernetes/kubernetes/pull/119186

Please free  feel to close this PR if it is unnecessary.

/assign @seans3