### PR TITLE
Fix typo in HPA scale velocity document

### DIFF
--- a/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
+++ b/keps/sig-autoscaling/853-configurable-hpa-scale-velocity/README.md
@@ -207,7 +207,7 @@ behavior:
     policies:
     - type: Pods
       value: 5
-      periodSeconds: 600
+      periodSeconds: 60
 ```
 
 i.e., the algorithm will:


### PR DESCRIPTION
A YAML example has 600 as value for the `periodSeconds` attribute, but in the text below it is referenced as a minute. The value should therefore be 60 to avoid confusion for the reader.
