### PR TITLE
KEP-127 (UserNS): allow customizing subids length  

### DIFF
--- a/keps/sig-node/127-user-namespaces/README.md
+++ b/keps/sig-node/127-user-namespaces/README.md
@@ -335,6 +335,8 @@ bool `pod.spec.hostUsers`.
 The mapping length will be 65536, mapping the range 0-65535 to the pod. This wide
 range makes sure most workloads will work fine. Additionally, we don't need to
 worry about fragmentation of IDs, as all pods will use the same length.
+The mapping length (multiple of 65536) will be customizable via a new
+`KubeletConfiguration` property `subidsPerPod`.
 
 The mapping will be chosen by the kubelet, using a simple algorithm to give
 different pods in this category ("without" volumes) a non-overlapping mapping.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP-127 (UserNS): allow customizing subids length

<!-- link to the k/enhancements issue -->
- Issue link:  #127

<!-- other comments or additional information -->
- Other comments:

The number of subuids and subgids for each of pods is hard-coded to 65536, regardless to the total ID count specified in `/etc/subuid` and `/etc/subgid`: https://github.com/kubernetes/kubernetes/blob/v1.32.0/pkg/kubelet/userns/userns_manager.go#L211-L228

This is not enough for some images.
Nested containerization needs a huge number of subids too.
