### PR TITLE
KEP-4247: Update criteria targeting to enable the QueueingHints by default

### DIFF
--- a/keps/sig-scheduling/4247-queueinghint/kep.yaml
+++ b/keps/sig-scheduling/4247-queueinghint/kep.yaml
@@ -18,12 +18,12 @@ see-also:
 
 stage: beta
 
-latest-milestone: "v1.29"
+latest-milestone: "v1.32"
 
 milestone:
   alpha: "v1.26" # This KEP stems from /keps/sig-node/3063-dynamic-resource-allocation.
   beta: "v1.28"
-  stable: "v1.32"
+  stable: "v1.34"
 
 feature-gates:
   - name: SchedulerQueueingHints


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update the metrics and beta criteria as we are targeting to enable the feature by default in v1.32.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4247

<!-- other comments or additional information -->
- Other comments: