### PR TITLE
KEP 1880: graduation to GA

### DIFF
--- a/keps/prod-readiness/sig-network/1880.yaml
+++ b/keps/prod-readiness/sig-network/1880.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@soltysh"
+stable:
+  approver: "@soltysh"

--- a/keps/sig-network/1880-multiple-service-cidrs/kep.yaml
+++ b/keps/sig-network/1880-multiple-service-cidrs/kep.yaml
@@ -20,18 +20,18 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
   beta: "v1.31"
-  stable:
+  stable: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: graduate to ga

- Issue link: https://github.com/kubernetes/enhancements/issues/1880

- Other comments:

There was only one bug opened during this time https://github.com/kubernetes/kubernetes/issues/127588 that was caused by a copy and paste error.

It is available in GKE https://cloud.google.com/kubernetes-engine/docs/how-to/use-beta-apis and used in production clusters.

It can be used by OSS users with installers that allow to set the feature gates and enable the beta apis, see kops https://github.com/kubernetes/test-infra/pull/33864/

It is been tested by the community https://github.com/spidernet-io/spiderpool/pull/4089#issuecomment-2505499043

There is also an external blog about it https://engineering.doit.com/scaling-kubernetes-how-to-seamlessly-expand-service-ip-ranges-246f392112f8

The feature has been 2 releases in beta, v1.31 and v1.32, it is being used in production and there is proof of usage and testing beyond kubernetes project, it should be enough signal to move it to GA and avoid having a permanent beta API

