### PR TITLE
KEP-4420: Promote retry generate name to beta

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/4420.yaml
+++ b/keps/prod-readiness/sig-api-machinery/4420.yaml
@@ -4,3 +4,5 @@
 kep-number: 4420
 alpha:
   approver: "@deads2k"
+beta:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
+++ b/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
@@ -7,17 +7,17 @@ participating-sigs:
 status: implementable
 creation-date: 2024-01-19
 reviewers:
-  - TODO
+  - "@deads2k"
 approvers:
   - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description:

No changes to the plan on this one, just a beta promotion so it's on-by-default in 1.31.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4420

<!-- other comments or additional information -->
- Other comments: