### PR TITLE
KEP-3331: update kep latest milestone to v1.32

### DIFF
--- a/keps/sig-auth/3331-structured-authentication-configuration/kep.yaml
+++ b/keps/sig-auth/3331-structured-authentication-configuration/kep.yaml
@@ -12,11 +12,10 @@ approvers:
 creation-date: "2022-06-02"
 status: implementable
 stage: beta
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 milestone:
   alpha: "v1.29"
   beta: "v1.30"
-  stable: "v1.32"
 feature-gates:
 - name: StructuredAuthenticationConfiguration
   components:


### PR DESCRIPTION
- Update KEP latest milestone to `v1.32`.
  - The feature will remain in beta in v1.32 but we plan to make some code changes in v1.32 release for metrics and tighter validation.
- Issue link: https://github.com/kubernetes/enhancements/issues/3331

/sig auth
/assign enj