### PR TITLE
KEP-3335: Update stable milestone to 1.31

### DIFF
--- a/keps/prod-readiness/sig-apps/3335.yaml
+++ b/keps/prod-readiness/sig-apps/3335.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/3335-statefulset-slice/kep.yaml
+++ b/keps/sig-apps/3335-statefulset-slice/kep.yaml
@@ -15,17 +15,18 @@ approvers:
   - "@soltysh"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.26"
   beta: "v1.27"
+  stable: "v1.31"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP-3335: Update stable milestone to 1.31

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3335

<!-- other comments or additional information -->
- Other comments: e2e tests will not be graduated (per the [conformance criteria](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md), as using the `.spec.ordinals` field is optional.