### PR TITLE
KEP-3221: update kep milestone and stage

### DIFF
--- a/keps/prod-readiness/sig-auth/3221.yaml
+++ b/keps/prod-readiness/sig-auth/3221.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@jpbetz"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-auth/3221-structured-authorization-configuration/kep.yaml
+++ b/keps/sig-auth/3221-structured-authorization-configuration/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 3221
 authors:
   - "@100mik"
   - "@palnabarun"
+  - "@ritazh"
 owning-sig: sig-auth
 status: implementable
 creation-date: 2022-06-21
@@ -14,11 +15,12 @@ approvers:
   - "@liggitt"
 see-also:
   - https://github.com/kubernetes/kubernetes/issues/101762
-stage: alpha
-latest-milestone: "v1.30"
+stage: stable
+latest-milestone: "v1.32"
 milestone:
   alpha: "v1.29"
   beta: "v1.30"
+  stable: "v1.32"
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:


### PR DESCRIPTION
- Update KEP latest milestone to v1.31.
  - The feature remains in beta in v1.31. plan to move to stable in v1.32
  
Issue link: https://github.com/kubernetes/enhancements/issues/3221

/sig auth
/assign liggitt