### PR TITLE
4330: compatibility versions: add linting as beta criteria

### DIFF
--- a/keps/sig-architecture/4330-compatibility-versions/README.md
+++ b/keps/sig-architecture/4330-compatibility-versions/README.md
@@ -881,6 +881,7 @@ We intend to have this up and running for Beta
   (Leveraging work from KEP-4355 if possible)
 - All existing features migrated to versioned feature gate - [kubernetes #125031](https://github.com/kubernetes/kubernetes/issues/125031)
 - Verification machinery added - [kubernetes #125032](https://github.com/kubernetes/kubernetes/issues/125032) 
+- Integrate [test/featuregate_linter](https://github.com/kubernetes/kubernetes/blob/35488ef5c7212a3d491b86e02b1ba05dbbc4b894/test/featuregates_linter/README.md) into golangci-lint
 
 <!--
 **Note:** *Not required until targeted at a release.*


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: add linting as beta criteria

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4330

<!-- other comments or additional information -->
- Other comments: As discussed in
https://github.com/kubernetes/kubernetes/pull/125830#issuecomment-2261025071, the stand-alone linter was okay as the initial solution, but integration into golangci-lint is expected to perform better and thus should be done before graduation to beta.
