### PR TITLE
KEP-4330: match beta goal version ranges to version ranges in beta graduation criteria (N-3)

### DIFF
--- a/keps/sig-architecture/4330-compatibility-versions/README.md
+++ b/keps/sig-architecture/4330-compatibility-versions/README.md
@@ -276,8 +276,8 @@ release for features to settle in as is typically needed for rollback support.
   - In alpha we intend to support:
     - `--emulation-version` range of `binaryMinorVersion`..`binaryMinorVersion-1`
   - In beta, we intend to extend support to:
-    - `--emulation-version` range of `binaryMinorVersion`..`binaryMinorVersion-1`
-    - `--min-compatibility-version` to `binaryMinorVersion`..`binaryMinorVersion-1`
+    - `--emulation-version` range of `binaryMinorVersion`..`binaryMinorVersion-3`
+    - `--min-compatibility-version` to `binaryMinorVersion`..`binaryMinorVersion-3`
 
 ### Non-Goals
 


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Correct typos in goals section.

<!-- link to the k/enhancements issue -->
- Issue link: #4330 

<!-- other comments or additional information -->
- Other comments: The [beta graduation criteria](https://github.com/kubernetes/enhancements/blob/72341d3c572566324fffdc8409c1f1e93b354f75/keps/sig-architecture/4330-compatibility-versions/README.md?plain=1#L878-L879) express a wider range of support for the compatibility and emulation versions (N-3 minor versions) than the [beta portion of the goals](https://github.com/kubernetes/enhancements/blob/72341d3c572566324fffdc8409c1f1e93b354f75/keps/sig-architecture/4330-compatibility-versions/README.md?plain=1#L278-L280) section (N-1 minor versions). The content of other sections, including the example in Feature Gate Lifecycles, and the discussion in #4395 suggests N-3 was intended. Fix for clarity.