### PR TITLE
KEP 3521/3838: graduate PodSchedulingReadiness to stable

### DIFF
--- a/keps/prod-readiness/sig-scheduling/3521.yaml
+++ b/keps/prod-readiness/sig-scheduling/3521.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-scheduling/3838.yaml
+++ b/keps/prod-readiness/sig-scheduling/3838.yaml
@@ -1,3 +1,5 @@
 kep-number: 3838
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/3521-pod-scheduling-readiness/README.md
+++ b/keps/sig-scheduling/3521-pod-scheduling-readiness/README.md
@@ -131,14 +131,14 @@ checklist items _must_ be updated for the enhancement to be released.
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
 - [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
-  - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+  - [x] e2e Tests for all Beta API Operations (endpoints)
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [x] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
@@ -512,12 +512,12 @@ integration and its implementation.
 In particular, update existing UTs or add new UTs
 in the following packages:
 
-- `pkg/api/pod`: `10/3/2022` - `70.1%`
-- `pkg/apis/core/validation`: `10/3/2022` - `82.3%`
-- `pkg/registry/core/pod`: `10/3/2022` - `60.4%`
-- `cmd/kube-scheduler/app`: `10/3/2022` - `32.9`
-- `pkg/scheduler`: `10/3/2022` - `75.9%`
-- `pkg/scheduler/framework/runtime`: `10/3/2022` - `81.9%`
+- `pkg/api/pod`: `1/29/2024` - `74.8%`
+- `pkg/apis/core/validation`: `1/29/2022` - `83.9%`
+- `pkg/registry/core/pod`: `1/29/2022` - `61.7%`
+- `cmd/kube-scheduler/app`: `1/29/2022` - `32%`
+- `pkg/scheduler`: `1/29/2022` - `78%`
+- `pkg/scheduler/framework/runtime`: `1/29/2022` - `80.3%`
 
 ##### Integration tests
 
@@ -1086,6 +1086,19 @@ This through this both in small and large cases, again with respect to the
 
 No.
 
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+No.
+
 ### Troubleshooting
 
 <!--
@@ -1143,7 +1156,8 @@ Major milestones might include:
 -->
 
 - 2022-09-16: Initial KEP
-- 2022-01-14: Graduate the feature to Beta
+- 2023-01-14: Graduate the feature to Beta
+- 2024-01-29: Graduate the feature to Stable
 
 ## Drawbacks
 

--- a/keps/sig-scheduling/3521-pod-scheduling-readiness/kep.yaml
+++ b/keps/sig-scheduling/3521-pod-scheduling-readiness/kep.yaml
@@ -18,18 +18,18 @@ see-also:
   - "/keps/sig-scheduling/624-scheduling-framework"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.26"
   beta: "v1.27"
-  stable: "v1.29"
+  stable: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -38,7 +38,7 @@ feature-gates:
     components:
       - kube-apiserver
       - kube-scheduler
-disable-supported: true
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:

--- a/keps/sig-scheduling/3838-pod-mutable-scheduling-directives/README.md
+++ b/keps/sig-scheduling/3838-pod-mutable-scheduling-directives/README.md
@@ -133,16 +133,16 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
-  - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+  - [x] e2e Tests for all Beta API Operations (endpoints)
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [x] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [x] (R) Production readiness review completed
 - [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [x] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
 **Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
@@ -395,7 +395,7 @@ This can inform certain test coverage improvements that we want to do before
 extending the production code to implement this enhancement.
 -->
 
-- `k8s.io/kubernetes/pkg/apis/core/validation`: `02/03/2023` - `83%`
+- `k8s.io/kubernetes/pkg/apis/core/validation`: `01/31/2024` - `83.9%`
 
 ##### Integration tests
 
@@ -930,6 +930,7 @@ N/A.
 ## Implementation History
 
 - 2023-02-03: Proposed KEP starting in beta status.
+- 2024-01-31: Graduate the feature to Stable
 
 <!--
 Major milestones in the lifecycle of a KEP should be tracked in this section.

--- a/keps/sig-scheduling/3838-pod-mutable-scheduling-directives/kep.yaml
+++ b/keps/sig-scheduling/3838-pod-mutable-scheduling-directives/kep.yaml
@@ -16,24 +16,24 @@ see-also:
   - "/keps/sig-scheduling/3521-pod-scheduling-readiness"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   beta: "1.27"
-  stable: "v1.28"
+  stable: "v1.30"
 
 feature-gates:
   - name: PodSchedulingReadiness
     components:
       - kube-apiserver
       - kube-scheduler
-disable-supported: true
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: graduate PodSchedulingReadiness to stable

<!-- link to the k/enhancements issue -->
- Issue link: #3521 #3838

<!-- other comments or additional information -->
- Other comments: This PR graduates two KEPs (3521 and 3838) to stable as they're both controlled by the same feature gate `PodSchedulingReadiness`