### PR TITLE
KEP-2000: Add note in KEP Proposal for `shutdown -h now` systemd version compatibility

### DIFF
--- a/keps/sig-node/2000-graceful-node-shutdown/README.md
+++ b/keps/sig-node/2000-graceful-node-shutdown/README.md
@@ -268,6 +268,7 @@ variety of methods for example:
    compute instances stop`. Depending on the cloud provider, this may result in
    virtual power button press by the underlying hypervisor.
 
+Note: The use of `shutdown -h now` is dependent on systemd version. This is explored in Github issue [#124039](https://github.com/kubernetes/kubernetes/issues/124039)
 
 Some of these cases will involve the machine receiving an ACPI event to change
 the power state. The machine can go from G0 (working state) to G2 (Soft Off)


### PR DESCRIPTION
- One-line PR description: 
Add note indicating that  'shutdown -h now` may not trigger GracefulNodeShutdown in the KEP-2000. 

- Issue link:
https://github.com/kubernetes/kubernetes/issues/124039

- Other comments:
Having `shutdown -h now` listed as the first way of shutting down gives the false impression that this method is recommended. But in some environments, the GracefulNodeShutdown may not trigger with `shutdown -h now`