### PR TITLE
Promote kubectl debug to GA

### DIFF
--- a/keps/prod-readiness/sig-cli/1441.yaml
+++ b/keps/prod-readiness/sig-cli/1441.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-cli/1441-kubectl-debug/README.md
+++ b/keps/sig-cli/1441-kubectl-debug/README.md
@@ -651,8 +651,8 @@ integration test for [Pod Troubleshooting with Ephemeral Debug Container
 
 #### Beta -> GA Graduation
 
-- [ ] Test plan GA milestones reached
-- [ ] User feedback gathered over 2 release cycles.
+- [x] Test plan GA milestones reached
+- [x] User feedback gathered over 2 release cycles.
 - [ ] 3 external articles suggest using `kubectl debug`
 
 ### Upgrade / Downgrade Strategy
@@ -848,6 +848,7 @@ resource usage (CPU, RAM, disk, IO, ...) in any components?**
 - *2020-09-20*: Updated KEP to reflect actual implementation details.
 - *2020-09-23*: Update KEP for mutating multiple container images in debug-by-copy.
 - *2020-09-24*: Update KEP for Production Readiness and beta graduation.
+- *2024-01-16*: Promote kubectl debug to GA
 
 ## Alternatives
 

--- a/keps/sig-cli/1441-kubectl-debug/README.md
+++ b/keps/sig-cli/1441-kubectl-debug/README.md
@@ -653,7 +653,10 @@ integration test for [Pod Troubleshooting with Ephemeral Debug Container
 
 - [x] Test plan GA milestones reached
 - [x] User feedback gathered over 2 release cycles.
-- [ ] 3 external articles suggest using `kubectl debug`
+- [x] 3 external articles suggest using `kubectl debug`
+  - https://collabnix.com/debug-your-kubernetes-applications-made-easy-with-kubectl-debug-tool/
+  - https://www.linkedin.com/pulse/debug-kubernetes-applications-kubectl-cuong-nguyen-duc
+  - https://medium.com/datamindedbe/debugging-running-pods-on-kubernetes-2ba160c47ef5
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-cli/1441-kubectl-debug/README.md
+++ b/keps/sig-cli/1441-kubectl-debug/README.md
@@ -682,157 +682,413 @@ exists, kubectl prints `ephemeral containers are disabled for this cluster`.
 
 ## Production Readiness Review Questionnaire
 
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
 ### Feature Enablement and Rollback
 
-* **How can this feature be enabled / disabled in a live cluster?**
-  - [ ] Feature gate (also fill in values in `kep.yaml`)
-    - Feature gate name:
-    - Components depending on the feature gate:
-  - [x] Other
-    - Describe the mechanism: **A new command in `kubectl alpha`**
-    - Will enabling / disabling the feature require downtime of the control
-      plane? **no**
-    - Will enabling / disabling the feature require downtime or reprovisioning
-      of a node? **no**
+<!--
+This section must be completed when targeting alpha to a release.
+-->
 
-* **Does enabling the feature change any default behavior?**
+###### How can this feature be enabled / disabled in a live cluster?
 
-  It's a new command so there's no default behavior in kubectl. If a user
-  has installed a plugin named "debug", that plugin will be masked by the
-  new `kubectl debug` command. This is a known issue with kubectl plugins,
-  and it's being addressed separately by sig-cli, likely by detecting this
-  condition and printing a warning.
+<!--
+Pick one of these and delete the rest.
 
-* **Can the feature be disabled once it has been enabled (i.e. can we roll back
-  the enablement)?**
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
 
-  Yes, you could roll back to a previous release of `kubectl` and any pods
-  created by `kubectl debug` would still be accessible via other `kubectl`
-  commands.
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
 
-* **What happens if we reenable the feature if it was previously rolled back?**
+- [ ] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name:
+  - Components depending on the feature gate:
+- [x] Other
+  - Describe the mechanism: A new command in `kubectl alpha`
+  - Will enabling / disabling the feature require downtime of the control
+    plane? no
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node? no
 
-  You can create pods again
+###### Does enabling the feature change any default behavior?
 
-* **Are there any tests for feature enablement/disablement?**
-  
-  No, because it cannot be disabled or enabled in a single release
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+
+It's a new command so there's no default behavior in kubectl. If a user
+has installed a plugin named "debug", that plugin will be masked by the
+new `kubectl debug` command. This is a known issue with kubectl plugins,
+and it's being addressed separately by sig-cli, likely by detecting this
+condition and printing a warning.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+
+Yes, you could roll back to a previous release of `kubectl` and any pods
+created by `kubectl debug` would still be accessible via other `kubectl`
+commands.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+You can create pods again
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+
+No, because it cannot be disabled or enabled in a single release
 
 ### Rollout, Upgrade and Rollback Planning
 
-* **How can a rollout fail? Can it impact already running workloads?**
+<!--
+This section must be completed when targeting beta to a release.
+-->
 
-  The feature is encapsulated entirely within the kubectl binary, so rollout is
-  an atomic client binary update. Pods created by the new command may be
-  manipulated by any version of `kubectl`, so there are no version dependencies.
+###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-* **What specific metrics should inform a rollback?**
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
 
-  There's no need for a rollback unless `kubectl` is not working at all.
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
 
-* **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
+The feature is encapsulated entirely within the kubectl binary, so rollout is
+an atomic client binary update. Pods created by the new command may be
+manipulated by any version of `kubectl`, so there are no version dependencies.
 
-  No, there's no need.
+###### What specific metrics should inform a rollback?
 
-* **Is the rollout accompanied by any deprecations and/or removals of features, APIs, 
-fields of API types, flags, etc.?**
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
 
-  The command will move from `kubectl alpha debug` to `kubectl debug`. If the
-  user has a kubectl plugin named "debug", it will be masked.
+There's no need for a rollback unless `kubectl` is not working at all.
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+No, there's no need.
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+The command will move from `kubectl alpha debug` to `kubectl debug`. If the
+user has a kubectl plugin named "debug", it will be masked.
 
 ### Monitoring Requirements
 
-* **How can an operator determine if the feature is in use by workloads?**
+<!--
+This section must be completed when targeting beta to a release.
 
-  Since it uses the standard core API, there's no way to determine whether a
-  pod or ephemeral container was created by `kubectl debug` or manually by a
-  user.
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
 
-* **What are the SLIs (Service Level Indicators) an operator can use to determine 
-the health of the service?**
-  - [ ] Metrics
-    - Metric name:
-    - [Optional] Aggregation method:
-    - Components exposing the metric:
-  - [x] Other (treat as last resort)
-    - Details: There's no running service.
+###### How can an operator determine if the feature is in use by workloads?
 
-* **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
 
-  There's no running service.
+Since it uses the standard core API, there's no way to determine whether a
+pod or ephemeral container was created by `kubectl debug` or manually by a
+user.
 
-* **Are there any missing metrics that would be useful to have to improve observability 
-of this feature?**
+###### How can someone using this feature know that it is working for their instance?
 
-  It would be easy to add a "created by kubectl debug" annotation to a newly
-  created pod, but we don't want to preemptively add features that are only
-  theoretically useful.
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [ ] Events
+  - Event Reason:
+- [ ] API .status
+  - Condition name:
+  - Other field:
+- [x] Other (treat as last resort)
+  - Details: There's no running service.
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+There's no running service.
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+- [ ] Metrics
+  - Metric name:
+  - [Optional] Aggregation method:
+  - Components exposing the metric:
+- [x] Other (treat as last resort)
+  - Details: There's no running service.
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+It would be easy to add a "created by kubectl debug" annotation to a newly
+created pod, but we don't want to preemptively add features that are only
+theoretically useful.
 
 ### Dependencies
 
-* **Does this feature depend on any specific services running in the cluster?**
+<!--
+This section must be completed when targeting beta to a release.
+-->
 
-  No.
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+No.
 
 ### Scalability
 
-* **Will enabling / using this feature result in any new API calls?**
-  Describe them, providing:
-  - API call type (e.g. PATCH pods):
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
 
-    GET/CREATE/PATCH pods, GET nodes
+For beta, this section is required: reviewers must answer these questions.
 
-  - estimated throughput:
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
 
-    Negligible, because it's human initiated. There will be 1 read + 1 mutate
-    per `kubectl debug` command. At that point there's a new pod for the system
-    to manage.
+###### Will enabling / using this feature result in any new API calls?
 
-  - originating component(s):
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
 
-    kubectl
+###### Will enabling / using this feature result in introducing new API types?
 
-* **Will enabling / using this feature result in introducing new API types?**
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
 
-  No.
+- API call type (e.g. PATCH pods):
+  GET/CREATE/PATCH pods, GET nodes
 
-* **Will enabling / using this feature result in any new calls to the cloud 
-provider?**
+- estimated throughput:
+  Negligible, because it's human initiated. There will be 1 read + 1 mutate
+  per `kubectl debug` command. At that point there's a new pod for the system
+  to manage.
 
-  No.
+- originating component(s):
+  kubectl
 
-* **Will enabling / using this feature result in increasing size or count of 
-the existing API objects?**
+###### Will enabling / using this feature result in any new calls to the cloud provider?
 
-  One new Pod or EphemeralContainer when initiated by a user.
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
 
-* **Will enabling / using this feature result in increasing time taken by any 
-operations covered by [existing SLIs/SLOs]?**
+No.
 
-  No.
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
 
-* **Will enabling / using this feature result in non-negligible increase of 
-resource usage (CPU, RAM, disk, IO, ...) in any components?**
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
 
-  Creating a pod will use more resources, but only when initiated by a user.
+One new Pod or EphemeralContainer when initiated by a user.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+
+No.
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+
+Creating a pod will use more resources, but only when initiated by a user.
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+No.
 
 ### Troubleshooting
 
-* **How does this feature react if the API server and/or etcd is unavailable?**
+<!--
+This section must be completed when targeting beta to a release.
 
-  `kubectl` is not resilient to API server unavailability.
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
 
-* **What are other known failure modes?**
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
 
-  This command creates objects using the core API. Writing a Playbook of how to
-  respond when the system is not creating core Kinds is outside the scope of
-  this KEP.
+###### How does this feature react if the API server and/or etcd is unavailable?
 
-* **What steps should be taken if SLOs are not being met to determine the problem?**
+`kubectl` is not resilient to API server unavailability.
 
-  Definitely stop running `kubectl debug`.
+###### What are other known failure modes?
 
-[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+This command creates objects using the core API. Writing a Playbook of how to
+respond when the system is not creating core Kinds is outside the scope of
+this KEP.
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+Definitely stop running `kubectl debug`.
 
 ## Implementation History
 

--- a/keps/sig-cli/1441-kubectl-debug/kep.yaml
+++ b/keps/sig-cli/1441-kubectl-debug/kep.yaml
@@ -19,18 +19,18 @@ see-also:
   - "/keps/sig-release/20190316-rebase-images-to-distroless.md"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.18"
   beta: "v1.20"
-  stable: "v1.26"
+  stable: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This PR promotes `kubectl debug` to stable. In reality, this promotion seems like a more paperwork because  `kubectl debug` has been used for nearly more than 3 years and this is a sufficient time to collect feedback, incorporate changes and add unit, integration tests(https://github.com/kubernetes/kubernetes/blob/master/test/cmd/debug.sh)

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1441

<!-- other comments or additional information -->
- Other comments: