### PR TITLE
KEP-753: Update documentation to clarify `restartPolicy` behavior

### DIFF
--- a/keps/sig-node/753-sidecar-containers/README.md
+++ b/keps/sig-node/753-sidecar-containers/README.md
@@ -391,14 +391,10 @@ and more details can be found in the section
 Sidecar containers will not block Pod completion - if all regular containers
 complete, sidecar containers will be terminated.
 
-During the sidecar startup stage the restart behavior will be similar to init
-containers. If Pod `restartPolicy` is `Never`, sidecar container failed during
-startup will NOT be restarted and the whole Pod will fail. If Pod
-`restartPolicy` is `Always` or `OnFailure`, it will be restarted.
-
-Once sidecar container is started (`postStart` completed and startup probe
-succeeded), this containers will be restarted even when the Pod `restartPolicy`
-is `Never` or `OnFailure`. 
+The `restartPolicy` field for individual init containers can override the
+Pod-level `restartPolicy` for sidecar containers. As a result, even if the Pod's
+`restartPolicy` is set to `Never` or `OnFailure`, sidecar containers will still
+be restarted.
 
 Note, a separate KEP https://github.com/kubernetes/enhancements/issues/4438 will enable
 sidecar containers to be restarted even during Pod termination.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link: #753

<!-- other comments or additional information -->
- Other comments:
https://github.com/kubernetes/kubernetes/issues/120234

The implementation is different from the current documentation.
This updates the documentation to clarify the relationship between the container-level restartPolicy and the pod-level restartPolicy.

We may introduce a new concept (or policy) for the restart behavior of the initialization.

/cc @SergeyKanzhelev 