### PR TITLE
KEP 4420:  Retry Generate Name KEP paperwork

### DIFF
--- a/keps/sig-api-machinery/4420-retry-generate-name/README.md
+++ b/keps/sig-api-machinery/4420-retry-generate-name/README.md
@@ -527,16 +527,9 @@ high retry load.
 
 ## Implementation History
 
-<!--
-Major milestones in the lifecycle of a KEP should be tracked in this section.
-Major milestones might include:
-- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
-- the `Proposal` section being merged, signaling agreement on a proposed design
-- the date implementation started
-- the first Kubernetes release where an initial version of the KEP was available
-- the version of Kubernetes where the KEP graduated to general availability
-- when the KEP was retired or superseded
--->
+- 2024-01-31: KEP merged as implementable
+- Kubernetes v1.30 - Implementation available as an off-by-default alpha feature
+- Kubernetes v1.31 - Implementation available as an on-by-default beta feature
 
 ## Drawbacks
 

--- a/keps/sig-api-machinery/4420-retry-generate-name/README.md
+++ b/keps/sig-api-machinery/4420-retry-generate-name/README.md
@@ -360,7 +360,7 @@ served by an apiserver with this feature enabled.
 ###### How can this feature be enabled / disabled in a live cluster?
 
 - [x] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: NameGenerationRetries
+  - Feature gate name: RetryGenerateName
   - Components depending on the feature gate: kube-apiserver
 
 

--- a/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
+++ b/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
@@ -28,7 +28,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: NameGenerationRetries
+  - name: RetryGenerateName
     components:
       - kube-apiserver
 disable-supported: true


### PR DESCRIPTION
Per request: https://github.com/kubernetes/enhancements/issues/4420#issuecomment-2148615582

- Update feature gate name to match implementation
- Update implementation history

/assign @deads2k @sttts