### PR TITLE
Mark client-go context as stable to match GA criteria in KEP

### DIFF
--- a/keps/sig-api-machinery/1601-client-go-context/kep.yaml
+++ b/keps/sig-api-machinery/1601-client-go-context/kep.yaml
@@ -15,4 +15,4 @@ last-updated: 2020-01-23
 status: implementable
 
 latest-milestone: "1.18"
-stage: "beta"
+stage: "stable"


### PR DESCRIPTION
Given https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1601-client-go-context#graduation-criteria:

"This enhancement will be GA immediately."

Let's track in in kep.yaml as such.

/sig api-machinery