### PR TITLE
KEP-4006: Adds GA requirement for websocket HTTPS proxy support

### DIFF
--- a/keps/sig-api-machinery/4006-transition-spdy-to-websockets/README.md
+++ b/keps/sig-api-machinery/4006-transition-spdy-to-websockets/README.md
@@ -754,6 +754,8 @@ in back-to-back releases.
 
 #### GA
 
+- Add WebSocket support for HTTPS proxies.
+  - See (https://github.com/kubernetes/kubernetes/issues/126134)
 - Conformance tests for `RemoteCommand` completed and enabled.
 - Conformance tests for `RemoteCommand` have been stable and
   non-flaky for two weeks.


### PR DESCRIPTION
* Adds GA requirement for currently missing websocket HTTPS proxy support.
  * See: https://github.com/kubernetes/kubernetes/issues/126134

https://github.com/kubernetes/enhancements/issues/4006
