### PR TITLE
KEP-4265: promote ProcMount option to beta

### DIFF
--- a/keps/sig-node/4265-proc-mount/README.md
+++ b/keps/sig-node/4265-proc-mount/README.md
@@ -505,7 +505,9 @@ Major milestones might include:
 2018-05-07: k/community update opened
 2018-05-27: k/kubernetes PR merged with support.
 2023-10-02: KEP opened and retargeted at Alpha
-2024-02-01: KEP updated to Beta
+2024-02-26: [Update](https://github.com/kubernetes/kubernetes/pull/123520) Unmasked ProcMountType to fail validation without a pod level user namespace.
+2024-05-31: Added e2e [tests](https://github.com/kubernetes/kubernetes/pull/123303)
+2024-05-31: KEP updated to Beta
 
 ## Drawbacks
 

--- a/keps/sig-node/4265-proc-mount/kep.yaml
+++ b/keps/sig-node/4265-proc-mount/kep.yaml
@@ -20,12 +20,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.12"
-  beta: "v1.30"
+  beta: "v1.31"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Updates target for KEP to beta in 1.30

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4265

<!-- other comments or additional information -->
- Other comments: