### PR TITLE
KEP-4443: Add more granular Job failure reason for PodFailurePolicy

### DIFF
--- a/keps/prod-readiness/sig-apps/4443.yaml
+++ b/keps/prod-readiness/sig-apps/4443.yaml
@@ -1,3 +1,3 @@
 kep-number: 4443
 alpha:
-  approver: "@wojtek-t"
+  approver: "@jpbetz"

--- a/keps/prod-readiness/sig-apps/4443.yaml
+++ b/keps/prod-readiness/sig-apps/4443.yaml
@@ -1,0 +1,3 @@
+kep-number: 4443
+beta:
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-apps/4443.yaml
+++ b/keps/prod-readiness/sig-apps/4443.yaml
@@ -1,3 +1,3 @@
 kep-number: 4443
-beta:
+alpha:
   approver: "@wojtek-t"

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -621,6 +621,7 @@ well as the [existing list] of feature gates.
   - Feature gate name: `PodFailurePolicyName`
   - Components depending on the feature gate:
     - kube-controller-manager
+    - kube-apiserver
 - [ ] Other
   - Describe the mechanism:
   - Will enabling / disabling the feature require downtime of the control
@@ -673,6 +674,8 @@ https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05
 We can add unit tests for:
 - feature enabled and field set
 - feature disabled and field set
