### PR TITLE
Mark implemented SIG API Machinery KEPs as such

### DIFF
--- a/keps/sig-api-machinery/1601-client-go-context/kep.yaml
+++ b/keps/sig-api-machinery/1601-client-go-context/kep.yaml
@@ -12,7 +12,7 @@ approvers:
 - "@lavalamp"
 creation-date: 2020-01-23
 last-updated: 2020-01-23
-status: implementable
+status: implemented
 
 latest-milestone: "1.18"
 stage: "stable"

--- a/keps/sig-api-machinery/2155-clientgo-apply/kep.yaml
+++ b/keps/sig-api-machinery/2155-clientgo-apply/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 2155
 authors:
   - "@jpbetz"
 owning-sig: sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2020-11-16
 reviewers:
   - "@apelisse"

--- a/keps/sig-api-machinery/2896-openapi-v3/kep.yaml
+++ b/keps/sig-api-machinery/2896-openapi-v3/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 2896
 authors:
   - "@jefftree"
 owning-sig: sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2021-08-25
 reviewers:
   - "@apelisse"

--- a/keps/sig-api-machinery/3488-cel-admission-control/kep.yaml
+++ b/keps/sig-api-machinery/3488-cel-admission-control/kep.yaml
@@ -9,7 +9,7 @@ authors:
 owning-sig: sig-api-machinery
 participating-sigs:
   - sig-auth
-status: implementable
+status: implemented
 creation-date: 2022-09-02
 reviewers:
   - "@TristonianJones"

--- a/keps/sig-api-machinery/95-custom-resource-definitions/kep.yaml
+++ b/keps/sig-api-machinery/95-custom-resource-definitions/kep.yaml
@@ -20,7 +20,7 @@ approvers:
 editor: TBD
 creation-date: 2018-04-15
 last-updated: 2018-04-24
-status: implementable
+status: implemented
 see-also:
   - "[Umbrella Issue](https://github.com/kubernetes/kubernetes/issues/58682)"
   - "[Vanilla OpenAPI Subset Design](https://docs.google.com/document/d/1pcGlbmw-2Y0JJs9hsYnSBXamgG9TfWtHY6eh80zSTd8)"


### PR DESCRIPTION
CEL for Admission control was implemented in 1.30
The others have been implemented for a long time and this is just cleanup.

/sig api-machinery
/assign @deads2k @fedebongio @sttts 