### PR TITLE
KEP-3257: cluster trust bundles: add a new in-tree signer and its CTB

### DIFF
--- a/keps/sig-auth/3257-cluster-trust-bundles/README.md
+++ b/keps/sig-auth/3257-cluster-trust-bundles/README.md
@@ -346,10 +346,6 @@ Kubelet in the cluster.  When they are updated, workloads will need to receive
 the updates fairly quickly (within 5 minutes across the whole cluster), to
 accommodate emergency rotation of trust anchors for a private CA.
 
-Security: Should individual trust anchor set entries designate an OCSP endpoint
-to check for certificate revociation?  Or should we require the URL to be
-embedded in the issued certificates?  Note: This question is deferred from the 1.30 beta scope, and will be discussed as an addition to the beta scope in 1.31.
-
 ## Design Details
 
 ### ClusterTrustBundle Object
@@ -375,18 +371,16 @@ as long as their name does not contain a colon.
 Multiple ClusterTrustBundle objects may be associated with a single signer.
 While each object is independent at the API level, consumers (mostly Kubelet)
 will select trust anchors by a combination of field selector on signer name, and
-a label selector.  Signer controllers may follow the convention of making the
-label selector `kubernetes.io/cluster-trust-bundle-version=live` correspond to a
-meaningful set of trust anchors.  In general, users are expected to read the documentation for their signer controller implementation in order to determine which label selectors to use for their needs, including [canarying](#canarying-changes-to-a-clustertrustbundle).
+a label selector. In general, users are expected to read the documentation for their signer controller implementation in order to determine which label selectors to use for their needs, including [canarying](#canarying-changes-to-a-clustertrustbundle).
 
 ClusterTrustBundle objects support `.metadata.generation`.
 
 ClusterTrustBundle creates and updates that result in an empty
-`.spec.pemTrustAnchors` will be rejected during validation.
+`.spec.trustBundle` will be rejected during validation.
 
 All of the new objects and fields described in this section are gated by the
 ClusterTrustBundle kube-apiserver feature gate.  Unless the feature gate is
-enabled, usage of these alpha objects and fields will be rejected by
+enabled, usage of these objects and fields will be rejected by
 kube-apiserver.
 
 #### API Object Definition

--- a/keps/sig-auth/3257-cluster-trust-bundles/kep.yaml
+++ b/keps/sig-auth/3257-cluster-trust-bundles/kep.yaml
@@ -27,12 +27,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.29"
-  beta: "v1.30"
+  beta: "v1.32"
   stable: ""
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Adds a mention of a new default trust bundle and its signer + one more non-goal

- Issue link: #3257 

- Other comments:

/cc ahmedtd enj liggitt 