### PR TITLE
KEP-4444: add "prefer same node" semantics to PreferClose

### DIFF
--- a/keps/sig-network/4444-service-traffic-distribution/README.md
+++ b/keps/sig-network/4444-service-traffic-distribution/README.md
@@ -363,8 +363,6 @@ NOTE: The expectation remains that *all* endpoints within an EndpointSlice must
   Aware
   Hints](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/2433-topology-aware-hints/README.md#kube-proxy), i.e. _"This is to provide safer transitions between enabled and disabled states. Without this fallback, endpoints could easily get overloaded as hints were being added or removed from some EndpointSlices but had not yet propagated to all of them."_
 
-<<[UNRESOLVED Name for the field is being discussed]>>
-
 ### Choice of field name
 The name `trafficDistribution` is meant to capture the highly
 implementation-specific nature of this field and how it affects the routing of
@@ -386,8 +384,6 @@ traffic
 * Use of the word "selection" for a name like `endpointSelection` were avoided
   so as not to confuse with the actual process of selecting the complete set of
   pods backing a service.
-
-<<[/UNRESOLVED]>>
 
 ### Intersection with internal/externalTrafficPolicy
 


### PR DESCRIPTION
- One-line PR description: Adds "prefer same node" / "node local topology" semantics
- Issue link: #4444
- Other comments:

Previously introduced as `internalTrafficPolicy: PreferLocal` in #3016 and then reworked as "node-level topology" in #3293 (which was closed before we came up with any specific API).

The goal here is "pods should connect to the local CoreDNS endpoint, if there is one".

Given that "PreferClose" has an intentionally vague name (which, in particular, does not mention "zones"), it seemed to make more sense to add prefer-same-node semantics to "PreferClose" than to add a new traffic distribution ("PreferREALLYClose"?) for this. The proposed rule for deciding when prefer-same-node can be used is:

      * the Service has `PreferClose` traffic distribution, and
      * the Service has endpoints on all or all-but-one of the Ready nodes, and
      * the endpoints of the Service are Pods that have `OwnerReferences` indicating
        that they are all part of the same DaemonSet.

(Bringing this up now because I have reason to want to kill off our downstream "prefer same node just for CoreDNS" patch again.)

I'm not sure if we'd need a new feature gate for this new behavior?

In the past, it has been suggested that this is what NodeLocal DNSCache is for, but NodeLocal DNSCache is just a bad partial reimplementation of Services, to make up for the fact that the real Service API doesn't have a prefer-same-node feature... (Among the reasons that it is bad: it doesn't support fallback-to-other-nodes when the DNS pods are being upgraded.)

/cc @aojea @thockin @gauravkghildiyal @robscott 