### PR TITLE
KEP-2258: Promote NodeLogQuery to beta

### DIFF
--- a/keps/prod-readiness/sig-windows/2258.yaml
+++ b/keps/prod-readiness/sig-windows/2258.yaml
@@ -1,3 +1,5 @@
 kep-number: 2258
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-windows/2258-node-log-query/kep.yaml
+++ b/keps/sig-windows/2258-node-log-query/kep.yaml
@@ -18,16 +18,17 @@ approvers:
 creation-date: 2021-01-14
 last-updated: 2023-05-02
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
+  beta: "v1.30"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- Promote NodeLogQuery to beta:
  - highlight that a periodic job was added
  - link to the NodeLogQuery kubelet plugin

<!-- link to the k/enhancements issue -->
- Issue link:
  - https://github.com/kubernetes/enhancements/issues/2258
