### PR TITLE
[KEP 3960]: Promote PodLifecycleSleepAction to stable 

### DIFF
--- a/keps/prod-readiness/sig-node/3960.yaml
+++ b/keps/prod-readiness/sig-node/3960.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-node/3960-pod-lifecycle-sleep-action/README.md
+++ b/keps/sig-node/3960-pod-lifecycle-sleep-action/README.md
@@ -47,8 +47,8 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [x] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [x] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [x] (R) Production readiness review completed
@@ -289,6 +289,7 @@ Tests List
 
 - No negative feedback
 - No bug issues reported
+- [e2e tests](https://github.com/kubernetes/kubernetes/blob/94df29b8f278503c3b332280132202096e247128/test/e2e/common/node/lifecycle_hook.go#L550) are promoted to conformance
 
 ### Upgrade / Downgrade Strategy
 
@@ -345,7 +346,7 @@ The change is opt-in, it doesn't impact already running workloads.
 
 ###### What specific metrics should inform a rollback?
 
-Metric `sleep_action_terminated_early_total` will be added in beta. 
+Users have to check Metric `sleep_action_terminated_early_total`.
 If it increases unreasonably, then user should check if something goes wrong and may need a rollback.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
@@ -454,7 +455,8 @@ Disable PodLifecycleSleepAction feature gate, and restart related components.
 
 - 2023-04-22: Initial draft KEP
 - 2023-12-20: Target to beta in v1.30 
-
+- 2024-09-21: Target to stable in v1.32
+  
 ## Drawbacks
 
 N/A

--- a/keps/sig-node/3960-pod-lifecycle-sleep-action/kep.yaml
+++ b/keps/sig-node/3960-pod-lifecycle-sleep-action/kep.yaml
@@ -15,12 +15,12 @@ see-also: []
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
PodLifecycleSleepAction is planned to graduate to ga in 1.32.
<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3960

<!-- other comments or additional information -->
- Other comments: