### PR TITLE
KEP 1645: update conditions in ServiceExport after KEP-1623

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -422,42 +422,22 @@ type ServiceExportStatus struct {
         // +patchMergeKey=type
         // +listType=map
         // +listMapKey=type
-        Conditions []ServiceExportCondition `json:"conditions,omitempty"`
+        Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
-
-// ServiceExportConditionType identifies a specific condition.
-type ServiceExportConditionType string
 
 const {
       // ServiceExportValid means that the service referenced by this
       // service export has been recognized as valid by an mcs-controller.
       // This will be false if the service is found to be unexportable
       // (ExternalName, not found).
-      ServiceExportValid ServiceExportConditionType = "Valid"
+      ServiceExportValid = "Valid"
       // ServiceExportConflict means that there is a conflict between two
       // exports for the same Service. When "True", the condition message
       // should contain enough information to diagnose the conflict:
       // field(s) under contention, which cluster won, and why.
       // Users should not expect detailed per-cluster information in the
       // conflict message.
-      ServiceExportConflict ServiceExportConditionType = "Conflict"
-}
-
-// ServiceExportCondition contains details for the current condition of this
-// service export.
-//
-// Once KEP-1623 (sig-api-machinery/1623-standardize-conditions) is
-// implemented, this will be replaced by metav1.Condition.
-type ServiceExportCondition struct {
-        Type ServiceExportConditionType `json:"type"`
-        // Status is one of {"True", "False", "Unknown"}
-        Status corev1.ConditionStatus `json:"status"`
-        // +optional
-        LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
-        // +optional
-        Reason *string `json:"reason,omitempty"`
-        // +optional
-        Message *string `json:"message,omitempty"`
+      ServiceExportConflict = "Conflict"
 }
 ```
 ```yaml
@@ -470,14 +450,20 @@ status:
   conditions:
   - type: Ready
     status: "True"
+    reason: Ready
     lastTransitionTime: "2020-03-30T01:33:51Z"
-  - type: InvalidService
+    reason: "Ready"
+  - type: Valid
     status: "False"
+    reason: Valid
     lastTransitionTime: "2020-03-30T01:33:55Z"
+    reason: "ServiceType"
+    message: "Service type ExternalName is not supported"
   - type: Conflict
     status: "True"
+    reason: Conflict
     lastTransitionTime: "2020-03-30T01:33:55Z"
-    message: "Conflicting type. Using \"ClusterSetIP\" from oldest service export in \"cluster-1\". 2/5 clusters disagree."
+    message: "Conflicting type. 2/5 clusters disagree. Using \"ClusterSetIP\" from oldest service export in \"cluster-1\"."
 ```
 
 To export a service, a `ServiceExport` should be created within the cluster and

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -438,6 +438,11 @@ const {
       // Users should not expect detailed per-cluster information in the
       // conflict message.
       ServiceExportConflict = "Conflict"
+      // ServiceExportLocalConflict means that the service export is directly
+      // involved in a conflict. This condition should be "True" if the local
+      // service export if involved in the conflict whether or not
+      // the conflict is resolved in the favor of this service export.
+      ServiceExportLocalConflict = "LocalConflict"
 }
 ```
 ```yaml
@@ -452,7 +457,6 @@ status:
     status: "True"
     reason: Ready
     lastTransitionTime: "2020-03-30T01:33:51Z"
-    reason: "Ready"
   - type: Valid
     status: "False"
     reason: Valid
@@ -464,6 +468,11 @@ status:
     reason: Conflict
     lastTransitionTime: "2020-03-30T01:33:55Z"
     message: "Conflicting type. 2/5 clusters disagree. Using \"ClusterSetIP\" from oldest service export in \"cluster-1\"."
+  - type: LocalConflict
+    status: "True"
+    reason: LocalConflict
+    lastTransitionTime: "2020-03-30T01:33:55Z"
+    message: "This ServiceExport is directly involved in the conflict."
 ```
 
 To export a service, a `ServiceExport` should be created within the cluster and


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Update conditions after KEP-1623 on KEP-1645 which match the actual CRDs here: https://github.com/kubernetes-sigs/mcs-api/blob/master/pkg/apis/v1alpha1/serviceexport.go#L47. 
<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1645

<!-- other comments or additional information -->
- Other comments: Also swap the "2/5 cluster disagree" in the conflict message example so that it's clear that the disagree sentence is for the service that we export and not from the oldest Service that we conflict with.