### PR TITLE
Correction to the Job pod failure policy update to GA

### DIFF
--- a/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
+++ b/keps/sig-apps/3329-retriable-and-non-retriable-failures/README.md
@@ -1785,7 +1785,6 @@ Fourth iteration (1.29):
 - Address reviews and bug reports from Beta users
 - Improved tests coverage:
   * unit test for preemption by kube-scheduler, if feasible
-  * integration test for re-enabling of the feature gate
 - Write a blog post about the feature
 - Graduate e2e tests as conformance tests
 - Lock the `PodDisruptionConditions` and `JobPodFailurePolicy` feature-gates


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Correction to the GA graduation plan

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3329

<!-- other comments or additional information -->
- Other comments: I have realized the current graduation criteria are not consistent. We cannot add the test if we lock the feature gates JobPodFailurePolicy and PodDisruptionConditions. It is too late. Alternatively, we could move the lock to GA+1, and removal to GA+3. Since the disablement and re-enablement was tested manually for upgrade tests I propose to just drop the automated test: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures#were-upgrade-and-rollback-tested-was-the-upgrade-downgrade-upgrade-path-tested. 