### PR TITLE
KEP-Template: Clarify the stage name of deprecated feature gates

### DIFF
--- a/api/approval.go
+++ b/api/approval.go
@@ -41,7 +41,8 @@ type PRRApproval struct {
 	Beta       *PRRMilestone `json:"beta" yaml:"beta,omitempty"`
 	Stable     *PRRMilestone `json:"stable" yaml:"stable,omitempty"`
 	Deprecated *PRRMilestone `json:"deprecated" yaml:"deprecated,omitempty"`
-	Removed    *PRRMilestone `json:"removed", yaml:"removed,omitempty"`
+	Removed    *PRRMilestone `json:"removed" yaml:"removed,omitempty"`
+	Disabled   *PRRMilestone `json:"disabled" yaml:"disabled,omitempty"`
 
 	// TODO(api): Move to separate struct for handling document parsing
 	Error error `json:"-" yaml:"-"`

--- a/api/proposal.go
+++ b/api/proposal.go
@@ -36,12 +36,18 @@ const (
 	AlphaStage  Stage = "alpha"
 	BetaStage   Stage = "beta"
 	StableStage Stage = "stable"
+	Deprecated  Stage = "deprecated"
+	Disabled    Stage = "disabled"
+	Removed     Stage = "removed"
 )
 
 var ValidStages = []Stage{
 	AlphaStage,
 	BetaStage,
 	StableStage,
+	Deprecated,
+	Disabled,
+	Removed,
 }
 
 func (s Stage) IsValid() error {
@@ -138,6 +144,7 @@ type Milestone struct {
 	Stable     string `json:"stable" yaml:"stable"`
 	Deprecated string `json:"deprecated" yaml:"deprecated,omitempty"`
 	Removed    string `json:"removed" yaml:"removed,omitempty"`
+	Disabled   string `json:"disabled" yaml:"disabled,omitempty"`
 }
 
 type FeatureGate struct {

--- a/keps/NNNN-kep-template/kep.yaml
+++ b/keps/NNNN-kep-template/kep.yaml
@@ -22,6 +22,8 @@ replaces:
   - "/keps/sig-ccc/3456-replaced-kep"
 
 # The target maturity stage in the current dev cycle for this KEP.
+# If the purpose of this KEP is to deprecate a user-visible feature
+# and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
 stage: alpha|beta|stable
 
 # The most recent milestone for which work toward delivery of this KEP has been


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:  Clarify the stage name of deprecated feature gates

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: This is a trivial matter, but we had some discussions about it before, so I would like to bring it up here for further discussion. Ref: https://github.com/kubernetes/enhancements/pull/4803/files#r1747083311

For us, deprecating a user-visible feature, or adding a bug fix that could be seen as 'removal', requires a small KEP for discussion and to document them and we also should add a Deprecated feature gate for such cases.

For these Deprecated feature gates, their lifecycle is shorter than a full feature gate lifecycle, typically following featuregate.Deprecated → wait a few releases → remove. So, we only need two phases to describe them, but we haven't clearly defined the names of these phases yet.

Some useful references: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/feature-gates.md#:~:text=Bug%20fixes%20that,can%20be%20disabled.

https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/feature-gates.md#deprecation