### PR TITLE
KEP-3331: update kep latest milestone to v1.31

### DIFF
--- a/keps/sig-auth/3331-structured-authentication-configuration/kep.yaml
+++ b/keps/sig-auth/3331-structured-authentication-configuration/kep.yaml
@@ -12,7 +12,7 @@ approvers:
 creation-date: "2022-06-02"
 status: implementable
 stage: beta
-latest-milestone: "v1.30"
+latest-milestone: "v1.31"
 milestone:
   alpha: "v1.29"
   beta: "v1.30"


### PR DESCRIPTION
- Update KEP latest milestone to `v1.31`.
  - The feature will remain in beta in v1.31 but we plan to make some code changes in v1.31 release for metrics and refactoring.
- Issue link: https://github.com/kubernetes/enhancements/issues/3331

/sig auth
/assign enj