### PR TITLE
Update sig-docs-leads in enhancements/OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -46,11 +46,8 @@ aliases:
   sig-docs-leads:
     - divya-mohan0209
     - katcosgrove
-    - kbhawkey
     - natalisucks
-    - onlydole
     - reylejano
-    - sftim
     - tengqm
     - salaxander
   sig-etcd-leads:


### PR DESCRIPTION
In `sig-docs-leads` in k/enhancement/OWNERS_ALIASES , this PR removes Karen Bradshaw, Taylor Dolezal, and Tim Bannister who have stepped down from the tech lead role
Follow up to comment in https://github.com/kubernetes/enhancements/pull/4630#discussion_r1600072255

/cc @natalisucks @divya-mohan0209 