### PR TITLE
Add `rexagod` to owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -58,8 +58,8 @@ aliases:
   sig-instrumentation-leads:
     - dashpole
     - dgrisonnet
-    - ehashman
     - logicalhan
+    - rexagod
   sig-k8s-infra-leads:
     - BenTheElder
     - ameukam


### PR DESCRIPTION
Adding myself to owners, to be able to update older instrumentation-based KEP descriptions. Also excluded Elana from the list since she has stepped down.