### PR TITLE
KEP 1645: remove MCS EndpointSlice ownership requirement

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -883,8 +883,9 @@ clusterset, associated with the derived `ServiceImport`. One or more
 `EndpointSlice` containing only endpoints from a single source cluster. These
 `EndpointSlice` objects will be marked as managed by the clusterset service
 controller, so that the endpoint slice controller doesn’t delete them.
-`EndpointSlices` will have an owner reference to their associated
-`ServiceImport`.
+
+When a service is un-exported, the associated EndpointSlices will be deleted.
+The specific mechanism by which they are deleted is an implementation detail.
 
 Since a given `ServiceImport` may be backed by multiple `EndpointSlices`, a
 given `EndpointSlice` will reference its `ServiceImport` using the label


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Remove MCS EndpointSlice ownership requirement

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1645

<!-- other comments or additional information -->
- Other comments: It was discussed at a recent sig meeting that the KEP shoudn't mandate an MCS EndpointSlice to have an OwnerReference to its ServiceImport as long as there is another cleanup mechanism in place.