### PR TITLE
KEP-Template: Fix KEP validation to correctly handle deprecated->disabled->removed releases.

### DIFF
--- a/api/approval.go
+++ b/api/approval.go
@@ -62,7 +62,10 @@ func (prr *PRRApproval) ApproverForStage(stage Stage) (string, error) {
 		return "", err
 	}
 
-	if prr.Alpha == nil && prr.Beta == nil && prr.Stable == nil {
+	// KEPs are usually of 2 types:
+	// 1. Features that go through Alpha->Beta->Stable
+	// 2. Removals that go through Deprecated->Disabled->Removed
+	if prr.Alpha == nil && prr.Beta == nil && prr.Stable == nil && prr.Deprecated == nil && prr.Disabled == nil && prr.Removed == nil {
 		return "", ErrPRRMilestonesAllEmpty
 	}
 
@@ -71,20 +74,37 @@ func (prr *PRRApproval) ApproverForStage(stage Stage) (string, error) {
 		if prr.Alpha == nil {
 			return "", ErrPRRMilestoneIsNil
 		}
-
 		return prr.Alpha.Approver, nil
+
 	case BetaStage:
 		if prr.Beta == nil {
 			return "", ErrPRRMilestoneIsNil
 		}
-
 		return prr.Beta.Approver, nil
+
 	case StableStage:
 		if prr.Stable == nil {
 			return "", ErrPRRMilestoneIsNil
 		}
-
 		return prr.Stable.Approver, nil
+
+	case Deprecated:
+		if prr.Deprecated == nil {
+			return "", ErrPRRMilestoneIsNil
+		}
+		return prr.Deprecated.Approver, nil
+
+	case Disabled:
+		if prr.Disabled == nil {
+			return "", ErrPRRMilestoneIsNil
+		}
+		return prr.Disabled.Approver, nil
+
+	case Removed:
+		if prr.Removed == nil {
+			return "", ErrPRRMilestoneIsNil
+		}
+		return prr.Removed.Approver, nil
 	}
 
 	return "", ErrPRRApproverUnknown

--- a/api/approval_test.go
+++ b/api/approval_test.go
@@ -40,6 +40,18 @@ var (
 		Stable: prrMilestoneWithApprover,
 	}
 
+	validDeprecatedPRR = &api.PRRApproval{
+		Deprecated: prrMilestoneWithApprover,
+	}
+
+	validDisabledPRR = &api.PRRApproval{
+		Disabled: prrMilestoneWithApprover,
+	}
+
+	validRemovedPRR = &api.PRRApproval{
+		Removed: prrMilestoneWithApprover,
+	}
+
 	invalidPRR = &api.PRRApproval{}
 )
 
@@ -82,6 +94,27 @@ func TestPRRApproval_ApproverForStage(t *testing.T) {
 			name:         "valid: stable",
 			stage:        "stable",
 			prr:          validStablePRR,
+			wantApprover: "@wojtek-t",
+			wantErr:      false,
+		},
+		{
+			name:         "valid: deprecated",
+			stage:        "deprecated",
+			prr:          validDeprecatedPRR,
+			wantApprover: "@wojtek-t",
+			wantErr:      false,
+		},
+		{
+			name:         "valid: disabled",
+			stage:        "disabled",
+			prr:          validDisabledPRR,
+			wantApprover: "@wojtek-t",
+			wantErr:      false,
+		},
+		{
+			name:         "valid: removed",
+			stage:        "removed",
+			prr:          validRemovedPRR,
 			wantApprover: "@wojtek-t",
 			wantErr:      false,
 		},


### PR DESCRIPTION

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Fix some validation bugs/issues that were introduced in https://github.com/kubernetes/enhancements/pull/4898.

The validation assumes release stages for a feature to only be Alpha->Beta->Stable but now we have another sort of release for removal of functionality that follows Deprecated->Disabled->Removed stages, so we need to update the KEP unit and verification tests to support these types of KEP proposals.

<!-- link to the k/enhancements issue -->
- Issue link:

<!-- other comments or additional information -->
- Other comments: