### PR TITLE
Fix title of KEP 3673 in metadata

### DIFF
--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
@@ -1,4 +1,4 @@
-title: KEP Template
+title: Kubelet limit of Parallel Image Pulls
 kep-number: 3673
 authors:
   - "@pacoxu"


### PR DESCRIPTION
This KEP currently shows up as `KEP Template` in aggregators like https://www.kubernetes.dev/resources/keps/; fix that.

cc @pacoxu
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->