### PR TITLE
KEP-2589: Promote Portworx CSI migration to GA in 1.33

### DIFF
--- a/keps/prod-readiness/sig-storage/2589.yaml
+++ b/keps/prod-readiness/sig-storage/2589.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@ehashman"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-storage/2589-csi-migration-portworx/README.md
+++ b/keps/sig-storage/2589-csi-migration-portworx/README.md
@@ -60,6 +60,8 @@ Major milestones for Portworx in-tree plugin CSI migration:
   - Portworx CSI migration to Beta, off by default
 - 1.31
   - Portworx CSI migration to Beta, on by default
+- 1.33
+  - Portworx CSI migration to Stable
 
 ## Design details
 

--- a/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
+++ b/keps/sig-storage/2589-csi-migration-portworx/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 2589
 authors:
   - "@trierra"
   - "@lpabon"
+  - "@gohilankit"
 owning-sig: sig-storage
 participating-sigs:
   - sig-cluster-lifecycle
@@ -13,7 +14,7 @@ approvers:
   - "@msau42"
 editor: "@Jiawei0227"
 creation-date: 2021-09-08
-last-updated: 2024-01-31
+last-updated: 2024-12-19
 disable-supported: true
 status: implementable
 see-also:
@@ -21,17 +22,18 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.23"
   beta: "v1.25"
+  stable: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update KEP for Portworx CSI Migration

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2589

<!-- other comments or additional information -->
- Other comments: This PR adds the details to the KEP for promoting Portworx CSI migration to GA in v1.33

/sig storage