### PR TITLE
RFC: KEP-4381: DRA: support vendor-independent attributes

### DIFF
--- a/keps/sig-node/4381-dra-structured-parameters/README.md
+++ b/keps/sig-node/4381-dra-structured-parameters/README.md
@@ -777,6 +777,27 @@ requests:
         attributes.bool["isGPU.gpu.k8s.io"]
 ```
 
+Vendor parameters could be used here, too, but they would have to use a format
+that is supported by all drivers which might provide resources matching this
+request.
+
+```
+<<[UNRESOLVED @pohly @johnbelamaric]>>
+A KEP standardizing certain attributes can also standardize setup
+parameters and add them as a new field that complements the opaque
+`vendorParameters`. However, a scheduler which doesn't know about
+the new field then would silently ignore it.
+
+Do we need a one-of-many around vendorParameters here to avoid that issue?
+
+Shall we perhaps rename to
+requests:
+  setupParameters:
+    vendor:
+      <raw extension>
+<<[/UNRESOLVED]>>
+```
+
 Resource class parameters are supported the same way. To ensure that
 permissions can be limited to administrators, there's a separate cluster-scoped
 ResourceClassParameters type. Instead of individual requests, one additional


### PR DESCRIPTION
- One-line PR description: vendor-independent attributes

- Issue link: https://github.com/kubernetes/enhancements/issues/4381

- Other comments:

While it isn't really feasible for GPUs, other kinds of hardware might be described via some standardized attributes. When removing the explicit driver name from requests and filters it becomes possible for users to ask for an instance where some standardized attribute is set without knowing in advance which driver is going to provide it.

The downside is that CEL expressions now must get applied to all instances, whether they are from the "expected" driver or some other one. It becomes the responsibility of the CEL expression to filter out unknown instances.
