### PR TITLE
Change the rollout question's answer for kubectl debug GA

### DIFF
--- a/keps/sig-cli/1441-kubectl-debug/README.md
+++ b/keps/sig-cli/1441-kubectl-debug/README.md
@@ -833,8 +833,7 @@ No, there's no need.
 Even if applying deprecation policies, they may still surprise some users.
 -->
 
-The command will move from `kubectl alpha debug` to `kubectl debug`. If the
-user has a kubectl plugin named "debug", it will be masked.
+No
 
 ### Monitoring Requirements
 


### PR DESCRIPTION
- One-line PR description: Change answer of a PRR question that is about roll out because of the promotion of kubectl debug to stable

- Issue link: https://github.com/kubernetes/enhancements/issues/1441