### PR TITLE
KEP 1645: add a derived service annotation on ServiceImport

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -312,8 +312,11 @@ implementation requiring no changes to kube-proxy is to have the mcs-controller
 maintain ServiceImports and create "dummy" or "shadow" Service objects, named
 after a mcs-controller managed EndpointSlice that aggregates all cross-cluster
 backend IPs, so that kube-proxy programs those endpoints like a regular Service.
-Other implementations are encouraged as long as the properties of the API described
-in this document are maintained.
+An implementation using "shadow" Services should add the annotation
+`multicluster.kubernetes.io/derived-service` in the ServiceImport objects to
+reference the "shadow"/"derived" Service directly. Other implementations are
+encouraged as long as the properties of the API described in this document are
+maintained.
 
 ### User Stories
 


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: If the implementation is using derived Service suggest adding the annotation `multicluster.kubernetes.io/derived-service` to ServiceImport objects to point toward the actual derived Service.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1645

<!-- other comments or additional information -->
- Other comments: If the implementation is using derived Service suggest adding the annotation `multicluster.kubernetes.io/derived-service` to ServiceImport objects to point toward the actual derived Service. This may help third party controllers like GatewayAPI implementations to integrate/add MCS-API support. This formalize what was already being done in the mcs-api "reference implementation" here:
https://github.com/kubernetes-sigs/mcs-api/blob/2833f83cfbdc46d80e0e18111ec977c4ef16e51d/pkg/controllers/serviceimport.go#L80-L90.
