### PR TITLE
Changing ReferenceGrant KEP to broader Referential Authorization KEP

### DIFF
--- a/keps/sig-auth/3766-referential-authorization/README.md
+++ b/keps/sig-auth/3766-referential-authorization/README.md
@@ -40,6 +40,7 @@
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Intentional Omissions](#intentional-omissions)
+  - [Object.Metadata sub-resource](#we-need-an-object.metadata-sub-resource)
   - [Wildcard Selectors?](#wildcard-selectors)
     - [Rationale](#rationale)
     - [Context](#context)
@@ -907,6 +908,26 @@ provide tooling to simplify this process.
 This KEP is already large in scope, so it is intentionally leaving some features
 out of scope. These are discussed below. In some cases these may be added in the
 future if needed.
+
+### We need an Object.Metadata sub-resource
+Controllers often have create/update/patch on the resources they control.
+This is too much access.
+Most controllers only need access to update resource status, ownerRefs, and
+finalizers.
+A controller being able to update the .spec field of a resource is usually
+unnessecary and creates a situation in which the controller can control its own
+inputs.
+In the case of a compromised controller user, an attacker could potentially
+create or update new resources that subsequently provide referential access to
+additional resources.
+The attacker must know or guess the names and namespaces of potential resources,
+but this is still a privilege escalation path.
+
+We already have status sub-resources for status updates.
+However, ownerRefs and finalizaers are stored in the metadata.
+We should have a metadata sub-resource, so that more granular controller access
+can be specified.
+This should be handled in a separate KEP.
 
 ### Wildcard Selectors?
 

--- a/keps/sig-auth/3766-referential-authorization/README.md
+++ b/keps/sig-auth/3766-referential-authorization/README.md
@@ -3,6 +3,9 @@
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
 - [Summary](#summary)
+- [Diagrams](#diagrams)
+  - [Proposed API Summary](#proposed-api-summary)
+  - [With RBAC for Illustration](#with-rbac-for-illustration)
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
@@ -97,6 +100,76 @@ to enable cross-namespace data sources.
 This KEP proposes building that overall idea of referential authorization
 directly into Kubernetes. This will build on the original idea of ReferenceGrant
 but add additional capabilities along the way.
+
+## Diagrams
+
+### Proposed API Summary
+This roughly illustrates how the proposed APIs are connected:
+
+```mermaid
+classDiagram
+    ClusterReferenceConsumer <.. ClusterReferenceGrant : When From + To + For match
+    ClusterReferenceConsumer <.. ReferenceGrant : When From + To + For match
+
+    class ClusterReferenceConsumer{
+        Subject Subject
+        From GroupResource
+        To GroupResource
+        For string
+    }
+    class ClusterReferenceGrant{
+        From GroupVersionResourcePath
+        To GroupResource
+        For string
+    }
+    class ReferenceGrant{
+        From GroupResource
+        To GroupResourceAndNames
+        For string
+    }
+```
+
+### With RBAC for Illustration
+Although we will not be generating RBAC as part of this work, it may help to
+illustrate how we could generate RBAC to show how these resources translate to
+authorization.
+
+```mermaid
+classDiagram
+    ClusterReferenceConsumer <.. ClusterReferenceGrant : When From + To + For match
+    ClusterReferenceConsumer <.. ReferenceGrant : When From + To + For match
+    ClusterReferenceGrant ..> Role : Names from Local References Matching Pattern
+    ReferenceGrant ..> Role : Names from List in "To"
+    ClusterReferenceConsumer <.. RoleBinding : Connects Roles Match From + To + For to Subject
+    RoleBinding <.. Role : Connects All Consumers Matching From + To + For
+
+    class ClusterReferenceConsumer{
+        Subject Subject
+        From GroupResource
+        To GroupResource
+        For string
+    }
+    class ClusterReferenceGrant{
+        From GroupVersionResourcePath
+        To GroupResource
+        For string
+    }
+    class ReferenceGrant{
+        From GroupResource
+        To GroupResourceAndNames
+        For string
+    }
+    class RoleBinding{
+        Subjects []Subject
+        RoleRefs []RoleRef
+    }
+    class Role{
+        APIGroups []string
+        Resources []string
+        ResourceNames []string
+        Verbs []string
+    }
+```
 
 ## Motivation
 

--- a/keps/sig-auth/3766-referential-authorization/kep.yaml
+++ b/keps/sig-auth/3766-referential-authorization/kep.yaml
@@ -1,4 +1,4 @@
-title: Move ReferenceGrant to sig-auth API Group
+title: Referential Authorization
 kep-number: 3766
 authors:
   - "@robscott"
@@ -21,9 +21,9 @@ approvers:
 
 stage: alpha
 
-latest-milestone: "v1.27"
+latest-milestone: "v1.30"
 
 milestone:
-  alpha: "v1.27"
+  alpha: "v1.30"
 
 disable-supported: true

--- a/keps/sig-auth/3766-referential-authorization/kep.yaml
+++ b/keps/sig-auth/3766-referential-authorization/kep.yaml
@@ -2,6 +2,7 @@ title: Referential Authorization
 kep-number: 3766
 authors:
   - "@robscott"
+  - "@stealthybox"
   - "@youngnick"
 owning-sig: sig-auth
 participating-sigs:


### PR DESCRIPTION
- One-line PR description: This significantly refactors the ReferenceGrant into a broader Referential Authorization KEP in response to conversations with SIG Auth leadership.

- Issue link: #3766 

- Other comments: This is a follow up from a rough [proposal doc](https://docs.google.com/document/d/1poQb0uxOkJsebNgTMrpaogcY9vcehGHe1myqvenCXtU/edit) and [corresponding POC](https://github.com/robscott/referencegrant-poc) to ensure it all works

/cc @deads2k @enj @liggitt @msau42 @thockin @ttakahashi21 @youngnick @stealthybox @sftim 