### PR TITLE
Owners scale

### DIFF
--- a/keps/sig-node/1769-memory-manager/OWNERS
+++ b/keps/sig-node/1769-memory-manager/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - klueska # scaling the approvers for individual KEPs

--- a/keps/sig-node/2000-graceful-node-shutdown/OWNERS
+++ b/keps/sig-node/2000-graceful-node-shutdown/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - yujuhong # scaling the approvers for individual KEPs

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/OWNERS
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - klueska # scaling the approvers for individual KEPs

--- a/keps/sig-node/3545-improved-multi-numa-alignment/OWNERS
+++ b/keps/sig-node/3545-improved-multi-numa-alignment/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - klueska # scaling the approvers for individual KEPs

--- a/keps/sig-node/3960-pod-lifecycle-sleep-action/OWNERS
+++ b/keps/sig-node/3960-pod-lifecycle-sleep-action/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - SergeyKanzhelev # scaling the approvers for individual KEPs

--- a/keps/sig-node/3983-drop-in-configuration/OWNERS
+++ b/keps/sig-node/3983-drop-in-configuration/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - SergeyKanzhelev # scaling the approvers for individual KEPs

--- a/keps/sig-node/4176-cpumanager-spread-cpus-preferred-policy/OWNERS
+++ b/keps/sig-node/4176-cpumanager-spread-cpus-preferred-policy/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - klueska # scaling the approvers for individual KEPs

--- a/keps/sig-node/4369-allow-special-characters-environment-variable/OWNERS
+++ b/keps/sig-node/4369-allow-special-characters-environment-variable/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - SergeyKanzhelev # scaling the approvers for individual KEPs

--- a/keps/sig-node/4438-container-restart-termination/OWNERS
+++ b/keps/sig-node/4438-container-restart-termination/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - SergeyKanzhelev # scaling the approvers for individual KEPs

--- a/keps/sig-node/4622-topologymanager-max-allowable-numa-nodes/OWNERS
+++ b/keps/sig-node/4622-topologymanager-max-allowable-numa-nodes/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - klueska # scaling the approvers for individual KEPs


### PR DESCRIPTION
In SIG Node we want to start scaling ownership for KEPs. We will start with KEPs introducing some already accepted concepts so the person, assigned as an approver can help move the KEP forward thru stages.

More complex KEPs and new KEPs will be kept for tech-leads to approve.

/sig node

I used these assignments and applied my judgement. Open for corrections if I have mistaken in any of those: https://github.com/orgs/kubernetes/projects/186/views/7?filterQuery=status%3A%22Draft+Stage%22%2C%22Proposed+for+consideration%22+&visibleFields=%5B%22Title%22%2C%22Status%22%2C130447354%2C126885563%2C130446877%2C130446939%2C%22Reviewers%22%2C130446997%5D&sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=130447354&sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=126885563 