### PR TITLE
added sig-node-tech-leads alias back to OWNER_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -79,6 +79,10 @@ aliases:
     - dchen1107
     - derekwaynecarr
     - mrunalp
+  sig-node-tech-leads:
+    - dchen1107
+    - derekwaynecarr
+    - mrunalp
   sig-release-leads:
     - Verolop
     - cpanato


### PR DESCRIPTION
/sig node

reverting https://github.com/kubernetes/enhancements/pull/4344#issuecomment-1917607836 for sig node.

SIG Node uses this alias for enhancements.