### PR TITLE
KEP-4222: Relax description of decode allocations fuzz test.

### DIFF
--- a/keps/sig-api-machinery/4222-cbor-serializer/README.md
+++ b/keps/sig-api-machinery/4222-cbor-serializer/README.md
@@ -700,8 +700,7 @@ As well as fuzz tests covering:
 
 - for all native types, native-to-JSON-to-unstructured and
   native-to-CBOR-to-unstructured is identical
-- the number of bytes allocated per decode is not more than directly
-  proportional to the input size
+- the number of bytes allocated per decode does not exceed a reasonable upper limit
 - roundtrip JSON-to-CBOR-to-JSON and CBOR-to-JSON-to-CBOR
 - roundtrip through implementations in at least some of the non-Go client
   languages


### PR DESCRIPTION


<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Relax description of decode allocations fuzz test.

<!-- link to the k/enhancements issue -->
- Issue link: https://kep.k8s.io/4222

<!-- other comments or additional information -->
- Other comments: The goal of this test was to be able to identify pathological inputs that cause the decoder to allocate excessive amounts of memory (for example, by trusting the length indicated by the initial bytes of a string and preallocating a slice of that length). That can be achieved without attempting to enforce a specific limit on the ratio between input length and bytes allocated, which is subject to many variables.
