### PR TITLE
KEP-2718: Mark client exec proxy as withdrawn

### DIFF
--- a/keps/sig-auth/2718-20210511-client-exec-proxy/kep.yaml
+++ b/keps/sig-auth/2718-20210511-client-exec-proxy/kep.yaml
@@ -6,7 +6,7 @@ owning-sig: sig-auth
 participating-sigs:
   - sig-cli
   - sig-api-machinery
-status: implementable
+status: withdrawn
 creation-date: 2021-05-11
 reviewers:
   - "@mikedanese"


### PR DESCRIPTION

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Mark client exec proxy as withdrawn

<!-- link to the k/enhancements issue -->
- Issue link: #2718 

<!-- other comments or additional information -->
- Other comments: There have been no updates in 1.5 years nor have there been any community requests.  That combined with a high complexity implementation lead me to believe that we will not pursue this KEP.