### PR TITLE
KEP-4601: moving authorize with selectors (4601) to beta

### DIFF
--- a/keps/prod-readiness/sig-auth/4601.yaml
+++ b/keps/prod-readiness/sig-auth/4601.yaml
@@ -1,3 +1,5 @@
 kep-number: 4601
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@jpbetz"

--- a/keps/sig-auth/4601-authorize-with-selectors/kep.yaml
+++ b/keps/sig-auth/4601-authorize-with-selectors/kep.yaml
@@ -26,13 +26,16 @@ latest-milestone: "v1.31"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.31"
-  beta: "TBD"
+  beta: "v1.32"
   stable: "TBD"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: AuthorizeWithSelectors
+    components:
+      - kube-apiserver
+  - name: AuthorizeNodeWithSelectors
     components:
       - kube-apiserver
 disable-supported: true


### PR DESCRIPTION
- One-line PR description: Updating PRR and testing section for moving to beta

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4601

<!-- other comments or additional information -->
- Other comments:

/assign @enj @jpbetz 