### PR TITLE
KEP-3063: Classic DRA: withdraw the KEP

### DIFF
--- a/keps/sig-node/3063-dynamic-resource-allocation/README.md
+++ b/keps/sig-node/3063-dynamic-resource-allocation/README.md
@@ -156,6 +156,14 @@ parameters" KEP](../4381-dra-structured-parameters/README.md) added an
 extension. Now the roles are reversed: #4381 defines the base functionality
 and this KEP is an optional extension.
 
+In Kubernetes 1.32, this KEP has been **withdrawn** and all code related to it
+gets removed. #4381 continues. The main objections against this KEP that
+led to this decision were:
+- Lack of support for cluster autoscaling because a cluster autoscaler cannot
+  reason about resource availability when adding or removing nodes.
+- Complex back-and-forth through the apiserver while scheduler and DRA
+  drivers negotiate how to allocate a ResourceClaim.
+
 With #4381, DRA drivers are limited by what the structured parameter model(s)
 defined by Kubernetes support. New requirements for future hardware may depend
 on changing Kubernetes first.

--- a/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
+++ b/keps/sig-node/3063-dynamic-resource-allocation/kep.yaml
@@ -6,7 +6,7 @@ owning-sig: sig-node
 participating-sigs:
   - sig-scheduling
   - sig-autoscaling
-status: implementable
+status: withdrawn
 creation-date: 2021-05-17
 reviewers:
   - "@ahg-g"
@@ -24,7 +24,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Classic DRA: withdraw the KEP

- Issue link: https://github.com/kubernetes/enhancements/issues/3063

- Other comments: There isn't sufficient justification for keeping it around when there is no clear path forward.
