### PR TITLE
[KEP-2400] swap updates, beta3 graduation and GA criterias

### DIFF
--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -31,6 +31,7 @@
     - [Exhausting swap resource](#exhausting-swap-resource)
     - [Security risk](#security-risk)
     - [Cgroupv1 support](#cgroupv1-support)
+    - [Memory-backed volumes](#memory-backed-volumes)
 - [Design Details](#design-details)
   - [Enabling swap as an end user](#enabling-swap-as-an-end-user)
   - [API Changes](#api-changes)
@@ -477,6 +478,25 @@ Additionally, end user may decide to disable swap completely for a Pod or a cont
 
 In the early release of this feature, there was a goal to support cgroup v1. As the feature progressed, sig-node realized that supporting swap with cgroup v1 would be very difficult.
 Therefore, this feature is limited to cgroupv2 only. The main goal is to deprecate cgroupv1 eventually so this should not be a major inconvience.
+
+#### Memory-backed volumes
+
+Kubernetes guarantees that some volumes' memory would never reside on disk, e.g. Secrets, memory-backed emptyDirs, etc.
+Behind the scenes, Kubelet mounts such volumes as tmpfs volumes on the host.
+
+To address this risk, if `--fail-swap-on=false`, the [tmpfs noswap option](https://www.kernel.org/doc/html/latest/filesystems/tmpfs.html)
+will be used in order to prevent the volumes' pages from swapping to disk.
+
+Bear in mind that the tmpfs noswap option is fairly new and is supported in kernel versions >= 6.4. However, different
+Linux distributions can decide to backport this options to older versions of the kernel. Therefore, when
+`--fail-swap-on=false` is being provided on a node:
+* If the kernel version equals or is above 6.4, the tmpfs noswap option is being used when necessary.
+* Else, kubelet would try to mount a dummy volume with the tmpfs noswap option to understand whether the option is
+  backported. If the mount succeeds, the tmpfs noswap option is being used when necessary.
+* Else, kubelet would raise a warning about the option not being supported and the possible risk.
+
+In the longer term, when this option would be very widely supported, this would no longer be a concern, hence this logic
+could be dropped.
 
 ## Design Details
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -53,6 +53,7 @@
     - [Alpha2](#alpha2)
     - [Beta 1](#beta-1)
     - [Beta 2](#beta-2)
+    - [Beta 3](#beta-3)
     - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
@@ -858,6 +859,10 @@ For beta 2:
 
 - Add Node-conformance tests for basic swap validation. To avoid disrupting node conformance lanes, only the
 cgroup knobs are validated to be defined as expected with no real memory stress or swap use.
+
+For beta 3:
+
+- We want e2e tests that can confirm that eviction will take in account swap usage
 - Add a lane dedicated for swap testing, including stress tests and other tests that might be disruptive and intensive.
 These lanes are called "swap-conformance", and are (and should remain) consistently green:
   - [kubelet-swap-conformance-fedora-serial](https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-fedora-serial): Green.
@@ -928,15 +933,22 @@ Here are specific improvements to be made:
 - Add e2e test confirming that swap is used for `LimitedSwap`.
 - Document [best practices](#best-practices) for setting up Kubernetes with swap
 
-[via cgroups]: #restrict-swap-usage-at-the-cgroup-level
+#### Beta 3
+
+- Enhance website documentation
+  - Docs should be close to GA quality before promoting to GA.
+- Make eviction manager swap aware.
+- Test a wide variety of scenarios that may be affected by swap support, including tests with aggressive memory stress.
+- Address memory-backed backed volumes which should not have access to swap.  
+- Add documentation regarding encrypted swap.
+- Test a wide variety of scenarios in which the node is being memory-stressed with different eviction and swap configurations. 
+Ensure the behavior is consistent and reliable.
+- Exclude high-priority, static and mirrored pods from gaining access to swap.
 
 #### GA
 
-_(Tentative.)_
-
-- Test a wide variety of scenarios that may be affected by swap support.
-- Remove feature flag.
-- Remove the Swap Support using Burstable QoS Pods only deprecated in Beta 2.
+- Remove feature gate.
+- Ensure swap-conformance tests are continuously green.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -96,7 +96,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) Graduation criteria is in place
 - [x] (R) Production readiness review completed
 - [x] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
+- [x] "Implementation History" section is up-to-date for milestone
 - [x] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
@@ -1421,14 +1421,25 @@ nodes that do not use swap memory.
 
 ## Implementation History
 
+This is a partial list of everything that was done, but contains the most significant implementations.
+
 - **2015-04-24:** Discussed in [#7294](https://github.com/kubernetes/kubernetes/issues/7294).
 - **2017-10-06:** Discussed in [#53533](https://github.com/kubernetes/kubernetes/issues/53533).
 - **2021-01-05:** Initial design discussion document for swap support and use cases.
 - **2021-04-05:** Alpha KEP drafted for initial node-level swap support and implementation (KEP-2400).
 - **2021-08-09:** New in Kubernetes v1.22: alpha support for using swap memory: https://kubernetes.io/blog/2021/08/09/run-nodes-with-swap-alpha/.
 - **2023-04-17:** KEP update for beta1 [#3957](https://github.com/kubernetes/enhancements/pull/3957).
+- **2023-07-18:** Add full cgroup v2 swap support with automatically calculated swap limit for LimitedSwap [#118764](https://github.com/kubernetes/kubernetes/pull/118764).
+- **2023-07-18:** Add swap to stats to Summary API and Prometheus endpoints (/stats/summary and /metrics/resource) [#118865](https://github.com/kubernetes/kubernetes/pull/118865).
 - **2023-08-15:** Beta1 released in kubernetes 1.28
 - **2024-01-12:** Updates to Beta2 KEP.
+- **2024-01-08:** Beta2 released in kubernetes 1.30.
+- **2024-03-06:** Add no swap as the default option for swap [#122745](https://github.com/kubernetes/kubernetes/pull/122745).
+- **2024-03-14:** Add swap-specific (a.k.a. swap conformance) test lanes [#32263](https://github.com/kubernetes/test-infra/pull/32263).
+- **2024-05-21:** Add swap serial stress tests, improve NodeConformance tests and adapt NoSwap behavior [#123557](https://github.com/kubernetes/kubernetes/pull/123557).
+- **2024-05-23:** Mount tmpfs memory-backed volumes with a noswap option if supported [#124060](https://github.com/kubernetes/kubernetes/pull/124060).
+- **2024-07-22:** Restrict access to swap for containers in high priority Pods [#125277](https://github.com/kubernetes/kubernetes/pull/125277).
+- **2024-08-28:** Updates to KEP, GA requirements and intention to release in version 1.32.
 
 ## Drawbacks
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -30,6 +30,7 @@
     - [Low footprint systems](#low-footprint-systems)
     - [Virtualization management overhead](#virtualization-management-overhead)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Future Extensions of Swap](#future-extensions-of-swap)
   - [Risks and Mitigations](#risks-and-mitigations)
     - [Existing use cases of Swap](#existing-use-cases-of-swap)
     - [Exhausting swap resource](#exhausting-swap-resource)
@@ -486,6 +487,18 @@ amount of swap for a workload as memory requested. We will update the default
 to not permit the use of swap by setting `memory-swap` equal to `limit`.
 
 [runtime specification]: https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
+
+### Future Extensions of Swap
+
+This feature was created so that we iterate on adding swap to Kubernetes.
+Due to this, pods will not be able to request swap memory directly nor explicitly for the current implementation.
+To make swap more useful for workloads, we acknowledge the need for proper APIs for swap to make it customizable and flexible.
+
+For example, we're considering the following features for future KEPs:
+- Swap should be opt-in and opt-out at the workload level.
+- Customization of swap limit calculation for workloads.
+- Eviction Manager to be more flexible in regards to swap limits.
+- Eviction Manager should look at more advanced ways of determining swap pressure (PSI for example).
 
 ### Risks and Mitigations
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -616,24 +616,20 @@ type KubeletConfiguration struct {
 }
 
 type MemorySwapConfiguration struct {
-	// Configure swap memory available to container workloads. May be one of
-  // "", "NoSwap": workload will not use swap
-	// "LimitedSwap": workload combined memory and swap usage cannot exceed pod memory limit
-	SwapBehavior string
-}
+	// swapBehavior configures swap memory available to container workloads. May be one of
+	// "", "NoSwap": workloads can not use swap, default option.
+	// "LimitedSwap": workload swap usage is limited. The swap limit is proportionate to the container's memory request.
+	// +featureGate=NodeSwap
+	// +optional
+	SwapBehavior string `json:"swapBehavior,omitempty"`}
 ```
 
 We want to expose common swap configurations based on the [Docker] and open
 container specification for the `--memory-swap` flag. Thus, the
 `MemorySwapConfiguration.SwapBehavior` setting will have the following effects:
 
-* If `SwapBehavior` is set to `"LimitedSwap"`, containers do not have
-  access to swap beyond their memory limit. This value prevents a container
-  from using swap in excess of their memory limit, even if it is enabled on a
-  system.
-  * With cgroups v2, swap is configured independently from memory. Thus, the
-    container runtimes can set [`memory.swap.max`] to 0 in this case, and _no_ swap
-    usage will be permitted.
+* If `SwapBehavior` is set to `"LimitedSwap"`, containers have limited (or no) swap access.
+  See "Steps to Calculate Swap Limit" above.
 * If `SwapBehavior` is set to `""` or `"NoSwap"`, no workloads will utilize swap.
 
 [docker]: https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -1,4 +1,4 @@
-# KEP-2400: Node system swap support
+# KEP-2400: Node memory swap support
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
@@ -117,6 +117,31 @@ support to nodes in a controlled, predictable manner so that Kubernetes users
 can perform testing and provide data to continue building cluster capabilities
 on top of swap.
 
+This KEP aims to
+introduce basic swap enablement and leave further extensions to follow-up KEPs.
+This way Kubernetes users / vendors would be able to use swap in a basic manner
+quickly while extensions would be brought to discussion in dedicated KEPs that
+would progress in the meantime.
+
+For example, to achieve this goal, this KEP does not introduce any APIs
+that allow customizing how the feature behaves, but instead only determines 
+whether the feature is enabled or disabled.
+From an API perspective, this is being done by presenting the kubelet `swapBehavior`
+configuration field.
+Within the scope of this KEP we will support only two basic behaviors: `NoSwap` and `LimitedSwap`.
+Both do not provide any customizability, as `NoSwap` disables swap for workloads and
+`LimitedSwap`'s behaviour is automatic and implicit that requires minimum user
+intervention (see [proposal below](#steps-to-calculate-swap-limit) for more details).
+As mentioned above, in the very near future, follow-up KEPs would bring API extension
+and customizability, supporting zswap, and many other extensions to discussion.
+These customization capabilities will probably be introduced as additional
+"swap behaviors" which will probably bring some API changes, perhaps at the pod level,
+that will extend this feature and make it more suitable for advanced usage.
+
+While this KEP sets the ground for extending the API in follow-ups through "swap behaviors",
+changing APIs, especially at the pod-level, is highly complex and controversial.
+Therefore, it is out of scope for this KEP.
+
 ## Motivation
 
 There are two distinct types of user for swap, who may overlap:
@@ -161,9 +186,11 @@ will be necessary to implement the third scenario.
 - Setting [swappiness]. This can already be set on a system-wide level outside
   of Kubernetes.
 - Allocating swap on a per-workload basis with accounting (e.g. pod-level
-  specification of swap). If desired, this should be designed and implemented
-  as part of a follow-up KEP. This KEP is a prerequisite for that work. Hence,
-  swap will be an overcommitted resource in the context of this KEP.
+  specification of swap), and/or APIs to customize and control the way kubelet
+  calculates swap limits, grants swap access, etc. If desired, this should be
+  designed and implemented as part of a follow-up KEP. This KEP is a
+  prerequisite for that work. Hence, swap will be an overcommitted resource
+  in the context of this KEP.
 - Supporting zram, zswap, or other memory types like SGX EPC. These could be
   addressed in a follow-up KEP, and are out of scope.
 - Use of swap for cgroupsv1.
@@ -194,7 +221,10 @@ Allocate the swap limit equal to the requested memory for each container and adj
 
 #### Set Aside Swap for System Critical Daemons
 
-**Note** In Beta2, we found that having system critical daemons swapping memory could cause degration of services.
+**Note** In Beta2, we found that having system-critical daemons swapping memory could cause degradation of services.
+Therefore, Kubelet will not automatically configure this, although the admin can still manually configure it
+this way. In the near future, when a follow-up KEP regarding customizability is presented, this will be considered
+to automatically be configured under a dedicated configuration.
 
 System critical daemons (such as Kubelet) are essential for node health. Usually, an appropriate portion of system resources (e.g., memory, CPU) is reserved as system reserved. However, swap doesn't inherently support reserving a portion out of the total available. For instance, in the case of memory, we set `memory.min` on the node-level cgroup to ensure an adequate amount of memory is set aside, away from the pods, and for system critical daemons. But there is no equivalent for swap; i.e., no `memory.swap.min` is supported in the kernel.
 
@@ -289,6 +319,10 @@ nodes could improve better resource pressure handling and recovery.
 - https://github.com/facebookincubator/oomd/blob/master/docs/production_setup.md#swap
 
 This user story is addressed by scenario 1 and 2, and could benefit from 3.
+
+Note: critical / high-priority pods would not be able to access swap, but can
+still be configured otherwise to gain swap access. In the future, APIs / more
+swap behaviors would be able to be used to control swap in a more customized way. 
 
 #### Long-running applications that swap out startup memory
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -467,6 +467,7 @@ To avoid exhausting swap on a node, `UnlimitedSwap` was dropped from the API in 
 #### Security risk
 
 Enabling swap on a system without encryption poses a security risk, as critical information, such as Kubernetes secrets, may be swapped out to the disk. If an unauthorized individual gains access to the disk, they could potentially obtain these secrets. To mitigate this risk, it is recommended to use encrypted swap. However, handling encrypted swap is not within the scope of kubelet; rather, it is a general OS configuration concern and should be addressed at that level. Nevertheless, it is essential to provide documentation that warns users of this potential issue, ensuring they are aware of the potential security implications and can take appropriate steps to safeguard their system.
+The documentation updates are required; there is already a [blog article](https://kubernetes.io/blog/2023/08/24/swap-linux-beta/) that mentions the security implications.
 
 To guarantee that system daemons are not swapped, the kubelet must configure the `memory.swap.max` setting to `0` within the system reserved cgroup. Moreover, to make sure that burstable pods are able to utilize swap space, kubelet should verify that the cgroup associated with burstable pods should not be nested under the cgroup designated for system reserved.
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -684,6 +684,46 @@ type SwapStats struct {
 }
 ```
 
+In addition, we've added swap to stats to Summary API and Prometheus endpoints (`/stats/summary` and
+`/metrics/resource`):
+```shell
+> kubectl get --raw "/api/v1/nodes/<NODE-NAME>/proxy/metrics/resource" | grep swap
+# HELP container_swap_usage_bytes [ALPHA] Current container amount of swap usage in bytes
+# TYPE container_swap_usage_bytes gauge
+container_swap_usage_bytes{container="c1",namespace="default",pod="test-pod"} 3.4400333824e+10 1687950863878
+container_swap_usage_bytes{container="coredns",namespace="kube-system",pod="coredns-8f5847b64-t9gmr"} 0 1687950855483
+# HELP node_swap_usage_bytes [ALPHA] Current node swap usage in bytes
+# TYPE node_swap_usage_bytes gauge
+node_swap_usage_bytes 1.8446743709127774e+19 1687950863599
+# HELP pod_swap_usage_bytes [ALPHA] Current pod amount of swap usage in bytes
+# TYPE pod_swap_usage_bytes gauge
+pod_swap_usage_bytes{namespace="default",pod="test-pod"} 3.4379333632e+10 1687950858784
+pod_swap_usage_bytes{namespace="kube-system",pod="coredns-8f5847b64-t9gmr"} 0 1687950863144
+```
+
+```shell
+> kubectl get --raw "/api/v1/nodes/localhost/proxy/stats/summary"
+
+node:
+ nodeName: localhost
+ swap:
+   swapAvailableBytes: 407531442176
+   swapUsageBytes: 18446743709127774000
+pods:
+- name: test-pod
+  swapUsageBytes: 34379333632
+  containers:
+  - name: c1
+    swapUsageBytes: 34400333824 
+- name: coredns-8f5847b64-t9gmr
+  swapUsageBytes: 0
+  containers:
+  - name: coredns
+    swapUsageBytes: 0
+```
+
+(This output is simplified, for full examples please look at the description of: https://github.com/kubernetes/kubernetes/pull/118865)
+
 ### Test Plan
 
 <!--

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -68,7 +68,6 @@
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
   - [Just set <code>--fail-swap-on=false</code>](#just-set---fail-swap-onfalse)
-  - [Restrict swap usage at the cgroup level](#restrict-swap-usage-at-the-cgroup-level)
 - [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
 <!-- /toc -->
 
@@ -1045,6 +1044,10 @@ automations, so be extremely careful here.
 
 No. If the feature flag is enabled, the user must still set
 `--fail-swap-on=false` to adjust the default behaviour.
+In addition, since the default "swap behavior" is "NoSwap",
+by default containers would not be able to access swap. Instead,
+the administrator would need to set a non-default behavior in order
+for swap to be accessible.
 
 A node must have swap provisioned and available for this feature to work. If
 there is no swap available, but the feature flag is set to true, there will
@@ -1077,7 +1080,8 @@ for workloads.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
-N/A
+As described above, swap can be turned on and off, although kubelet would need to be
+restarted.
 
 ###### Are there any tests for feature enablement/disablement?
 
@@ -1088,8 +1092,18 @@ with and without the feature, are necessary. At the very least, think about
 conversion tests if API types are being modified.
 -->
 
-N/A. This should be tested separately for scenarios with the flag enabled and
-disabled.
+There are extensive tests to ensure that the swap feature as expected.
+
+Unit tests are in place to test that this feature operates as expected with
+cgroup v1/v2, the feature gate being on/off, and different swap behaviors defined.
+
+In addition, node e2e tests are added and run as part of the node-conformance
+suite. These tests ensure that the underlying cgroup knobs are being configured
+as expected.
+
+Furthermore, "swap-conformance" periodic lanes have been introduced for the purpose
+testing swap on a stressed environment. These tests ensure that swap kicks in when
+expected, tested while stressing both on the node-level and container-level. 
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -1155,9 +1169,8 @@ This section must be completed when targeting beta to a release.
 
 ###### How can someone using this feature know that it is working for their instance?
 
-See #swap-metrics
-
-1. Kubelet stats API will be extended to show swap usage details.
+See #swap-metrics: available by both Summary API (/stats/summary) and Prometheus (/metrics/resource)
+which provide how and if swap is utilized in the node, pod and container level.
 
 ###### How can an operator determine if the feature is in use by workloads?
 
@@ -1166,6 +1179,9 @@ Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
 checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
+
+See #swap-metrics: available by both Summary API (/stats/summary) and Prometheus (/metrics/resource)
+which provide how and if swap is utilized in the node, pod and container level.
 
 KubeletConfiguration has set `failOnSwap: false`.
 
@@ -1178,19 +1194,22 @@ utilization.
 Pick one more of these and delete the rest.
 -->
 
-TBD. We will determine a set of metrics as a requirement for beta graduation.
-We will need more production data; there is not a single metric or set of
-metrics that can be used to generally quantify node performance.
+See #swap-metrics: available by both Summary API (/stats/summary) and Prometheus (/metrics/resource)
+which provide how and if swap is utilized in the node, pod and container level.
 
-This section to be updated before the feature can be marked as graduated, and
-to be worked on during 1.23 development.
-
-We will also add swap memory utilization to the Kubelet stats API, to provide a means of monitoring this beyond cadvisor Prometheus stats.
-
-- [ ] Metrics
-  - Metric name:
-  - [Optional] Aggregation method:
-  - Components exposing the metric:
+- [X] Metrics
+  - Metric names:
+    - `container_swap_usage_bytes`
+    - `pod_swap_usage_bytes`
+    - `node_swap_usage_bytes`
+    Components exposing the metric: `/metrics/resource` endpoint
+  - Metric names:
+    - `node.swap.swapUsageBytes`
+    - `node.swap.swapAvailableBytes`
+    - `node.systemContainers.swap.swapUsageBytes`
+    - `pods[i].swap.swapUsageBytes`
+    - `pods[i].containers[i].swap.swapUsageBytes`
+    Components exposing the metric: `/stats/summary` endpoint
 - [ ] Other (treat as last resort)
   - Details:
 
@@ -1206,7 +1225,14 @@ high level (needs more precise definitions) those may be things like:
   - 99,9% of /health requests per day finish with 200 code
 -->
 
-N/A
+Swap is being managed by the kernel, depends on many factors and configurations
+that are outside of kubelet's reach like the nature of the workloads running on the node,
+swap capacity, memory capacity and other distro-specific configurations. However, generally:
+
+- Nodes with swap enabled -> `node.swap.swapAvailableBytes` should be non-zero.
+- Nodes with memory pressure -> `node.swap.swapUsageBytes` should be non-zero.
+- Containers that reach their memory limit threshold -> `pods[i].containers[i].swap.swapUsageBytes` should be non-zero.
+- Pods with containers that reach their memory limit threshold -> `pods[i].swap.swapUsageBytes` should be non-zero. 
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
@@ -1321,9 +1347,11 @@ Think about adding additional work or introducing new steps in between
 -->
 
 Yes, enabling swap can affect performance of other critical daemons on the system.
-Any scenario where swap memory gets utilized is a result of system running out of physical RAM.
+Any scenario where swap memory gets utilized is a result of system running out of physical RAM,
+or a container reaching its memory limit threshold.
 Hence, to maintain the SLIs/SLOs of critical daemons on the node we highly recommend to disable the swap for the system.slice
-along with reserving adequate enough system reserved memory.
+along with reserving adequate enough system reserved memory, giving io latency precedence to the system.slice, and more.
+See #best practices for more info.
 
 The SLI that could potentially be impacted is [pod startup latency](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md).
 If the container runtime or kubelet are performing slower than expected, pod startup latency would be impacted.
@@ -1412,41 +1440,24 @@ When swap is enabled, particularly for workloads, the kubelet’s resource
 accounting may become much less accurate. This may make cluster administration
 more difficult and less predictable.
 
-Currently, there exists an unsupported workaround, which is setting the kubelet
-flag `--fail-swap-on` to false.
+In general, swap is less predictable and might cause performance degradation.
+It also might be hard in certain scenarios to understand why certain workloads
+are the chosen candidates for swapping, which could occur for reasons external
+to the workload.
+
+In addition, containers with memory limits would be killed less frequently
+since with swap enabled the kernel can usually reclaim a lot more memory.
+While this can help to avoid crashes, it could also "hide a problem" of a container
+reaching its memory limits.
 
 ## Alternatives
 
 ### Just set `--fail-swap-on=false`
 
-This is insufficient for most use cases because there is inconsistent control
-over how swap will be used by various container runtimes. Dockershim currently
-sets swap available for workloads to 0. The CRI does not restrict it at all.
-This inconsistency makes it difficult or impossible to use swap in production,
-particularly if a user wants to restrict workloads from using swap when using
-the CRI rather than dockershim.
-
-This is also a breaking change. 
-Users have used --fail-swap-on=false to allow for kubernetes to run
-on a swap enabled node.
-
-### Restrict swap usage at the cgroup level
-
-Setting a swap limit at the cgroup level would allow us to restrict the usage
-of swap on a pod-level, rather than container-level basis.
-
-For alpha, we are opting for the container-level basis to simplify the
-implementation (as the container runtimes already support configuration of swap
-with the `memory-swap-limit` parameter). This will also provide the necessary
-plumbing for container-level accounting of swap, if that is proposed in the
-future.
-
-In beta, we may want to revisit this.
-
-See the [Pod Resource Management design proposal] for more background on the
-cgroup limits the kubelet currently sets based on each QoS class.
-
-[Pod Resource Management design proposal]: https://github.com/kubernetes/design-proposals-archive/blob/master/node/pod-resource-management.md#pod-level-cgroups
+When `--fail-swap-on=false` is provided to Kubelet but swap is not configured
+otherwise it is guaranteed that, by default, no Kubernetes workloads would
+be able to utilize swap. However, everything outside of kubelet's reach
+(e.g. system daemons, kubelet, etc) would be able to use swap.
 
 ## Infrastructure Needed (Optional)
 
@@ -1456,4 +1467,7 @@ new subproject, repos requested, or GitHub details. Listing these here allows a
 SIG to get the process for these resources started right away.
 -->
 
-We may need Linux VM images built with swap partitions for e2e testing in CI.
+Added the "swap-conformance" lane for extensive swap testing under node pressure: [kubelet-swap-conformance-fedora-serial](https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-fedora-serial),
+kubelet-swap-conformance-ubuntu-serial](https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-ubuntu-serial).
+
+See #e2e tests above for more information

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -18,6 +18,10 @@
       - [Swap as the default](#swap-as-the-default)
   - [Steps to Calculate Swap Limit](#steps-to-calculate-swap-limit)
     - [Example](#example)
+  - [Swap-aware Evictions](#swap-aware-evictions)
+    - [Background](#background)
+    - [Defining &quot;accessible swap&quot;](#defining-accessible-swap)
+    - [Changes to the eviction manager's memory pressure handling](#changes-to-the-eviction-managers-memory-pressure-handling)
   - [User Stories](#user-stories)
     - [Improved Node Stability](#improved-node-stability)
     - [Long-running applications that swap out startup memory](#long-running-applications-that-swap-out-startup-memory)
@@ -178,6 +182,7 @@ will be necessary to implement the third scenario.
 - Cluster administrators can enable and configure kubelet swap utilization on a
   per-node basis.
 - Use of swap memory for cgroupsv2.
+- Swap-aware eviction manager.
 
 ### Non-Goals
 
@@ -304,6 +309,67 @@ Step 2: Determine swap limitation for the containers:
 In this example, Container A would have a swap limit of 19 GB, and Container B would have a swap limit of 9.5 GB.
 
 This approach allocates swap limits based on each container's memory request and adjusts the proportion based on the total swap memory available in the system. It ensures that each container gets a fair share of the swap space and helps maintain resource allocation efficiency.
+
+### Swap-aware Evictions
+
+As part of this KEP, the eviction manager will be enhanced to be swap-aware.
+This update will enable the eviction manager to account for swap usage in its decision-making process.
+By doing so, it will help prevent the system from exhausting swap space, thereby maintaining system stability and responsiveness.
+
+#### Background
+
+Before this KEP, kubelet's eviction manager completely overlooked swap memory, leading to several issues:
+* Inaccessible Swap: The memory eviction threshold is configured in such a way that swap is never triggered during node-level pressure, 
+as eviction occurs before the node starts swapping memory.
+* Unfairness & Instability: The eviction manager may evict the "wrong" or innocent pods, failing to address the actual memory pressure.
+* Unexpected Behavior: Pods that exceed their memory limits (with regular and swap memory) are not evicted first,
+even though they would immediately get killed if swap were not used.
+
+Here we present an extension to the eviction manager that will address these issues by becoming swap-aware.
+The proposed logic is fully backward compatible and requires no additional configuration, making it completely transparent to the user.
+
+To achieve this, we recommend enhancing the eviction manager's memory pressure handling to account for swap memory, rather than adding a distinct swap signal.
+Memory and swap are inherently connected and should be addressed as a single issue.
+By integrating swap memory into the eviction manager's logic, we ensure a more accurate and efficient handling of system resources.
+For example, separating memory and swap memory is problematic because swap is not used until memory is full.
+However, with the approach suggested in this KEP memory will not be considered full until the accessible swap is also full.
+
+#### Defining "accessible swap"
+
+Let `accessible swap` be the amount of swap that is accessible by pods according to the [LimitedSwap swap behavior](#steps-to-calculate-swap-limit).
+Note that the amount of accessible swap changes in time according to the pods running on the node.
+
+In addition, note that since only some of the Burstable QoS pods will have access to swap, the swap space will
+almost never be used in its entirety by workloads. In other words, this approach will effectively leave some of
+the swap space inaccessible for pods and reserved for system daemons and other system processes.
+
+#### Changes to the eviction manager's memory pressure handling
+
+When dealing with evictions, there are two main questions needed to be answered:
+how to identify when the node is under pressure and how to rank pods for eviction.
+
+The eviction manager will become swap aware by making the following changes to its memory pressure handling:
+- **How to identify pressure**: The eviction manager will consider the total sum of all running pods' accessible swap as additional memory capacity.
+- **How to rank pods for eviction**: In the context of ranking pods for evictions, swap memory is considered as additional "regular" memory
+and accessible swap is considered as additional memory request.
+This is relevant for checking whether memory requests are exceeded [1] or for identifying which pods uses more memory [2].
+
+In other words, the order of evictions documented [3] will have to change to the following:
+> ```
+> The kubelet uses the following parameters to determine the pod eviction order:
+> 1. Whether the pod's resource usage with swap (memory usage + swap usage) exceeds requests with swap (memory requests + swap requests).
+> 2. [Pod Priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
+> 3. The pod's resource usage (memory usage + swap usage) relative to requests (memory requests + swap requests).
+> ```
+
+That is, in (1) and (3) swap is considered as an additional resource usage and memory request.  Step (2) is unchanged.
+
+On nodes with swap disabled, the accessible swap will equal to zero and pods won't be able to use swap,
+hence the eviction manager will behave the same as before.
+
+[1] https://github.com/kubernetes/kubernetes/blob/d8093cc40394b8e25a864576fe6a38306730d3cb/pkg/kubelet/eviction/helpers.go#L684
+[2] https://github.com/kubernetes/kubernetes/blob/d8093cc40394b8e25a864576fe6a38306730d3cb/pkg/kubelet/eviction/helpers.go#L703
+[3] https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction
 
 ### User Stories
 
@@ -465,6 +531,9 @@ This can cause problems where workloads can use up all swap.
 If all swap is used up on a node, it can make the node go unhealthy.
 To avoid exhausting swap on a node, `UnlimitedSwap` was dropped from the API in beta2.
 
+It was determined that the eviction manager should still be able to protect the node in case of swap memory pressure.
+In this case, we will teach the eviction manager to be aware of swap as a resource to avoid exhausting swap resource.
+
 #### Security risk
 
 Enabling swap on a system without encryption poses a security risk, as critical information, such as Kubernetes secrets, may be swapped out to the disk. If an unauthorized individual gains access to the disk, they could potentially obtain these secrets. To mitigate this risk, it is recommended to use encrypted swap. However, handling encrypted swap is not within the scope of kubelet; rather, it is a general OS configuration concern and should be addressed at that level. Nevertheless, it is essential to provide documentation that warns users of this potential issue, ensuring they are aware of the potential security implications and can take appropriate steps to safeguard their system.
@@ -514,6 +583,7 @@ We summarize the implementation plan as following:
    the CRI on the amount of swap to allocate to each container. The container
    runtime will then write the swap settings to the container level cgroup.
 1. Add node stats to report swap usage.
+1. Enhance eviction manager to protect against swap memory running out.
 
 ### Enabling swap as an end user
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -449,11 +449,13 @@ As beta2 was being worked on, we discovered use cases where `--fail-swap-on=fals
 Kind e2e tests run kubelet with `--fail-swap-on=false` and
 the default developer configuration for `hack/local-up-cluster` allows for running developer clusters with swap enabled.
 
-We need to support the `--fail-swap-on=false` for both cgroup v1 and cgroupv2. We will not support KEP-2400 with cgroup v1.
-So when one wants to GA this feature, we need to have a way to disable workloads from using swap while keeping the feature toggle on.
-To address this, we will propose a new field to `MemorySwap` called `NoSwap`. This will disable swap usage on the node while keeping the feature active.
+Now, `--fail-swap-on=false` is supported for both cgroup v1 and cgroupv2 although KEP-2400 does not support cgroup v1.
+This is achieved by the newly introduced `MemorySwap` called `NoSwap`, which serves as the default swap behavior, that
+will disable swap usage on the node while keeping the feature active.
+In addition, nodes that support cgroups v1 only would be able to only use `NoSwap`, i.e. in such environments containers
+will be restricted from having access to swap. 
 
-This can address existing use cases where `--fail-swap-on=false` in cgroupv1 and still allow us to turn this feature on.
+This addresses existing use cases where `--fail-swap-on=false` in cgroupv1 and still allow us to turn this feature on.
 
 #### Exhausting swap resource
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -42,6 +42,7 @@
     - [KubeConfig addition](#kubeconfig-addition)
     - [CRI Changes](#cri-changes)
     - [Swap Metrics](#swap-metrics)
+    - [Add swap support to NFD](#add-swap-support-to-nfd)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
@@ -723,6 +724,30 @@ pods:
 ```
 
 (This output is simplified, for full examples please look at the description of: https://github.com/kubernetes/kubernetes/pull/118865)
+
+#### Add swap support to NFD
+
+Although not directly related to API changes since NFD is out-of-tree, bringing swap support to NFD is extremely
+valuable and relevant.
+It allows deferring the API changes discussion to the follow-up KEP that will focus on this subject specifically
+(for more info on the scope of this KEP and the follow-up KEPs look at the summary section above).
+
+With NFD, the end-user would be able to easily understand which nodes have swap enabled.
+In the following example, only worker nodes 1 and 3 have swap enabled.
+The user would be possible to easily check which nodes have swap enabled by performing the following:
+
+```shell
+> kubectl get nodes
+NAME                    STATUS   ROLES           AGE   VERSION
+k8s-dev-control-plane   Ready    control-plane   78s   v1.30.0
+k8s-dev-worker1         Ready    <none>          66s   v1.30.0
+k8s-dev-worker2         Ready    <none>          66s   v1.30.0
+k8s-dev-worker3         Ready    <none>          66s   v1.30.0
+
+> kubectl get nodes -o custom-columns=NAME:.metadata.name,LABELS:.metadata.labels | grep memory-swap:true | cut -d" " -f1
+k8s-dev-worker1
+k8s-dev-worker3
+```
 
 ### Test Plan
 

--- a/keps/sig-node/2400-node-swap/README.md
+++ b/keps/sig-node/2400-node-swap/README.md
@@ -854,6 +854,19 @@ For beta 1:
 - Add e2e tests that verify pod-level control of swap utilization.
 - Add e2e tests that verify swap performance with pods using a tmpfs.
 
+For beta 2:
+
+- Add Node-conformance tests for basic swap validation. To avoid disrupting node conformance lanes, only the
+cgroup knobs are validated to be defined as expected with no real memory stress or swap use.
+- Add a lane dedicated for swap testing, including stress tests and other tests that might be disruptive and intensive.
+These lanes are called "swap-conformance", and are (and should remain) consistently green:
+  - [kubelet-swap-conformance-fedora-serial](https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-fedora-serial): Green.
+  - [kubelet-swap-conformance-ubuntu-serial](https://testgrid.k8s.io/sig-node-kubelet#kubelet-swap-conformance-ubuntu-serial): Green.
+
+For GA:
+
+- Ensure that all e2e tests, especially swap-conformance tests, are consistently green.
+
 ### Graduation Criteria
 
 #### Alpha

--- a/keps/sig-node/2400-node-swap/kep.yaml
+++ b/keps/sig-node/2400-node-swap/kep.yaml
@@ -27,13 +27,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.30"
-  stable: "TBD"
+  stable: "v1.34"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Add updates, GA criterias and clarifications

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2400

<!-- other comments or additional information -->
- Other comments:

This PR updates the KEP in the following ways:

**Emphasize that this KEP is about basic swap enablement**
The original KEP indicated that pod-level swap APIs are out of scope:
https://github.com/kubernetes/enhancements/blob/155a949378fe85d4ca936176ad48103bf9567402/keps/sig-node/2400-node-swap/README.md?plain=1#L163-L166
https://github.com/kubernetes/enhancements/blob/155a949378fe85d4ca936176ad48103bf9567402/keps/sig-node/2400-node-swap/README.md?plain=1#L142-L144

However, the lack of APIs and the implicit nature of the current implementation sometimes brings suggestions to extend the API under this KEP.

This KEP focuses on a basic swap enablement. Follow-up KEPs regarding several topics (e.g. customization, zram/zswap suport, and more) will be introduced in the near future, in which we would be able to design and implement each extension in a focused way.

This PR updates the KEP to emphasize this approach.

**Swap-aware evictions**
This KEP also details how the eviction manager will be extended.
Implementation PR is available here: https://github.com/kubernetes/kubernetes/pull/129578.

 **beta3 and GA criterias**
The PR adds beta3 and GA criterias, alongside the intent to graduate to beta3 in version 1.33 and GA in 1.34.

 **Make sure PRR is ready**

 **Updates**
Since the last KEP updates, many improvements were made and many concerns were addressed. For example:
- Memory-backed volumes
- Added metrics
- Kubelet Configuration examples
- more

This PR updates the KEP to reflect these updates.