### PR TITLE
Promote KEP-2578 to beta

### DIFF
--- a/keps/sig-windows/2578-windows-conformance/kep.yaml
+++ b/keps/sig-windows/2578-windows-conformance/kep.yaml
@@ -1,4 +1,4 @@
-title: Windows Conformance
+title: Windows Operational Readiness Specification
 kep-number: 2578
 authors:
   - "@vladimirvivien"
@@ -18,15 +18,16 @@ reviewers:
   - "@jsturtevant"
 approvers:
   - "@marosset"
+
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.24"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.25"
+  beta: "v1.30"


### PR DESCRIPTION
- One-line PR description: Updating milestones and promoving KEP to beta 

> The suite is graduated to beta when the core tests are implemented and running.

By the definition in the KEP all core-tests were already implemented.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2578


<!-- other comments or additional information -->
- Other comments: Ref https://github.com/kubernetes/website/pull/45130#issuecomment-2002549940