### PR TITLE
KEP-4427: Relaxed DNS search validation to beta

### DIFF
--- a/keps/prod-readiness/sig-network/4427.yaml
+++ b/keps/prod-readiness/sig-network/4427.yaml
@@ -1,3 +1,5 @@
 kep-number: 4427
 alpha:
   approver: "@jpbetz"
+beta:
+  approver: "@jpbetz"

--- a/keps/sig-network/4427-relaxed-dns-search-validation/README.md
+++ b/keps/sig-network/4427-relaxed-dns-search-validation/README.md
@@ -268,7 +268,7 @@ In addition to the Pod itself, each integration test should be repeated with obj
 - [X] Initial e2e tests completed and enabled
 
 #### Beta
-- [ ] No trouble reports from alpha release
+- [X] No trouble reports from alpha release
 
 #### GA
 - [ ] No trouble reports with the beta release, plus some anecdotal evidence of it being used successfully.
@@ -385,7 +385,8 @@ Describe manual testing that was done and the outcomes.
 Longer term, we may want to require automated upgrade/rollback tests, but we
 are missing a bunch of machinery and tooling and can't do that now.
 -->
-Will be tested during implementation.
+
+Tested by hand.
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 

--- a/keps/sig-network/4427-relaxed-dns-search-validation/kep.yaml
+++ b/keps/sig-network/4427-relaxed-dns-search-validation/kep.yaml
@@ -4,19 +4,19 @@ authors:
   - "@sethev"
   - "@adrianmoisey"
 owning-sig: sig-network
-status: implementable
+status: implemented
 creation-date: 2024-01-22
 reviewers:
   - "@danwinship"
 approvers:
   - "@thockin"
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.32"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Updates sections for beta release targeting 1.33

- Issue link: https://github.com/kubernetes/enhancements/issues/4427

- Other comments: This is my first time doing this. I think I covered everything, but forgive me if I missed something

/sig network
/assign aojea danwinship thockin

PRR reviewers:
/assign jpbetz
