### PR TITLE
KEP-4381: DRA: PRR and API for beta of structured parameters in 1.32

### DIFF
--- a/keps/prod-readiness/sig-node/4381.yaml
+++ b/keps/prod-readiness/sig-node/4381.yaml
@@ -4,3 +4,5 @@
 kep-number: 4381
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/4381-dra-structured-parameters/kep.yaml
+++ b/keps/sig-node/4381-dra-structured-parameters/kep.yaml
@@ -20,16 +20,17 @@ see-also:
   - "/keps/sig-node/3063-dynamic-resource-allocation"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.30"
+  beta: "v1.32"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -40,8 +41,18 @@ feature-gates:
       - kube-controller-manager
       - kube-scheduler
       - kubelet
+  - name: DRAAdminAccess
+    components:
+      - kube-apiserver
+      - kube-controller-manager
+      - kube-scheduler
 disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  # - my_feature_metric
+  - resourceclaim_controller_create_total
+  - resourceclaim_controller_create_failures_total
+  - workqueue_* with name="resource_claim" in kube-controller-manager
+  - resourceclaim_controller_resource_claims
+  - resourceclaim_controller_allocated_resource_claims
+  - dra_operations_seconds in kubelet


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: PRR and API for beta of structured parameters in 1.32

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4381

<!-- other comments or additional information -->
- Other comments:

Much of the PRR text that was originally written for "classic DRA" applies also to "structured parameters". It gets moved from #3063 to #4381, with some minor adaptions. The placeholder comments get restored in #3063 because further work on the KEP would be needed to move it forward - if it gets moved forward at all instead of being abandoned.

The v1beta1 API will be almost identical to the v1alpha3 API, with just some minor tweaks to fix oversights.

The kubelet gRPC gets bumped with no changes. Nonetheless, drivers should get updated, which can be done by updating the Go dependencies and optionally changing the API import.
