### PR TITLE
[cleanup] update KEP-3673 status: e2e added in v1.32 for beta

### DIFF
--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
@@ -6,7 +6,7 @@ authors:
 owning-sig: sig-node
 status: implementable
 creation-date: 2023-01-05
-last-updated: 2024-01-29
+last-updated: 2024-10-31
 reviewers:
   - "@SergeyKanzhelev"
 approvers:
@@ -18,10 +18,10 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.32"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
-  beta: "v1.30"
-  stable: "v1.32"
+  beta: "v1.32"
+  stable: "v1.34"


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update the status of the KEP
  - Adding e2e test means the FG is beta: https://github.com/kubernetes/kubernetes/pull/121604. Not FG.

<!-- link to the k/enhancements issue -->
- Issue link: #3673
