### PR TITLE
KEP-4420: Promote RetryGenerateName to GA in 1.32

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/4420.yaml
+++ b/keps/prod-readiness/sig-api-machinery/4420.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/4420-retry-generate-name/README.md
+++ b/keps/sig-api-machinery/4420-retry-generate-name/README.md
@@ -530,6 +530,7 @@ high retry load.
 - 2024-01-31: KEP merged as implementable
 - Kubernetes v1.30 - Implementation available as an off-by-default alpha feature
 - Kubernetes v1.31 - Implementation available as an on-by-default beta feature
+- Kubernetes v1.32 - Implementation available as a locked-to-enabled stable feature
 
 ## Drawbacks
 

--- a/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
+++ b/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
@@ -12,12 +12,12 @@ approvers:
   - "@deads2k"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION

- One-line PR description: Promote RetryGenerateName to GA in 1.32


- Issue link: https://github.com/kubernetes/enhancements/issues/4420
