### PR TITLE
KEP-3857: Recursive Read-only (RRO) mounts: promote to Beta

### DIFF
--- a/keps/prod-readiness/sig-node/3857.yaml
+++ b/keps/prod-readiness/sig-node/3857.yaml
@@ -1,3 +1,5 @@
 kep-number: 3857
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@soltysh"

--- a/keps/sig-node/3857-rro-mounts/kep.yaml
+++ b/keps/sig-node/3857-rro-mounts/kep.yaml
@@ -21,17 +21,17 @@ approvers:
 #  - "/keps/sig-ccc/3456-replaced-kep"
 #
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.30"
-#  beta: "v1.XX"
+  beta: "v1.31"
 #  stable: "v1.XX"
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP-3857: Recursive Read-only (RRO) mounts: promote to Beta

<!-- link to the k/enhancements issue -->
- Issue link: #3857

<!-- other comments or additional information -->
- Other comments: The KEP can be moved to beta, as the feature is now ready for containerd, CRI-O, and cri-dockerd: 
  - https://github.com/containerd/containerd/pull/9787
  - https://github.com/cri-o/cri-o/pull/7962
  - https://github.com/Mirantis/cri-dockerd/pull/370