### PR TITLE
SIG-Multicluster leadership change: pmorie emeritus, skitt co-chair

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -65,7 +65,7 @@ aliases:
     - upodroid
   sig-multicluster-leads:
     - jeremyot
-    - pmorie
+    - skitt
   sig-network-leads:
     - aojea
     - danwinship


### PR DESCRIPTION
pmorie moving to emeritus, skitt becoming co-chair, jeremyot unchanged; see
https://groups.google.com/g/kubernetes-sig-multicluster/c/xhj2OnFO-8M for the discussion and lazy consensus (deadline July 1, 2024).