+- feature disabled after Jobs have `JobFailed` condition with reason set using the
+new format
 
 ### Rollout, Upgrade and Rollback Planning
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -357,8 +357,7 @@ If unset, it will default to `PodFailurePolicy`, which is the current [reason](h
 controller uses when a PodFailurePolicy triggers a Job failure.
 
 #### Validation
-- We will validate the user-defined Reason is a valid reason ([non-empty, CamelCase string](https://github.com/kubernetes/kubernetes/blob/dd301d0f23a63acc2501a13049c74b38d7ebc04d/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1555)).
-We will also validate the user-defined Reason is less than 
+- We will validate the user-defined Reason is a valid reason ([non-empty, CamelCase string](https://github.com/kubernetes/kubernetes/blob/dd301d0f23a63acc2501a13049c74b38d7ebc04d/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1555)). We will also validate the user-defined Reason is less than 128 characters.
 - We will also validate the user-defined Reason does not conflict with any [K8s internal reasons used by the Job controller](https://sourcegraph.com/github.com/kubernetes/kubernetes@862ff187baad9373d59d19e5d736dcda1e25e90d/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L543-553). 
 
 #### Business logic

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -99,6 +99,8 @@ tags, and then generate with `hack/update-toc.sh`.
       - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
@@ -329,12 +331,9 @@ spec:
 
 ### Notes/Constraints/Caveats (Optional)
 
-<!--
-What are the caveats to the proposal?
-What are some important details that didn't come across above?
-Go in to as much detail as necessary here.
-This might be a good place to talk about core concepts and how they relate.
--->
+It should be noted that upon pod failure, the Job's pod failure policy rules
+are evaluated in order, and only the first matching rule is executed, even
+if multiple rules match a pod failure.
 
 ### Risks and Mitigations
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -408,6 +408,9 @@ extending the production code to implement this enhancement.
 -->
 
 - `k8s.io/kubernetes/pkg/controller/job`: `02/05/2024` - `91.5%`
+- `k8s.io/kubernetes/pkg/apis/batch/v1`: `06/05/2024` - `87.3%`
+- `k8s.io/kubernetes/pkg/apis/batch/v1beta1`: `06/05/2024` - `78.3%`
+- `k8s.io/kubernetes/pkg/apis/batch/validation`: `06/05/2024` - `87.7%`
 
 ##### Integration tests
 
@@ -570,8 +573,17 @@ enhancement:
   CRI or CNI may require updating that component before the kubelet.
 -->
 
-N/A. This feature doesn't require coordination between control plane components,
-the changes to the Job controller are self-contained. 
+This feature is limited to control plane, so the version skew with kubelet does
+not matter.
+
+In case kube-apiserver is running in HA mode, and the versions are skewed, then
+the old version of kube-apiserver (from before this change) may not handle
+the the new `Name` field if it is set in a Job PodFailurePolicy spec.
+
+In case the version of the kube-controller-manager leader is skewed (old), the
+built-in Job controller would reconcile the Jobs with the new `Name` field and
+simply drop the field, thereby not using it when setting the `JobFailed` condition
+reason.
 
 ## Production Readiness Review Questionnaire
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -341,7 +341,7 @@ if multiple rules match a pod failure.
 What are the risks of this proposal, and how do we mitigate? Think broadly.
 For example, consider both security and how this will impact the larger
 Kubernetes ecosystem.
-
+Validate all pod failure policy rule names are unique
 How will security be reviewed, and by whom?
 
 How will UX be reviewed, and by whom?
@@ -362,6 +362,8 @@ When `Name` is unset, the Job controller will set the reason suffix to the index
 
 #### Validation
 - Validate all pod failure policy rule names are unique.
+- Validate pod failure policy rule names do not have integer values of any of the existing indexes
+(unless the value is the rule's own index).
 - We will validate the Job failure condition reason that would be generated from a given
 PodFailurePolicy rule name (i.e., `PodFailurePolicy_{ruleName}`) will be a valid reason (CamelCase, max length of 128 characters, and matches the regex defined [here](https://github.com/kubernetes/kubernetes/blob/dd301d0f23a63acc2501a13049c74b38d7ebc04d/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1559)).
 - We will also validate the pod failure policy rule does not conflict with any [K8s internal reasons used by the Job controller](https://github.com/kubernetes/kubernetes/blob/862ff187baad9373d59d19e5d736dcda1e25e90d/staging/src/k8s.io/api/batch/v1/types.go#L542-L553). 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -1,0 +1,927 @@
+<!--
+**Note:** When your KEP is complete, all of these comment blocks should be removed.
+
+To get started with this template:
+
+- [ ] **Pick a hosting SIG.**
+  Make sure that the problem space is something the SIG is interested in taking
+  up. KEPs should not be checked in without a sponsoring SIG.
+- [ ] **Create an issue in kubernetes/enhancements**
+  When filing an enhancement tracking issue, please make sure to complete all
+  fields in that template. One of the fields asks for a link to the KEP. You
+  can leave that blank until this KEP is filed, and then go back to the
+  enhancement and add the link.
+- [ ] **Make a copy of this template directory.**
+  Copy this template into the owning SIG's directory and name it
+  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
+  leading-zero padding) assigned to your enhancement above.
+- [ ] **Fill out as much of the kep.yaml file as you can.**
+  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
+  "Status", and date-related fields.
+- [ ] **Fill out this file as best you can.**
+  At minimum, you should fill in the "Summary" and "Motivation" sections.
+  These should be easy if you've preflighted the idea of the KEP with the
+  appropriate SIG(s).
+- [ ] **Create a PR for this KEP.**
+  Assign it to people in the SIG who are sponsoring this process.
+- [ ] **Merge early and iterate.**
+  Avoid getting hung up on specific details and instead aim to get the goals of
+  the KEP clarified and merged quickly. The best way to do this is to just
+  start with the high-level sections and fill out details incrementally in
+  subsequent PRs.
+
+Just because a KEP is merged does not mean it is complete or approved. Any KEP
+marked as `provisional` is a working document and subject to change. You can
+denote sections that are under active debate as follows:
+
+```
+<<[UNRESOLVED optional short context or usernames ]>>
+Stuff that is being argued.
+<<[/UNRESOLVED]>>
+```
+
+When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
+focused. If you disagree with what is already in a document, open a new PR
+with suggested changes.
+
+One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
+You do not need a new KEP to move from beta to GA, for example. If
+new details emerge that belong in the KEP, edit the KEP. Once a feature has become
+"implemented", major changes should get new KEPs.
+
+The canonical place for the latest set of instructions (and the likely source
+of this file) is [here](/keps/NNNN-kep-template/README.md).
+
+**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
+it is marked `implementable`, must be approved by each of the KEP approvers.
+If none of those approvers are still appropriate, then changes to that list
+should be approved by the remaining approvers and/or the owning SIG (or
+SIG Architecture for cross-cutting KEPs).
+-->
+# KEP-4443: Configurable PodFailurePolicy Reason
+
+<!--
+This is the title of your KEP. Keep it short, simple, and descriptive. A good
+title can help communicate what the KEP is and should be considered as part of
+any review.
+-->
+
+<!--
+A table of contents is helpful for quickly jumping to sections of a KEP and for
+highlighting any additional information provided beyond the standard KEP
+template.
+
+Ensure the TOC is wrapped with
+  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
+tags, and then generate with `hack/update-toc.sh`.
+-->
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge code into a release, there must be an
+issue in [kubernetes/enhancements] referencing this KEP and targeting a release
+milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
+of the targeted release**.
+
+For enhancements that make changes to code or processes/procedures in core
+Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
+Signoff checklist to be completed.
+
+Check these off as they are completed for the Release Team to track. These
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+This KEP proposes to extend the Job API by adding an optional `Reason` field to `PodFailurePolicyRule`, which if specified, would be included as the reason in the `JobFailed` condition upon Job failure triggered by a `PodFailurePolicy`.
+
+## Motivation
+
+Higher level APIs, such as [JobSet](https://sigs.k8s.io/jobset), use the Job API as a building block for orchestrating large, distributed workloads.
+These higher level APIs need to be able to distinguish between different types of Job failures in order to make informed decisions about how to react
+to them. Currently, no mechanism exists in the Job API to propagate granular failure reason information (e.g., container exit codes) up to be 
+programmatically consumed by higher level software managing Jobs. A `PodFailurePolicy` can be configured to add a `Reason` of `PodFailurePolicy` to
+the `JobFailed` condition added to the Job when it fails, but different pod failure policies targeting different container exit codes all use the
+same `Reason` of `PodFailurePolicy`. This prevents higher level APIs like JobSet from distinguishing them and being able to take different actions
+depending on the type of Job failure that occurred.
+
+For a concrete use case, see the JobSet [Configurable Failury Policy KEP](https://github.com/kubernetes-sigs/jobset/pull/381) which illuminated the need for more granular pod failure policy reasons.
+
+### Goals
+
+For pod failure policies to be able communicate different failure types to higher level APIs.
+
+### Non-Goals
+
+<!--
+What is out of scope for this KEP? Listing non-goals helps to focus discussion
+and make progress.
+-->
+
+## Proposal
+
+The proposal is to add an optional `Reason` field to the `PodFailurePolicyRule`. 
+If unset, it will default to `PodFailurePolicy`, which is the current [reason](https://sourcegraph.com/github.com/kubernetes/kubernetes@6a4e93e776a35d14a61244185c848c3b5832621c/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L542) the Job
+controller uses when a PodFailurePolicy triggers a Job failure.
+
+When a `PodFailurePolicyRule` matches a pod failure and the `Action` is `FailJob`, the Job
+controller will add the reason defined in the `Reason` field to the JobFailed [condition](https://sourcegraph.com/github.com/kubernetes/kubernetes@6a4e93e776a35d14a61244185c848c3b5832621c/-/blob/pkg/controller/job/job_controller.go?L816) added
+to the Job.
+
+### User Stories (Optional)
+
+<!--
+Detail the things that people will be able to do if this KEP is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+-->
+
+#### Story 1
+
+As a user, I am using a JobSet to manage a group of jobs, each running a HPC simulation.
+Each job runs a simulation with different random initial parameters. When a simulation ends, the
+application will exit with one of two exit codes:
+
+- Exit code 2, which indicates the simulation produced an invalid result due to bad starting parameters, and should
+not be retried.
+- Exit code 3, which indicates the simulation produced an invalid result but the initial parameters were reasonable,
+so the simulation should be restarted.
+
+When a Job fails due to a pod failing with exit code 2, I want my job management software to leave the Job in
+a failed state.
+
+When a Job fails due to a pod failing with exit code 3, I want my job management software to to restart the Job.
+
+**Example JobSet with a Pod Failure Policy configuration for this use case**:
+```yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: restart-job-example
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: {{topologyDomain}} # 1:1 job replica to topology domain assignment
+spec:
+  failurePolicy:
+    rules:
+    # If Job fails due to a pod failing with exit code 2, leave it in a failed state.
+    - action: FailJob
+      targetReplicatedJobs:
+      - simulations
+      onJobFailureReasons:
+      - ExitCode2
+    # If Job fails due to a pod failing with exit code 3, restart that Job.
+    - action: RestartJob
+      targetReplicatedJobs:
+      - simulations
+      onJobFailureReasons:
+      - ExitCode3
+    maxRestarts: 10
+  replicatedJobs:
+  - name: simulations
+    replicas: 10
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 0
+        # If a pod fails with exit code 2 or 3, fail the Job, using the user-defined reason.
+        podFailurePolicy:
+          rules:
+          - action: FailJob
+            onExitCodes:
+              containerName: main
+              operator: In
+              values: [2]
+            reason: "ExitCode2"
+          - action: FailJob
+            onExitCodes:
+              containerName: main
+              operator: In
+              values: [3]
+            reason: "ExitCode3"
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: main
+              image: python:3.10
+              command: ["..."]
+```
+
+**Alternative example: single Job with a Pod Failure Policy configuration for this use case**:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: simulation
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  # If a pod fails with exit code 2 or 3, fail the Job, using the user-defined reason.
+  podFailurePolicy:
+    rules:
+    - action: FailJob
+      onExitCodes:
+        containerName: main
+        operator: In
+        values: [2]
+      reason: "ExitCode2"
+    - action: FailJob
+      onExitCodes:
+        containerName: main
+        operator: In
+        values: [3]
+      reason: "ExitCode3"
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: main
+        image: python:3.10
+        command: ["..."]
+```
+
+### Notes/Constraints/Caveats (Optional)
+
+<!--
+What are the caveats to the proposal?
+What are some important details that didn't come across above?
+Go in to as much detail as necessary here.
+This might be a good place to talk about core concepts and how they relate.
+-->
+
+### Risks and Mitigations
+
+<!--
+What are the risks of this proposal, and how do we mitigate? Think broadly.
+For example, consider both security and how this will impact the larger
+Kubernetes ecosystem.
+
+How will security be reviewed, and by whom?
+
+How will UX be reviewed, and by whom?
+
+Consider including folks who also work outside the SIG or subproject.
+-->
+
+I don't see any notable risks for this feature.
+
+
+## Design Details
+
+If unset, it will default to `PodFailurePolicy`, which is the current [reason](https://sourcegraph.com/github.com/kubernetes/kubernetes@6a4e93e776a35d14a61244185c848c3b5832621c/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L542) the Job
+controller uses when a PodFailurePolicy triggers a Job failure.
+
+When a `PodFailurePolicyRule` matches a pod failure and the `Action` is `FailJob`, the Job
+controller will add the reason defined in the `Reason` field to the JobFailed [condition](https://sourcegraph.com/github.com/kubernetes/kubernetes@6a4e93e776a35d14a61244185c848c3b5832621c/-/blob/pkg/controller/job/job_controller.go?L816) added
+to the Job.
+
+### Test Plan
+
+This feature can be tested via unit tests. We don't need integration tests or e2e tests for this.
+
+[X] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+<!--
+Based on reviewers feedback describe what additional tests need to be added prior
+implementing this enhancement to ensure the enhancements have also solid foundations.
+-->
+
+##### Unit tests
+
+<!--
+In principle every added code should have complete unit test coverage, so providing
+the exact set of tests will not bring additional value.
+However, if complete unit test coverage is not possible, explain the reason of it
+together with explanation why this is acceptable.
+-->
+
+<!--
+Additionally, for Alpha try to enumerate the core package you will be touching
+to implement this enhancement and provide the current unit coverage for those
+in the form of:
+- <package>: <date> - <current test coverage>
+The data can be easily read from:
+https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
+
+This can inform certain test coverage improvements that we want to do before
+extending the production code to implement this enhancement.
+-->
+
+- `k8s.io/kubernetes/pkg/controller/job`: `02/05/2024` - `<test coverage>`
+
+##### Integration tests
+
+<!--
+Integration tests are contained in k8s.io/kubernetes/test/integration.
+Integration tests allow control of the configuration parameters used to start the binaries under test.
+This is different from e2e tests which do not allow configuration of parameters.
+Doing this allows testing non-default options and multiple different and potentially conflicting command line options.
+-->
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+-->
+
+<!-- - <test>: <link to test coverage> -->
+- When feature flag is enabled and a Job's PodFailurePolicy triggers a Job failure, due to a
+matching PodFailurePolicyRule with the `Reason` field defined, check that the `JobFailed`
+condition has the user-specified `Reason` set on it correctly.
+
+##### e2e tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
+https://storage.googleapis.com/k8s-triage/index.html
+
+We expect no non-infra related flakes in the last month as a GA graduation criteria.
+-->
+
+<!-- - <test>: <link to test coverage> -->
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+
+#### Alpha
+
+- Feature implemented behind a feature flag
+- Initial e2e tests completed and enabled
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Complete features A, B, C
+- Additional tests are in Testgrid and linked in KEP
+
+#### GA
+
+- N examples of real-world usage
+- N installs
+- More rigorous forms of testing—e.g., downgrade tests and scalability tests
+- Allowing time for feedback
+
+**Note:** Generally we also wait at least two releases between beta and
+GA/stable, because there's no opportunity for user feedback, or even bug reports,
+in back-to-back releases.
+
+**For non-optional features moving to GA, the graduation criteria must include
+[conformance tests].**
+
+[conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
+
+#### Deprecation
+
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+#### Alpha
+
+- Feature implemented behind a feature flag
+- Initial unit and integration tests are implemented
+
+### Upgrade / Downgrade Strategy
+
+<!--
+If applicable, how will the component be upgraded and downgraded? Make sure
+this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to maintain previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to make use of the enhancement?
+-->
+After a user upgrades their cluster to a k8s version which supports this feature, 
+the user can use this feature by simply specifying the new field in their podFailurePolicy
+config.
+
+When a user downgrades from a k8s version that supports this field to one that does
+not support this field:
+- for existing Jobs, this new field will be ignored by the Job controller,
+resulting in the `Reason` being set to the previous default of `PodFailurePolicy`
+for any Job failures triggered by a pod failure policy.
+- for new Jobs, the kube-apiserver would remove this field when the Job is submitted.
+
+### Version Skew Strategy
+
+<!--
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- Does this enhancement involve coordinating behavior in the control plane and nodes?
+- How does an n-3 kubelet or kube-proxy without this feature available behave when this feature is used?
+- How does an n-1 kube-controller-manager or kube-scheduler without this feature available behave when this feature is used?
+- Will any other components on the node change? For example, changes to CSI,
+  CRI or CNI may require updating that component before the kubelet.
+-->
+
+N/A. This feature doesn't require coordination between control plane components,
+the changes to the Job controller are self-contained. 
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+<!--
+This section must be completed when targeting alpha to a release.
+-->
+- Upgrade to k8s version 1.30+
+- Enable feature flag `PodFailurePolicyReason`
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+<!--
+Pick one of these and delete the rest.
+
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
+
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
+
+- [X] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name: `PodFailurePolicyReason`
+  - Components depending on the feature gate:
+    - kube-controller-manager
+- [ ] Other
+  - Describe the mechanism:
+  - Will enabling / disabling the feature require downtime of the control
+    plane?
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node?
+
+###### Does enabling the feature change any default behavior?
+
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+No
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+Yes, by disabling the feature flag `PodFailurePolicyReason`.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+For new Jobs, the apiserver will stop wiping out the new field.
+For existing Jobs, the Job controller will stop ignoring the new field, and begin
+using it as described in previous sections.
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+We can add unit tests for:
+- feature enabled and field set
+- feature disabled and field set
+
+### Rollout, Upgrade and Rollback Planning
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
+
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
+
+###### What specific metrics should inform a rollback?
+
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+### Monitoring Requirements
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### How can an operator determine if the feature is in use by workloads?
+
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
+
+###### How can someone using this feature know that it is working for their instance?
+
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [ ] Events
+  - Event Reason: 
+- [ ] API .status
+  - Condition name: 
+  - Other field: 
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+- [ ] Metrics
+  - Metric name:
+  - [Optional] Aggregation method:
+  - Components exposing the metric:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+### Dependencies
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+### Scalability
+
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
+
+For beta, this section is required: reviewers must answer these questions.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### Will enabling / using this feature result in any new API calls?
+
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
+No
+
+###### Will enabling / using this feature result in introducing new API types?
+
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
+No, just a new string field on an existing API type.
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
+No
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
+If the optional `Reason` field is specified, the podFailurePolicy object size will increase by 1 byte per
+character in the `Reason` string.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+No
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+No
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+No
+
+### Troubleshooting
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+###### What are other known failure modes?
+
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of a KEP should be tracked in this section.
+Major milestones might include:
+- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
+- the `Proposal` section being merged, signaling agreement on a proposed design
+- the date implementation started
+- the first Kubernetes release where an initial version of the KEP was available
+- the version of Kubernetes where the KEP graduated to general availability
+- when the KEP was retired or superseded
+-->
+- KEP Published: 02/05/2024
+
+## Drawbacks
+
+None
+
+## Alternatives
+
+Rather than having the user specify a custom `Reason`, which will require validation and an additional step
+in the user-experience, instead the Job controller could automatically generate reasons, using a determnistic
+format which depends on if the podFailurePolicy was triggered by the `onPodConditions` or `onContainerExitCodes`.
+
+For example, in the case of container exit codes, we could append the container exit code to
+the default reason (e.g., `PodFailurePolicy-ExitCode3`). For `onPodConditions`, it could be the pod condition
+type and status joined together (e.g., `PodFailurePolicy-{type}-{status}`). However, this limits flexibility
+for the user, and locks us in to supporting this concrete, specific behavior, rather than the more generic
+behavior resulting from the optional `Reason` field set by the user.
+
+## Infrastructure Needed (Optional)
+
+<!--
+Use this section if you need things from the project/SIG. Examples include a
+new subproject, repos requested, or GitHub details. Listing these here allows a
+SIG to get the process for these resources started right away.
+-->

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -356,7 +356,9 @@ we are validating against malformed/invalid inputs.
 ## Design Details
 
 #### Defaulting
-If unset, the `Name` field will default to the index of the pod failure policy rule in the `Rules` slice.
+
+There will be no defaulting for the new pod failure policy `Name` field.
+When `Name` is unset, the Job controller will set the reason suffix to the index of the rule in the `podFailurePolicy.rules` slice (e.g. `PodFailurePolicy_{index}`).
 
 #### Validation
 - Validate all pod failure policy rule names are unique.
@@ -435,8 +437,7 @@ https://storage.googleapis.com/k8s-triage/index.html
 - Test that when the feature flag is off, but when it was previously enabled, there is an existing Job
 which already had the `JobFailed` condition reason set with the new suffix (i.e., `PodFailurePolicy_{Name}`), that the Job controller does not overwrite the reason to `PodFailurePolicy`, and that it remains set to the existing value.
 
-- Add test cases for both onPodConditions and onExitCodes to ensure the `Name` is properly added
-as a suffix to the JobFailed reason upon Job failure.
+- Add test cases for both onPodConditions and onExitCodes to ensure the `Name` or the rule's index (when `Name` is empty) is properly added.
 
 ##### e2e tests
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -162,9 +162,11 @@ This KEP proposes to extend the Job API by adding an optional `SetConditionReaso
 
 ## Motivation
 
-Higher level APIs, such as [JobSet](https://sigs.k8s.io/jobset), use the Job API as a building block for orchestrating large, distributed workloads.
-These higher level APIs need to be able to distinguish between different types of Job failures in order to make informed decisions about how to react
-to them. Currently, no mechanism exists in the Job API to propagate granular failure reason information (e.g., container exit codes) up to be 
+Higher level K8s APIs are built via a composition of features, using primitive K8S APIs as building blocks to implement more advanced features.
+These higher level APIs using the Job API as a building block need to be able to distinguish between different types of Job failures in order to
+make informed decisions about how to react to these failures.
+
+Currently, no mechanism exists in the Job API to propagate granular failure reason information (e.g., container exit codes) up to be 
 programmatically consumed by higher level software managing Jobs. A `PodFailurePolicy` can be configured to add a condition reason of `PodFailurePolicy`
 to the `JobFailed` condition added to the Job when it fails, but different pod failure policies targeting different container exit codes all use the
 same condition reason of `PodFailurePolicy`. This prevents higher level APIs like JobSet from distinguishing them and being able to take different
@@ -351,11 +353,12 @@ I don't see any notable risks for this feature.
 ## Design Details
 
 #### Defaulting
-If unset, it will default to `PodFailurePolicy`, which is the current [reason](https://sourcegraph.com/github.com/kubernetes/kubernetes@6a4e93e776a35d14a61244185c848c3b5832621c/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L542) the Job
+If unset, it will default to `PodFailurePolicy`, which is the current [reason](https://github.com/kubernetes/kubernetes/blob/dd301d0f23a63acc2501a13049c74b38d7ebc04d/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1555) the Job
 controller uses when a PodFailurePolicy triggers a Job failure.
 
 #### Validation
 - We will validate the user-defined Reason is a valid reason ([non-empty, CamelCase string](https://github.com/kubernetes/kubernetes/blob/dd301d0f23a63acc2501a13049c74b38d7ebc04d/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1555)).
+We will also validate the user-defined Reason is less than 
 - We will also validate the user-defined Reason does not conflict with any [K8s internal reasons used by the Job controller](https://sourcegraph.com/github.com/kubernetes/kubernetes@862ff187baad9373d59d19e5d736dcda1e25e90d/-/blob/staging/src/k8s.io/api/batch/v1/types.go?L543-553). 
 
 #### Business logic
@@ -824,7 +827,7 @@ Describe them, providing:
   - Supported number of objects per cluster
   - Supported number of objects per namespace (for namespace-scoped objects)
 -->
-No, just a new string field on an existing API type.
+No.
 
 ###### Will enabling / using this feature result in any new calls to the cloud provider?
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -132,18 +132,18 @@ checklist items _must_ be updated for the enhancement to be released.
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
 - [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+- [X] (R) Design details are appropriately documented
+- [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
   - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
-- [ ] (R) Graduation criteria is in place
+- [X] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
+- [X] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -421,9 +421,14 @@ https://storage.googleapis.com/k8s-triage/index.html
 -->
 
 <!-- - <test>: <link to test coverage> -->
-- When feature flag is enabled and a Job's PodFailurePolicy triggers a Job failure, due to a
+- Test that when the feature flag is enabled and a Job's PodFailurePolicy triggers a Job failure, due to a
 matching PodFailurePolicyRule with the `SetConditionReason` field defined, check that the `JobFailed`
 condition has the user-specified `SetConditionReason` set on it correctly.
+
+- Test that when the feature flag is off, but when it was previously enabled, there is an existing Job
+which already had the `JobFailed` condition reason set by the new `SetConditionReason` field, that the
+Job controller does not overwrite the reason to `PodFailurePolicy`, and that it remains set to the
+user-defined `SetConditionReason`.
 
 ##### e2e tests
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/README.md
@@ -178,10 +178,8 @@ For pod failure policies to be able communicate different failure types to highe
 
 ### Non-Goals
 
-<!--
-What is out of scope for this KEP? Listing non-goals helps to focus discussion
-and make progress.
--->
+- Modifying PodFailurePolicy behavior
+- The Job controller using this new field for any purpose not explicitly defined in the proposal.
 
 ## Proposal
 

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@danielvegamyhre"
 owning-sig: sig-apps
 status: provisional
-creation-date: 2024-01-26
+creation-date: 2024-02-05
 reviewers:
   - "@ahg-g"
   - "@kannon92"

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -1,4 +1,4 @@
-title: Configurable Job failure reason for PodFailurePolicyRule
+title: More granular Job failure reasons for PodFailurePolicy
 kep-number: 4443
 authors:
   - "@danielvegamyhre"
@@ -22,16 +22,16 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.30"
+  alpha: "v1.31"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: PodFailurePolicyReason
+  - name: PodFailurePolicyName
     components:
       - kube-apiserver
       - kube-controller-manager

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -13,8 +13,8 @@ approvers:
   - "@soltysh"
 
 see-also:
-  - "https://github.com/kubernetes-sigs/jobset/pull/381"
-  - "https://github.com/kubernetes/enhancements/pull/3374"
+  - "https://github.com/kubernetes-sigs/jobset/tree/main/keps/262-ConfigurableFailurePolicy"
+  - "https://github.com/kubernetes/enhancements/blob/master/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -1,4 +1,4 @@
-title: KEP Template
+title: Configurable Job failure reason for PodFailurePolicyRule
 kep-number: 4443
 authors:
   - "@danielvegamyhre"
@@ -10,7 +10,6 @@ reviewers:
   - "@kannon92"
 approvers:
   - "@alculquicondor"
-  - "@msau42"
 
 see-also:
   - "https://github.com/kubernetes-sigs/jobset/pull/381"

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -1,0 +1,41 @@
+title: KEP Template
+kep-number: 4443
+authors:
+  - "@danielvegamyhre"
+owning-sig: sig-apps
+status: provisional
+creation-date: 2024-01-26
+reviewers:
+  - "@ahg-g"
+  - "@kannon92"
+approvers:
+  - "@alculquicondor"
+  - "@msau42"
+
+see-also:
+  - "https://github.com/kubernetes-sigs/jobset/pull/381"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.30"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v1.30"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: PodFailurePolicyReason
+    components:
+      - kube-apiserver
+      - kube-controller-manager
+disable-supported: true
+
+# # The following PRR answers are required at beta release
+# metrics:
+#   - my_feature_metric

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 4443
 authors:
   - "@danielvegamyhre"
 owning-sig: sig-apps
-status: provisional
+status: implementable
 creation-date: 2024-02-05
 reviewers:
   - "@ahg-g"
@@ -14,6 +14,7 @@ approvers:
 
 see-also:
   - "https://github.com/kubernetes-sigs/jobset/pull/381"
+  - "https://github.com/kubernetes/enhancements/pull/3374"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
+++ b/keps/sig-apps/4443-configurable-pod-failure-policy-reasons/kep.yaml
@@ -8,8 +8,9 @@ creation-date: 2024-01-26
 reviewers:
   - "@ahg-g"
   - "@kannon92"
-approvers:
   - "@alculquicondor"
+approvers:
+  - "@soltysh"
 
 see-also:
   - "https://github.com/kubernetes-sigs/jobset/pull/381"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Configurable Job failure reason for PodFailurePolicy

<!-- link to the k/enhancements issue -->
- Issue link: #4443 

<!-- other comments or additional information -->
- Other comments: