### PR TITLE
KEP-4318: DRA: avoid kubelet API version dependency

### DIFF
--- a/keps/sig-node/4381-dra-structured-parameters/README.md
+++ b/keps/sig-node/4381-dra-structured-parameters/README.md
@@ -2096,8 +2096,9 @@ desired.
 
 The daemonset of a DRA driver must be configured to have a service account
 which grants the following permissions:
-- read/write/patch ResourceSlice
-- read ResourceClaim
+- get/list/watch/create/update/oatch/delete ResourceSlice
+- get ResourceClaim
+- get Node
 
 Ideally, write access to ResourceSlice should be limited to objects belonging
 to the node. This is possible with a [validating admission


### PR DESCRIPTION
- One-line PR description: DRA: avoid kubelet API version dependency

- Issue link: https://github.com/kubernetes/enhancements/issues/4381

- Other comments:

By requiring that drivers on a node connect to the apiserver directly it becomes possible to update drivers and the control plane to a newer release than the kubelet because the kubelet doesn't need to encode/decode the resource.k8s.io API types that are used by the drivers. This simplifies cluster upgrades.
