### PR TITLE
KEP-4205: reporting experimental results and concerns on phase 2

### DIFF
--- a/keps/sig-node/4205-psi-metric/README.md
+++ b/keps/sig-node/4205-psi-metric/README.md
@@ -133,6 +133,18 @@ risk of early reporting for nodes under pressure. We intend to address this conc
 by conducting careful experimentation with PSI threshold values to identify the optimal
 default threshold to be used for reporting the nodes under heavy resource pressure.
 
+> [!IMPORTANT]
+> After some investigation we understood that
+> we cannot directly/solely use PSI metrics at node level to identify nodes under "pressure" and taint them.
+
+Experimental results show that a CPU intensive pod with stringent CPU limit is reporting a really high PSI pressure
+even if the pressure is only due to CPU throttling and not by competition with neighbors.
+But due to how the PSI interface is defined, this is reported also on the kubelet slice and at node level.
+So having a badly configured pod on the node, is enough to get a relevant PSI pressure reported at node level
+even if the node is not really suffering.
+This raises a significant concern about phase 2
+(utilize the node level PSI metric to set node condition and node taints).
+
 ## Design Details
 
 #### Phase 1


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: PSI is currently not able to tell us if the pressure is caused by the contention of a scarce resource or it's due to CPU throttling according to the limits and this is reported also at node level.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5062

<!-- other comments or additional information -->
- Other comments: