### PR TITLE
Fix status of OpenAPI Enum Types KEP

### DIFF
--- a/keps/sig-api-machinery/2887-openapi-enum-types/kep.yaml
+++ b/keps/sig-api-machinery/2887-openapi-enum-types/kep.yaml
@@ -20,7 +20,7 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
@@ -30,6 +30,7 @@ latest-milestone: "v1.23"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.23"
+  beta: "v1.24"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
This KEP graduated to beta in 1.24 according  to https://github.com/kubernetes/enhancements/pull/3184.

This update kep.yaml to match.

/sig api-machinery
