### PR TITLE
KEP-4438: rename gate and update milestones

### DIFF
--- a/keps/sig-node/4438-container-restart-termination/README.md
+++ b/keps/sig-node/4438-container-restart-termination/README.md
@@ -207,6 +207,15 @@ the restart during Pod termination.
 List the specific goals of the KEP. What is it trying to achieve? How will we
 know that this has succeeded?
 -->
+The following behaviors should be maintained during pod termination:
+- sidecar containers restarting
+- liveness, readiness and startup probing
+- container lifecycle hooks running
+- service account token rotation
+- secret and configmap volume updates
+
+Also, container termination should be non-blocking, which will fix issue [#121398](https://github.com/kubernetes/kubernetes/issues/121398)
+a container cannot restart when there is any terminating container in the same pod.
 
 ### Non-Goals
 
@@ -471,7 +480,7 @@ in back-to-back releases.
 #### Alpha
 
 - Allow sidecar containers to restart during the shutdown of the Pod.
-- Enable `livenessProbe` and `startupProbe` during the shutdown of the Pod for sidecar containers that restart.
+- Enable `livenessProbe`, `readinessProbe` and `startupProbe` during the shutdown of the Pod for sidecar containers that restart.
 - Enable `postStart` and `preStop` hooks during the shutdown of the Pod for sidecar containers that restart.
 
 #### Beta
@@ -559,7 +568,7 @@ well as the [existing list] of feature gates.
 -->
 
 - [X] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: SidecarContainerRestartDuringTermination
+  - Feature gate name: RestartContainerDuringTermination
   - Components depending on the feature gate:
     - kubelet
 - [ ] Other

--- a/keps/sig-node/4438-container-restart-termination/kep.yaml
+++ b/keps/sig-node/4438-container-restart-termination/kep.yaml
@@ -8,7 +8,7 @@ participating-sigs:
   - sig-scheduler
 status: implementable
 creation-date: 2024-01-25
-last-updated: 2024-02-02
+last-updated: 2024-05-22
 reviewers:
   - "@mrunalp"      # overall
   - "@ahg-g"        # SIG Scheduling
@@ -27,18 +27,18 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.30"
-  beta: "v1.31"
-  stable: "v1.32"
+  alpha: "v1.31"
+  beta: "v1.32"
+  stable: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: SidecarContainerRestartDuringTermination
+  - name: RestartContainerDuringTermination
     components:
       - kubelet
 disable-supported: true


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: preparing KEP for 1.31 release cycle

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4438

<!-- other comments or additional information -->
- Other comments: for 1.31 we'll mostly work on sidecars, however pod termination will be more broadly modified on next cycles