### PR TITLE
Promote CRD field selectors to GA

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/4358.yaml
+++ b/keps/prod-readiness/sig-api-machinery/4358.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/4358-custom-resource-field-selectors/README.md
+++ b/keps/sig-api-machinery/4358-custom-resource-field-selectors/README.md
@@ -737,7 +737,8 @@ Below are some examples to consider, in addition to the aforementioned [maturity
 
 ## GA
 
-- Add field selection support to informers
+- Add test coverage for informers
+- Promote e2e tests to conformance
 
 <!--
 #### GA

--- a/keps/sig-api-machinery/4358-custom-resource-field-selectors/kep.yaml
+++ b/keps/sig-api-machinery/4358-custom-resource-field-selectors/kep.yaml
@@ -16,7 +16,7 @@ see-also:
   - "/keps/sig-api-machinery/95-custom-resource-definitions"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
@@ -27,6 +27,7 @@ latest-milestone: "v1.31"
 milestone:
   alpha: "v1.30"
   beta: "v1.31"
+  stable: "v1.32"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
We realized when discussing informers that client side evaluation of field selectors is not possible since built-in field selectors have custom server-side logic and so it is not possible to perform client side field selection based purely on the name of the field selector.