### PR TITLE
KEP4368-Job managedBy - update latest-milestone

### DIFF
--- a/keps/sig-apps/4368-support-managed-by-for-batch-jobs/kep.yaml
+++ b/keps/sig-apps/4368-support-managed-by-for-batch-jobs/kep.yaml
@@ -23,7 +23,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
One-line PR description: Bump latest-milestone to 1.32

Issue link: https://github.com/kubernetes/enhancements/issues/4368

Other comments:
- The main KEP update changes for 1.32 were done in https://github.com/kubernetes/enhancements/pull/4856, this PR is to align the omitted latest-milestone as per https://github.com/kubernetes/enhancements/issues/4368#issuecomment-2381647225