### PR TITLE
Add xmudrii as K8s Infra Tech Lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -63,6 +63,7 @@ aliases:
     - ameukam
     - dims
     - upodroid
+    - xmudrii
   sig-multicluster-leads:
     - jeremyot
     - skitt


### PR DESCRIPTION
Add myself (@xmudrii) as a SIG K8s Infra Tech Lead.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/community/issues/8204

/assign @BenTheElder @dims @ameukam @upodroid 
