### PR TITLE
KEP-3243: Update the design to mutate the label selector based on matchLabelKeys at api-server instead of the scheduler handling it

### DIFF
--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
@@ -296,10 +296,22 @@ How will UX be reviewed, and by whom?
 
 Consider including folks who also work outside the SIG or subproject.
 -->
-In addition to using `pod-template-hash` added by the Deployment controller, 
-users can also provide the customized key in  `MatchLabelKeys` to identify 
-which pods should be grouped. If so, the user needs to ensure that it is 
-correct and not duplicated with other unrelated workloads.
+- 
+  In addition to using `pod-template-hash` added by the Deployment controller, 
+  users can also provide the customized key in  `MatchLabelKeys` to identify 
+  which pods should be grouped. If so, the user needs to ensure that it is 
+  correct and not duplicated with other unrelated workloads.
+- 
+  `MatchLabelKeys` may be broken when the pod's label values corresponding to 
+  `MatchLabelKeys` are updated after the pod is created and unscheduled.
+  `LabelSelector` will not be updated even if the pod's label values are updated, 
+  because kube-apiserver merges key-value labels into `LabelSelector` and persists 
+  them in the pod object when the pod is created.
+  But, it is not general that the pod's labels are updated at that timing, and 
+  this means the pod will be scheduled without satisfying the `TopologySpreadConstraint`, 
+  not be unschedulable.
+  In the first place, it is deprecated to define `MatchLabelKeys` with label keys
+  whose value may change dynamically, and we should document it.
 
 
 ## Design Details

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
@@ -325,7 +325,7 @@ Also, we assume the risk is acceptably low because:
    or the labels specified at `matchLabelKeys` are frequently updated (which we'll declare as not recommended).
 2. If it happens, `selfMatchNum` will be 0 and both `matchNum` and `minMatchNum` will be retained.
    Consequently, depending on the current number of matching pods in the domain, `matchNum` - `minMatchNum` might be bigger than `maxSkew`, 
-   and the node(s) could be unschedulable.
+   and the pod(s) could be unschedulable.
    But, it does not mean that the unfortunate pods would be unschedulable forever.
 
 ## Design Details
@@ -337,7 +337,7 @@ required) or even code snippets. If there's any ambiguity about HOW your
 proposal will be implemented, this is the place to discuss them.
 -->
 
-A new optional field named `MatchLabelKeys` will be introduced to`TopologySpreadConstraint`.
+A new optional field named `MatchLabelKeys` will be introduced to `TopologySpreadConstraint`.
 Currently, when scheduling a pod, the `LabelSelector` defined in the pod is used 
 to identify the group of pods over which spreading will be calculated. 
 `MatchLabelKeys` adds another constraint to how this group of pods is identified.
@@ -398,7 +398,7 @@ kube-apiserver modifies the `labelSelector` like the following:
     - app
 ```
 
-In addition, kube-scheduler handles `matchLabelKeys` within the cluster-level default constraints 
+In addition, kube-scheduler will handle `matchLabelKeys` within the cluster-level default constraints 
 in the scheduler configuration in the future (see https://github.com/kubernetes/kubernetes/issues/129198).
 
 Finally, the feature will be guarded by a new feature flag. If the feature is 


### PR DESCRIPTION
- One-line PR description: As discussed [#129480](https://github.com/kubernetes/kubernetes/issues/129480#issuecomment-2575417106), I've updated this KEP related to 
  labelSelector.
- Issue link: https://github.com/kubernetes/enhancements/issues/3243
- Other comments: