### PR TITLE
Job Success Policy - add a GA graduation point to verify success reason in conformance tests

### DIFF
--- a/keps/sig-apps/3998-job-success-completion-policy/README.md
+++ b/keps/sig-apps/3998-job-success-completion-policy/README.md
@@ -452,6 +452,8 @@ to implement this enhancement.
 #### GA
 
 - No negative feedback.
+- Verify reason for the Job's `Complete` condition in all e2e conformance tests
+  (see [example](https://github.com/kubernetes/kubernetes/blob/e5dd48efd07e8a052604b3073e0fafe7361ca689/test/e2e/apps/job.go#L804))
 
 ### Upgrade / Downgrade Strategy
 


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
One-line PR description: Add a graduation point to verify reason for the Job's complete condition

<!-- link to the k/enhancements issue -->
Issue link: https://github.com/kubernetes/enhancements/issues/3998

<!-- other comments or additional information -->
Other comments:
- The update was prompted by the [comment](https://github.com/kubernetes/kubernetes/pull/126169#discussion_r1759182682)
- We don't verify currently the reason for the Complete condition in conformance tests, as the conformance suite does not enable beta features (including "Success Policy" feature which changed the reason for the condition)