### PR TITLE
Promote Portworx CSI migration to Beta in 1.31

### DIFF
--- a/keps/sig-storage/2589-csi-migration-portworx/README.md
+++ b/keps/sig-storage/2589-csi-migration-portworx/README.md
@@ -58,6 +58,8 @@ Major milestones for Portworx in-tree plugin CSI migration:
   - Portworx CSI migration to Alpha
 - 1.25
   - Portworx CSI migration to Beta, off by default
+- 1.31
+  - Portworx CSI migration to Beta, on by default
 
 ## Design details
 

--- a/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
+++ b/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
@@ -2,6 +2,7 @@ title: In-tree Storage Plugin to CSI Migration - Portworx
 kep-number: 2589
 authors:
   - "@trierra"
+  - "@lpabon"
 owning-sig: sig-storage
 participating-sigs:
   - sig-cluster-lifecycle
@@ -12,7 +13,7 @@ approvers:
   - "@msau42"
 editor: "@Jiawei0227"
 creation-date: 2021-09-08
-last-updated: 2021-09-08
+last-updated: 2024-01-31
 disable-supported: true
 status: implementable
 see-also:
@@ -25,7 +26,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.25"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
This commit adds the details to the KEP for promoting Portworx CSI migration to Beta on-by-default on v1.31

One-line PR description: Update KEP for Portworx CSI Migration

Issue link: Portworx file in-tree to CSI driver migration #https://github.com/kubernetes/enhancements/issues/2589

Other comments:

/sig storage

One-line PR description:
Issue link:
Other comments:
