### PR TITLE
KEP4664: Guarantee PodDisruptionBudget When Preemption Happens

### DIFF
--- a/keps/prod-readiness/sig-scheduling/3280.yaml
+++ b/keps/prod-readiness/sig-scheduling/3280.yaml
@@ -1,3 +1,0 @@
-kep-number: 3280
-alpha:
-  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-scheduling/4664.yaml
+++ b/keps/prod-readiness/sig-scheduling/4664.yaml
@@ -1,0 +1,4 @@
+# Previously, the KEP had the number 3280, but since the original author no longer has the time to maintain it and the new author unable to modify the original KEP issue, we need to create a new issue and modify the KEP number to allow the new author to track and update everything about this KEP.
+kep-number: 4664
+alpha:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/4664-guarantee-pdb-when-preemption-happens/README.md
+++ b/keps/sig-scheduling/4664-guarantee-pdb-when-preemption-happens/README.md
@@ -58,7 +58,11 @@ If none of those approvers are still appropriate, then changes to that list
 should be approved by the remaining approvers and/or the owning SIG (or
 SIG Architecture for cross-cutting KEPs).
 -->
-# KEP-3280: Guarantee PodDisruptionBudget When Preemption Happens
+
+<!--
+ Previously, the KEP had the number 3280, but since the original author no longer has the time to maintain it and the new author unable to modify the original KEP issue, we need to create a new issue and modify the KEP number to allow the new author to track and update everything about this KEP.
+-->
+# KEP-4664: Guarantee PodDisruptionBudget When Preemption Happens
 
 <!--
 This is the title of your KEP. Keep it short, simple, and descriptive. A good
@@ -369,14 +373,14 @@ when selecting victims.
 - if the priority of the preemptor is greater than or equal to the value of `AllowDisruptionByPriorityGreaterThanOrEqual` in victim pod, 
   the implementation will remain consistent with the existing behavior, meaning that the scheduler will try to select victims whose PDBs 
   are not violated by preemption, but if no such victims are found, preemption will still happen and lower priority pods will be preempted 
-  via the `/evictions` endpoint despite their PDBs being violated. If the `/eviction` endpoint returns a response `429 Too Many Requests`
-  and the scheduler will fallback to deletion as an alternative.
+  via the `/evictions` endpoint despite their PDBs being violated. If the `/eviction` endpoint returns a response `429 Too Many Requests`, 
+  the scheduler will fallback to deletion as an alternative.
 - if the priority of the preemptor is less than the value of `AllowDisruptionByPriorityGreaterThanOrEqual` in victim pod, 
   the scheduler will check if the victim' PDBs will be violated when selecting victims
   - if violate the victims' PDBs, this victim will not be selected as candidates.
-  - if not violate the victims' PDBs, scheduler will preempt this pod via the `/evictions` endpoint. If it responds `200 OK`, 
-    it means the eviction is allowed, and the victim is deleted, similar to sending a DELETE request to the Pod URL. If it responses
-    `429 Too Many Requests`, the scheduler will output an error log and choose another victim among the candidate victims to preempt 
+  - if not violate the victims' PDBs, scheduler will preempt this pod via the `/evictions` endpoint. 
+    - If it responds `200 OK`, it means the eviction is allowed, and the victim is deleted, similar to sending a DELETE request to the Pod URL. 
+    - If it responses `429 Too Many Requests`, the scheduler will output an error log and choose another victim among the candidate victims to preempt 
     until it succeeds or there are no more candidates.
 
 ### PreemptionPolicy vs AllowDisruptionByPriorityGreaterThanOrEqual
@@ -932,6 +936,7 @@ Major milestones might include:
 -->
 - 2023-01-19: Initial KEP
 - 2023-01-28: Move the responsibilities from `AllowDisruptionByPriorityGreaterThanOrEqual` to `PriorityClass`
+- 2024-05-25: Restart KEP. Update design details.
 
 ## Drawbacks
 

--- a/keps/sig-scheduling/4664-guarantee-pdb-when-preemption-happens/kep.yaml
+++ b/keps/sig-scheduling/4664-guarantee-pdb-when-preemption-happens/kep.yaml
@@ -1,7 +1,9 @@
 title: Guarantee PodDisruptionBudget When Preemption Happens
-kep-number: 3280
+# Previously, the KEP had the number 3280, but since the original author no longer has the time to maintain it and the new author unable to modify the original KEP issue, we need to create a new issue and modify the KEP number to allow the new author to track and update everything about this KEP.
+kep-number: 4664
 authors:
   - "@denkensk"
+  - "AxeZhan"
 owning-sig: sig-scheduling
 participating-sigs:
   - sig-auth
@@ -27,11 +29,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.27"
+  alpha: "v1.31"
   beta: TBD
   stable: TBD
 


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Guarantee PodDisruptionBudget When Preemption Happens.
<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4664

<!-- other comments or additional information -->
- Other comments:
This is the first pr for #4664. But notice that #4664 is only taking over #3280. That's why this pr only contains a few updates on the design details(Most part of it has already been reviewed and approved)