### PR TITLE
RFC: KEP-4381: DRA: management access

### DIFF
--- a/keps/sig-node/4381-dra-structured-parameters/README.md
+++ b/keps/sig-node/4381-dra-structured-parameters/README.md
@@ -1495,6 +1495,8 @@ type ResourceClaimSpec struct {
     // access mode that is only granted when there is a Quota object
     // in the same namespace as the claim where AllowManagementAccess
     // is true.
+    //
+    // This field is immutable after creation.
     ManagementAccess bool
 
     // ParametersRef references a separate object with arbitrary parameters
@@ -1505,6 +1507,18 @@ type ResourceClaimSpec struct {
     // +optional
     ParametersRef *ResourceClaimParametersReference
 }
+```
+
+```
+<<[UNRESOLVED @pohly ]>>
+Storing ManagementAccess only in the spec means that drivers are currently not
+getting to see it. https://github.com/kubernetes/enhancements/pull/4615 is needed to
+address this.
+
+We also need to add a comment to NodePrepareResources about checking whether parallel
+access to the same instance through different claims is allowed. This is a sanity
+check for erronous allocation.
+<<[/UNRESOLVED]>>
 ```
 
 The `ResourceClassName` field may be left empty. The parameters are sufficient

--- a/keps/sig-node/4381-dra-structured-parameters/README.md
+++ b/keps/sig-node/4381-dra-structured-parameters/README.md
@@ -1173,6 +1173,11 @@ prevent abuse, the default is to deny allocation of management claims. To allow
 that, the namespace must have a [Quota](#quota) object with the
 `AllowManagementAccess` field set to true.
 
+This new boolean alone is not sufficient to deploy a daemon set which requests
+and gets access to all resource instances of a certain type on a node. Some way
+to ask for ">= 1 instance" with no upper bound will be needed. This can be
+added together with support for optional allocation.
+
 ### API
 
 ```


### PR DESCRIPTION
- One-line PR description: management access

- Issue link: https://github.com/kubernetes/enhancements/issues/4381

- Other comments:

A claim with management access to the underlying resource(s) is useful, e.g. for health checks or statistics gathering. Because this is privileged access, we need a way to control whether users are granted that privilege.
