### PR TITLE
KEP-3104: Update latest milestone to 1.32

### DIFF
--- a/keps/sig-cli/3104-introduce-kuberc/kep.yaml
+++ b/keps/sig-cli/3104-introduce-kuberc/kep.yaml
@@ -26,11 +26,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.31"
+  alpha: "v1.32"
   beta: ""
   stable: ""
 


### PR DESCRIPTION
- One-line PR description: Since https://github.com/kubernetes/kubernetes/pull/125230 has been deferred to 1.32, this PR updates the latest milestone to 1.32

- Issue link: https://github.com/kubernetes/enhancements/issues/3104

- Other comments: