### PR TITLE
KEP-3633: graduate matchLabelKeys/mismatchLabelKeys to beta

### DIFF
--- a/keps/prod-readiness/sig-scheduling/3633.yaml
+++ b/keps/prod-readiness/sig-scheduling/3633.yaml
@@ -1,3 +1,5 @@
 kep-number: 3633
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity/README.md
+++ b/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity/README.md
@@ -734,7 +734,8 @@ You can take a look at one potential example of such test in:
 https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
 -->
 
-No. But, the tests to confirm the behavior on switching the feature gate will be added.
+No. But, the tests to confirm the behavior on switching the feature gate will be added,
+https://github.com/kubernetes/kubernetes/issues/123156.
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -770,8 +771,12 @@ that might indicate a serious problem?
 
 - A spike on metric `schedule_attempts_total{result="error|unschedulable"}` when pods using this feature are added.
 
-No need to check latency of the scheduler because the scheduler doesn't get changed at all for this feature.
-The only possibility is the bug in the Pod creation process in kube-apiserver and it results in some unintended scheduling.
+The only possibility of the bug is in the Pod creation process in kube-apiserver and it results in some unintended scheduling.
+
+Also, the scheduler's latency may also get increased 
+because of the additional calculation for the label selector made from `matchLabelKeys`/`mismatchLabelKeys`.
+But, it should be tiny increase because the scheduler doesn't get changed at all for this feature,
+and using `matchLabelKeys`/`mismatchLabelKeys` just equals to adding some Pods with additional label selectors to the cluster.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 

--- a/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity/README.md
+++ b/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity/README.md
@@ -492,14 +492,10 @@ https://storage.googleapis.com/k8s-triage/index.html
   - `matchLabelKeys`/`mismatchLabelKeys` with the feature gate enabled/disabled.
 
 **Filter**
-- `k8s.io/kubernetes/test/integration/scheduler/filters/filters_test.go`: https://storage.googleapis.com/k8s-triage/index.html?test=TestPodTopologySpreadFilter
+- [`k8s.io/kubernetes/test/integration/scheduler/filters/filters_test.go`](https://github.com/kubernetes/kubernetes/blob/3a4c35cc89c0ce132f8f5962ce4b9a48fae77873/test/integration/scheduler/filters/filters_test.go#L807-L1069): https://storage.googleapis.com/k8s-triage/index.html?test=TestPodTopologySpreadFilter
 
 **Score**
-- `k8s.io/kubernetes/test/integration/scheduler/scoring/priorities_test.go`: https://storage.googleapis.com/k8s-triage/index.html?test=TestPodTopologySpreadScoring
-
-Also, we should make sure this feature brings no significant performance degradation in both Filter and Score.
-
-- `k8s.io/kubernetes/test/integration/scheduler_perf/scheduler_perf_test.go`: https://storage.googleapis.com/k8s-triage/index.html?test=BenchmarkPerfScheduling
+- [`k8s.io/kubernetes/test/integration/scheduler/scoring/priorities_test.go`](https://github.com/kubernetes/kubernetes/blob/master/test/integration/scheduler/scoring/priorities_test.go#L383-L643): https://storage.googleapis.com/k8s-triage/index.html?test=TestPodTopologySpreadScoring
 
 ##### e2e tests
 
@@ -761,8 +757,9 @@ will rollout across nodes.
 It shouldn't impact already running workloads. It's an opt-in feature,
 and users need to set `matchLabelKeys` or `mismatchLabelKeys` field in PodAffinity or PodAntiAffinity to use this feature. 
 
-When this feature is disabled by the feature flag, the already created Pod's `matchLabelKeys`/`mismatchLabelKeys` (+ `labelSelector` generated from them) is kept.
-But, the newly created Pod's `matchLabelKeys` or `mismatchLabelKeys` field is silently dropped.
+When this feature is disabled by the feature flag, 
+the already created Pod's `matchLabelKeys`/`mismatchLabelKeys` is kept and the `labelSelector` is not modified back.
+But, the newly created Pod's `matchLabelKeys` or `mismatchLabelKeys` field is ignored and silently dropped.
 
 ###### What specific metrics should inform a rollback?
 
@@ -989,7 +986,7 @@ Think about adding additional work or introducing new steps in between
 
 Yes. there is an additional work: kube-apiserver uses the keys in `matchLabelKeys` or `mismatchLabelKeys` to look up label values from the pod, 
 and change `labelSelector` according to them.
-Maybe result in a very small impact in the latency of pod creation request in kube-apiserver. 
+The impact in the latency of pod creation request in kube-apiserver should be negligible. 
 
 ###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
 

--- a/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity/kep.yaml
+++ b/keps/sig-scheduling/3633-matchlabelkeys-to-podaffinity/kep.yaml
@@ -13,9 +13,9 @@ approvers:
 see-also:
   - "/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades"
 
-stage: alpha
+stage: beta
 
-latest-milestone: "v1.29"
+latest-milestone: "v1.30"
 
 milestone:
   alpha: "v1.29"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: fill the sections need to graduate matchLabelKeys/mismatchLabelKeys to beta.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3633

<!-- other comments or additional information -->
- Other comments: