### PR TITLE
KEP-4247: correct the milestone at kep.yaml

### DIFF
--- a/keps/sig-scheduling/4247-queueinghint/kep.yaml
+++ b/keps/sig-scheduling/4247-queueinghint/kep.yaml
@@ -22,7 +22,7 @@ latest-milestone: "v1.32"
 
 milestone:
   alpha: "v1.26" # This KEP stems from /keps/sig-node/3063-dynamic-resource-allocation.
-  beta: "v1.28"
+  beta: "v1.32"
   stable: "v1.34"
 
 feature-gates:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Change the beta milestone to v1.32

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4247

<!-- other comments or additional information -->
- Other comments: So, the context is that we once graduate it as beta at v1.28, but we soon reverted it because we found a memory leak bug. v1.32 fixes the bug, and we tried again to graduate it to beta. So, I believe we should note the graduation of beta was v1.32.