### PR TITLE
KEP update to extend the Pod Failure Policy guide for FailIndex

### DIFF
--- a/keps/sig-apps/3850-backoff-limits-per-index-for-indexed-jobs/README.md
+++ b/keps/sig-apps/3850-backoff-limits-per-index-for-indexed-jobs/README.md
@@ -777,6 +777,8 @@ in back-to-back releases.
 
 - Address reviews and bug reports from Beta users
 - Write a blog post about the feature
+- Revisit extend the [hands-on guide for Pod failure policy](https://kubernetes.io/docs/tasks/job/pod-failure-policy/)
+  for using `FailIndex`
 - Graduate e2e tests as conformance tests
 - Lock the `JobBackoffLimitPerIndex` feature gate
 - Declare deprecation of the `JobBackoffLimitPerIndex` feature gate in documentation

--- a/keps/sig-apps/3850-backoff-limits-per-index-for-indexed-jobs/README.md
+++ b/keps/sig-apps/3850-backoff-limits-per-index-for-indexed-jobs/README.md
@@ -777,8 +777,8 @@ in back-to-back releases.
 
 - Address reviews and bug reports from Beta users
 - Write a blog post about the feature
-- Revisit extend the [hands-on guide for Pod failure policy](https://kubernetes.io/docs/tasks/job/pod-failure-policy/)
-  for using `FailIndex`
+- Revisit extending the [hands-on guide for Pod failure policy](https://kubernetes.io/docs/tasks/job/pod-failure-policy/)
+  to use `FailIndex`
 - Graduate e2e tests as conformance tests
 - Lock the `JobBackoffLimitPerIndex` feature gate
 - Declare deprecation of the `JobBackoffLimitPerIndex` feature gate in documentation


### PR DESCRIPTION

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP update to revisit extending the pod failure policy tutorial before GA

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3850

<!-- other comments or additional information -->
- Other comments: 
Follow up to discussion: https://github.com/kubernetes/website/pull/46896?notification_referrer_id=NT_kwDOAJ4RjbQxMTE2ODEwMjc3NzoxMDM1OTE4MQ#discussion_r1700516273