### PR TITLE
Mark GA sig-api-machinery KEPs as implemented

### DIFF
--- a/keps/sig-api-machinery/1929-built-in-default/kep.yaml
+++ b/keps/sig-api-machinery/1929-built-in-default/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 1929
 authors:
   - apelisse
 owning-sig: sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2020-08-04
 reviewers:
   - jpbetz

--- a/keps/sig-api-machinery/4358-custom-resource-field-selectors/kep.yaml
+++ b/keps/sig-api-machinery/4358-custom-resource-field-selectors/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@jpbetz"
 owning-sig: sig-api-machinery
 participating-sigs:
-status: implementable
+status: implemented
 creation-date: 2023-12-12
 reviewers:
   - "@wojtek-t"

--- a/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
+++ b/keps/sig-api-machinery/4420-retry-generate-name/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@jpbetz"
 owning-sig: sig-api-machinery
 participating-sigs:
-status: implementable
+status: implemented
 creation-date: 2024-01-19
 reviewers:
   - "@deads2k"


### PR DESCRIPTION
All of these are marked as GA by kubernetes/kubernetes feature gates.

/sig api-machinery