### PR TITLE
KEP-961: Bump Statefulset maxUnavailable to beta (built on top of #3997)

### DIFF
--- a/keps/prod-readiness/sig-apps/961.yaml
+++ b/keps/prod-readiness/sig-apps/961.yaml
@@ -1,3 +1,5 @@
 kep-number: 961
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/3335-statefulset-slice/README.md
+++ b/keps/sig-apps/3335-statefulset-slice/README.md
@@ -139,10 +139,10 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Design details are appropriately documented
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [X] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
 - [X] "Implementation History" section is up-to-date for milestone
@@ -390,7 +390,7 @@ In the main control loop, StatefulSet will attempt to create pod replicas `[k, N
 *   When scaling down pods: If ordinal `j` exists but is not in range `[k, N+k-1]`), pod `j` will be terminated.
 **RollingUpdate Partition Changes**
 
-Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid. 
+Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid.
 
 ### Test Plan
 

--- a/keps/sig-apps/3335-statefulset-slice/README.md
+++ b/keps/sig-apps/3335-statefulset-slice/README.md
@@ -139,10 +139,10 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Design details are appropriately documented
 - [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) Ensure GA e2e tests for meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [X] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
 - [X] "Implementation History" section is up-to-date for milestone
@@ -390,7 +390,7 @@ In the main control loop, StatefulSet will attempt to create pod replicas `[k, N
 *   When scaling down pods: If ordinal `j` exists but is not in range `[k, N+k-1]`), pod `j` will be terminated.
 **RollingUpdate Partition Changes**
 
-Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid.
+Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid. 
 
 ### Test Plan
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -598,7 +598,6 @@ on feature enable and disabled
 A rollout or rollback of this feature can fail if there is a bug which causes the kube-apiserver or
 the kube-controller-manager to start crashing when the feature flag is enabled.
 
-
 Yes, it can impact already running workloads.
 
 If a rolling update is in progress for a StatefulSet, while this feature is being enabled in kube-apiserver
@@ -610,7 +609,8 @@ maxUnavailable pods with the same identity and never more than maxUnavailable be
 ###### What specific metrics should inform a rollback?
 
 When feature enabled but rolling update in a unexpected phenomenon like the update pods at a time is not equal to the
-`maxUnavailable` value or rolling update in a unexpected order.
+`maxUnavailable` value (we may have some other factors impacting this, but this should apply for most of the time) or
+rolling update in a unexpected order.
 
 Or we can refer to the `rolling-update-duration` metric for observation, if it didn't decrease when setting the `maxUnavailable`
 great than 1 or the duration increased abnormally, then we should rollback.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -320,15 +320,15 @@ partition. Which means all Pods with an ordinal that is greater than or equal to
 updated when the StatefulSet’s .spec.template is updated. Lets say total replicas is 5 and partition is set to 2 and maxUnavailable is set to 2. If the image is changed in this scenario, following
   are the possible behavior choices we have:-
 
-  1. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). Once they are both running and ready, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
+  1. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). Once they are both running and available, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
 will remain untouched due the partition. In this choice, the number of pods terminating is not always
-maxUnavailable, but sometimes less than that. For e.g. if pod with ordinal 3 is running and ready but 4 is not, we still wait for 4 to be running and ready before moving on to 2. This implementation avoids
+maxUnavailable, but sometimes less than that. For e.g. if pod with ordinal 3 is running and available but 4 is not, we still wait for 4 to be running and available before moving on to 2. This implementation avoids
 out of order Terminations of pods.
-  2. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When any of 4 or 3 are running and ready, pods with ordinal 2 will start Terminating. This could violate
-ordering guarantees, since if 3 is running and ready, then both 4 and 2 are terminating at the same
-time out of order. If 4 is running and ready, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation, guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
-  3. Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and ready, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
-running and ready before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
+  2. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When any of 4 or 3 are running and available, pods with ordinal 2 will start Terminating. This could violate
+ordering guarantees, since if 3 is running and available, then both 4 and 2 are terminating at the same
+time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation, guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
+  3. Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
+running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
 only 1 is unavailable although we requested 2.
   4. Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further
 PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesnt apply to Rolling Updates. So instead of coming up
@@ -387,7 +387,7 @@ https://github.com/kubernetes/kubernetes/blob/eb8f3f194fed16484162aebdaab69168e0
     }
 
     // Collect all targets in the range between getStartOrdinal(set) and getEndOrdinal(set). Count any targets in that range
-    // that are unhealthy i.e. terminated or not running and ready as unavailable). Select the
+    // that are unhealthy i.e. terminated or not running and available as unavailable). Select the
     // (MaxUnavailable - Unavailable) Pods, in order with respect to their ordinal for termination. Delete
     // those pods and count the successful deletions. Update the status with the correct number of deletions.
     unavailablePods := 0

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -2,30 +2,43 @@ title: Implement maxUnavailable for StatefulSets
 kep-number: 961
 authors:
   - "@krmayankk"
+  - "@kerthcet"
 owning-sig: sig-apps
-participating-sigs:
-  - sig-apps
+participating-sigs: []
+status: implementable
+creation-date: 2018-12-29
 reviewers:
   - "@janetkuo"
   - "@kow3ns"
 approvers:
   - "@janetkuo"
   - "@kow3ns"
-editor: TBD
-creation-date: 2018-12-29
-last-updated: 2022-01-01
-status: implementable
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
+
+see-also: []
+replaces: []
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.25"
-  stable: "v1.26"
-latest-milestone: "v1.24"
-stage: "alpha"
+  beta: "v1.28"
+  stable: TBD
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: MaxUnavailableStatefulSet
+    components:
+      - kube-controller-manager
+      - kube-apiserver
+
+# The following PRR answers are required at beta release
+metrics:
+  - rolling-update-duration

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 961
 authors:
   - "@krmayankk"
   - "@kerthcet"
+  - "@knelasevero"
 owning-sig: sig-apps
 participating-sigs: []
 status: implementable
@@ -25,12 +26,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.28"
+  beta: "v1.30"
   stable: TBD
 
 # The following PRR answers are required at alpha release
@@ -44,4 +45,4 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - rolling-update-duration-seconds
+  - kube_statefulset_spec_strategy_rollingupdate_max_unavailable

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -40,7 +40,8 @@ feature-gates:
     components:
       - kube-controller-manager
       - kube-apiserver
+disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - rolling-update-duration
+  - rolling-update-duration-seconds

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -10,9 +10,11 @@ creation-date: 2018-12-29
 reviewers:
   - "@janetkuo"
   - "@kow3ns"
+  - "@soltysh"
 approvers:
   - "@janetkuo"
   - "@kow3ns"
+  - "@soltysh"
 
 see-also: []
 replaces: []


### PR DESCRIPTION
Supersedes #3997
One-line PR description: Bump statefulset maxUnavailable to beta
Issue link: https://github.com/kubernetes/enhancements/issues/961
Other comments:
Previous commits: kept Kante's commits here
My commits: Went over review notes not addressed and changed a few things related to proposed metric and some descriptions.

