### PR TITLE
1847: Update kep.yaml for StatefulSetAutoDeletePVC which was implemented in 1.31

### DIFF
--- a/keps/sig-apps/1847-autoremove-statefulset-pvcs/kep.yaml
+++ b/keps/sig-apps/1847-autoremove-statefulset-pvcs/kep.yaml
@@ -7,7 +7,7 @@ authors:
 owning-sig: sig-apps
 participating-sigs:
   - sig-storage
-status: implementable
+status: implemented
 creation-date: 2020-06-04
 reviewers:
   - "@kow3ns"  


### PR DESCRIPTION
- One-line PR description:
Update kep.yaml for StatefulSetAutoDeletePVC which was implemented in 1.31

- Issue link: #1847 
