### PR TITLE
N/A: Fixed periodSeconds in HPA scaleDown example

### DIFF
--- a/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
+++ b/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
@@ -207,7 +207,7 @@ behavior:
     policies:
     - type: Pods
       value: 5
-      periodSeconds: 600
+      periodSeconds: 60
 ```
 
 i.e., the algorithm will:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This fixes the value of the periodSeconds field in the example for the stabilization window in HPA scale down behavior.

<!-- link to the k/enhancements issue -->
- Issue link: N/A

<!-- other comments or additional information -->
- Other comments: The text under the example talks about how the scale down behavior will be limited to 5 pods per minute, however, the periodSeconds field is set to 600s (10m).