### PR TITLE
KEP-4004: Replace with Deprecated feature gates

### DIFF
--- a/keps/sig-network/4004-deprecate-kube-proxy-version/README.md
+++ b/keps/sig-network/4004-deprecate-kube-proxy-version/README.md
@@ -18,7 +18,6 @@
       - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
-    - [Beta](#beta)
     - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
@@ -148,10 +147,7 @@ to implement this enhancement.
 
 - Created the feature gate, disabled by default.
 - Started looking for components that might be using the deprecated field.
-
-#### Beta
-
-- Make sure that upgrades to the Beta version will work across supported levels of [version skew](https://kubernetes.io/releases/version-skew-policy/).
+- Make sure it works fine on supported versions of [version skew](https://kubernetes.io/releases/version-skew-policy/).
 
 #### GA
 
@@ -191,7 +187,7 @@ I manually confirmed that restarting kubelet behaves as expected with feature ga
 
 I've tried to simulate this manually by running (using `local-cluster-up.sh).
 
-Cluster Version v1.31+, `FEATURE_GATES=DisableNodeKubeProxyVersion=false` (manual setting):
+Cluster Version v1.31+, `FEATURE_GATES=DisableNodeKubeProxyVersion=false` (default value):
 
 ```
 ~ kubectl get nodes 127.0.0.1 -oyaml
@@ -290,7 +286,7 @@ N/A
    
    * The value of the `kubeProxyVersion` field in nodeInfo is not empty.
    
-2. Cluster Version v1.31+ `FEATURE_GATES=DisableNodeKubeProxyVersion=true` (default value)
+2. Cluster Version v1.31+ `FEATURE_GATES=DisableNodeKubeProxyVersion=true` (manual setting)
 
    ```
    git checkout master
@@ -338,7 +334,7 @@ N/A
    
    * The value of the `kubeProxyVersion` field in nodeInfo is empty.
    
-4. Cluster Version v1.31+ `FEATURE_GATES=DisableNodeKubeProxyVersion=false` (manual setting)
+4. Cluster Version v1.31+ `FEATURE_GATES=DisableNodeKubeProxyVersion=false` (default value)
 
    ```
    git checkout master
@@ -422,6 +418,8 @@ N/A.
 \- 2023-05-15: Initial draft KEP
 
 \- 2024-06-10: Promoted to beta and add manual upgrade and rollback tests
+
+\- 2024-08-25: Replace with Deprecated feature gates.
 
 ## Drawbacks
 

--- a/keps/sig-network/4004-deprecate-kube-proxy-version/kep.yaml
+++ b/keps/sig-network/4004-deprecate-kube-proxy-version/kep.yaml
@@ -26,8 +26,7 @@ latest-milestone: "v1.31"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.29"
-  beta: "v1.31"
+  deprecated: "v1.29"
   stable: "v1.33"
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: We replaced the `DisableNodeKubeProxyVersion` feature gate with Deprecated in https://github.com/kubernetes/kubernetes/pull/126720, modifying the KEP to be consistent with the implementation

<!-- link to the k/enhancements issue -->
- Issue link:  https://github.com/kubernetes/enhancements/issues/4004

<!-- other comments or additional information -->
- Other comments: