### PR TITLE
CDI for device plugins: update test grid and triage links

### DIFF
--- a/keps/sig-node/4009-add-cdi-devices-to-device-plugin-api/README.md
+++ b/keps/sig-node/4009-add-cdi-devices-to-device-plugin-api/README.md
@@ -157,10 +157,10 @@ This test case has been added to the existing `e2e_node` tests:
   - DevicePlugin can make a CDI device accessible in a container
 
 Links to test grid:
-- https://testgrid.k8s.io/sig-node-containerd#e2e-cos-device-plugin-gpu
+- https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cdi-device-plugins
 
 Links to k8s-triage for tests:
-- https://storage.googleapis.com/k8s-triage/index.html?test=DevicePlugin
+- https://storage.googleapis.com/k8s-triage/index.html?job=ci-crio-cdi-device-plugins
 
 ### Graduation Criteria
 


### PR DESCRIPTION
- One-line PR description: CDI for device plugins: update test grid and triage links

- Issue link: https://github.com/kubernetes/enhancements/issues/4009

- Other comments: [New test infra job](https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cdi-device-plugins) has been  created to test CDI support for device plugins to make sure other tests will not influence graduation of this feature to GA. This PR updates test grid and triage links to point to the new job.