### PR TITLE
KEP-4444: Rename field routingPreference to trafficDistribution as per the decision during implementation.

### DIFF
--- a/keps/sig-network/4444-service-traffic-distribution/kep.yaml
+++ b/keps/sig-network/4444-service-traffic-distribution/kep.yaml
@@ -1,4 +1,4 @@
-title: Routing Preference for Services
+title: Traffic Distribution for Services
 kep-number: 4444
 authors:
   - "@gauravkghildiyal"
@@ -34,7 +34,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: ServiceRoutingPreference
+  - name: ServiceTrafficDistribution
     components:
       - kube-controller-manager
       - kube-proxy


### PR DESCRIPTION

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update the name of the field (and field values) which was decided during the implementation.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4444

<!-- other comments or additional information -->
- Other comments: This PR is in preparation for targeting Beta release in v1.31. The renaming changes have been isolated from other updates to help with the review process.

/sig network

/assign @robscott 