### PR TITLE
KEP 3836 - v1.30 updates - update beta/stable milestones 

### DIFF
--- a/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability/kep.yaml
+++ b/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability/kep.yaml
@@ -8,11 +8,11 @@ approvers: ['@thockin']
 creation-date: "2023-02-03"
 status: implementable
 stage: beta
-latest-milestone: "v1.29"
+latest-milestone: "v1.30"
 milestone:
     alpha: "v1.28"
-    beta: "v1.29"
-    stable: "v1.30"
+    beta: "v1.30"
+    stable: "v1.31"
 feature-gates:
   - name: KubeProxyDrainingTerminatingNodes
     components:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: update beta and stable milestones

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3836

<!-- other comments or additional information -->
- Other comments: the KEP was transitioned to beta in 1.29,[ but annoyingly I forgot to update the feature gate in Kube](https://github.com/kubernetes/kubernetes/blob/v1.29.0/pkg/features/kube_features.go#L1109), so it actually never transitioned to beta in 1.29. I am therefore updating all milestones in this KEP update.  


/sig network
/cc @thockin @aojea 