### PR TITLE
Change proposed milestone for recover from resize failure KEP

### DIFF
--- a/keps/sig-storage/1790-recover-resize-failure/kep.yaml
+++ b/keps/sig-storage/1790-recover-resize-failure/kep.yaml
@@ -21,12 +21,11 @@ see-also:
 replaces:
 superseded-by:
 
-latest-milestone: "v1.28"
+latest-milestone: "v1.30"
 stage: "alpha"
 
 milestone:
   alpha: "v1.23"
-
 
 feature-gates:
   - name: RecoverVolumeExpansionFailure


### PR DESCRIPTION
Change latest milestone for recover from volume expansion feature.

https://github.com/kubernetes/enhancements/issues/1790

Since this feature is staying in alpha, I am not updating the existing PRR, since it hasn't changed yet.