### PR TITLE
KEP-3288: correct the feature gate's name

### DIFF
--- a/keps/sig-node/3288-separate-stdout-from-stderr/kep.yaml
+++ b/keps/sig-node/3288-separate-stdout-from-stderr/kep.yaml
@@ -29,7 +29,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: "SplitStdoutAndStderr"
+  - name: "PodLogsQuerySplitStreams"
     components:
       - kubelet
       - kube-apiserver


### PR DESCRIPTION
The feature gate has been renamed to PodLogsQuerySplitStreams

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/3288

<!-- other comments or additional information -->
- Other comments: