### PR TITLE
KEP-3895: Promote interactive delete to stable

### DIFF
--- a/keps/prod-readiness/sig-cli/3895.yaml
+++ b/keps/prod-readiness/sig-cli/3895.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
@@ -142,8 +142,8 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [ ] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-- [ ] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
+- [x] (R) Production readiness review completed
+- [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
@@ -867,6 +867,7 @@ N/A
 ## Implementation History
 The KEP was proposed on 2023-03-01
 The KEP was promoted to beta on 2023-10-02
+The KEP was promoted to stable on 2024-01-09
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.
 Major milestones might include:

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/README.md
@@ -136,12 +136,12 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
 - [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
-- [ ] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [x] (R) Graduation criteria is in place
+  - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [x] (R) Production readiness review completed
 - [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/kep.yaml
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/kep.yaml
@@ -19,18 +19,18 @@ see-also:
   - "https://github.com/kubernetes/enhancements/pull/2777"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.29"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.28"
   beta: "v1.29"
-  stable: "TBD"
+  stable: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/keps/sig-cli/3895-kubectl-delete-interactivity/kep.yaml
+++ b/keps/sig-cli/3895-kubectl-delete-interactivity/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 3895
 authors:
   - "@ardaguclu"
 owning-sig: sig-cli
-status: implementable
+status: implemented
 creation-date: 2023-03-01
 reviewers:
   - "@eddiezane"


### PR DESCRIPTION
- One-line PR description: Promote interactive flag in kubectl delete command to stable

- Issue link: https://github.com/kubernetes/enhancements/issues/3895

- Other comments: