### PR TITLE
SIG Cloud Provider update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,11 +27,9 @@ aliases:
     - mpuckett159
     - soltysh
   sig-cloud-provider-leads:
-    - andrewsykim
     - bridgetkromhout
     - cheftako
     - elmiko
-    - nckturner
   sig-cluster-lifecycle-leads:
     - CecileRobertMichon
     - fabriziopandini


### PR DESCRIPTION
Updated [OWNERS_ALIASES](https://git.k8s.io/enhancements/OWNERS_ALIASES) in [kubernetes/enhancements](https://github.com/kubernetes/enhancements) for https://github.com/kubernetes/community/issues/7865.

/sig cloud-provider