### PR TITLE
postponed kep-3673 parallel image pull limit to v1.30 for beta

### DIFF
--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/README.md
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/README.md
@@ -924,7 +924,7 @@ Alpha feature was implemented in 1.27: <https://github.com/kubernetes/kubernetes
 
 ### Beta
 
-Add e2e tests(WIP):
+Add e2e tests <https://github.com/kubernetes/kubernetes/pull/121604>(WIP):
 
 1. A new node_e2e test to confirm image pull will be blocked if maxParallelImagePulls is reached.
 2. Verfiy behavior of image pull in parallel for same image using `imagePullPolicy:Always`.

--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
@@ -6,7 +6,7 @@ authors:
 owning-sig: sig-node
 status: implementable
 creation-date: 2023-01-05
-last-updated: 2023-09-08
+last-updated: 2024-01-29
 reviewers:
   - "@SergeyKanzhelev"
 approvers:
@@ -18,10 +18,10 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.29"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
-  beta: "v1.29"
-  stable: "v1.30"
+  beta: "v1.30"
+  stable: "v1.32"


### PR DESCRIPTION
- One-line PR description: promoting to beta is pending to v1.30 due to PR is still in review https://github.com/kubernetes/kubernetes/pull/121604(waiting for reviewing and approval)

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3673

<!-- other comments or additional information -->
- Other comments: just update the kep version to meet the plan/progress.