### PR TITLE
KEP-2091: Do not pass K8s NetworkPolicy implicit denies to BaselineAdminNetworkPolicy

### DIFF
--- a/keps/sig-network/2091-admin-network-policy/README.md
+++ b/keps/sig-network/2091-admin-network-policy/README.md
@@ -188,7 +188,7 @@ selected by the AdminNetworkPolicy, as opposed to what NetworkPolicy rules imply
 
 - Pass: Traffic that matches a `Pass` rule will skip all further rules from all
   lower precedenced ANPs, and instead be enforced by the K8s NetworkPolicies.
-  If there is no K8s NetworkPolicy rule match, and no BaselineAdminNetworkPolicy
+  If there is no K8s NetworkPolicy selecting the pod, and no BaselineAdminNetworkPolicy
   rule match (more on this in the [priority section](#priority)), traffic will be
   governed by the implementation. For most implementations, this means "allow",
   but there may be implementations which have their own policies outside of the


### PR DESCRIPTION
The previous spec implies that traffic that does not match a rule in any K8s NetworkPolicy should be passed to the BaselineAdminNetworkPolicy (if present) and then on to the implementation default behavior (usually Allow).  This would cause all traffic to be allowed regardless of NetworkPolicy unless a BaselineAdminNetworkPolicy is created, which is not an acceptable upgrade behavior and is unlikely to be intended.

I think only passing traffic to the Baseline policies that isn't selected (meaning the combination of podSelector and presence of ingress or egress rules as appropriate) is probably the intended behavior, so this is what I've changed it to here.

I also presume that the intended behavior is not dependent on whether there is a Passing AdminNetworkPolicy, so if that is indeed what's intended I can also move this section elsewhere in the doc.