### PR TITLE
KEP-2008: Graduate "Forensic Container Checkpointing" to GA

### DIFF
--- a/keps/prod-readiness/sig-node/2008.yaml
+++ b/keps/prod-readiness/sig-node/2008.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@ehashman"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-node/2008-forensic-container-checkpointing/README.md
+++ b/keps/sig-node/2008-forensic-container-checkpointing/README.md
@@ -306,6 +306,11 @@ extending the production code to implement this enhancement.
   - `pkg/kubelet/container`: 02-08-2024 - 55.7
   - `pkg/kubelet/server`: 02-08-2024 - 65.1
   - `pkg/kubelet/cri/remote`: 02-08-2024 - 18.9
+- Test coverage before GA graduation
+  - `pkg/kubelet`: 01-27-2025 - 70.6
+  - `pkg/kubelet/container`: 01-08-2025 - 52.9
+  - `pkg/kubelet/server`: 01-27-2025 - 64.9
+  - `staging/src/k8s.io/cri-client/pkg`: 01-27-2025 - 38.2
 
 ##### Integration tests
 
@@ -354,6 +359,14 @@ We expect no non-infra related flakes in the last month as a GA graduation crite
   features enabled with CRI-O, no results have been collected and tests have
   been skipped.
 
+- Since the release of containerd 2.0 and CRI-O 1.25 and since the graduation of
+  Forensic Container Checkpointing to Beta, end to end tests are being run:
+  <https://storage.googleapis.com/k8s-triage/index.html?test=checkpoint#a3361808c39a7eb28162>
+  Looking at the results today (2025-01-27) the only error seems to have been
+  on 2025-01-16 using containerd as well as CRI-O. Looking at the log files of the
+  failed tests the failure was also seen with other tests which indicates that
+  this failure was not related to the Forensic Container Checkpointing feature.
+
 ### Graduation Criteria
 
 #### Alpha
@@ -388,12 +401,12 @@ In Kubernetes:
 CRI-O as well as containerd have to have implemented the corresponding CRI APIs:
 
 - [x] CRI-O
-- [x] containerd (<https://github.com/containerd/containerd/pull/6965>)
+- [x] containerd
 
 Ensure that e2e tests are working with
 
 - [x] CRI-O
-- [x] containerd (<https://github.com/containerd/containerd/pull/6965>)
+- [x] containerd
 
 ### Upgrade / Downgrade Strategy
 
@@ -681,6 +694,7 @@ that can be turned off during startup or runtime configuration.
 * 2022-04-05: Added CRI API section and targeted 1.25
 * 2022-05-17: Remove *restore* RPC from the CRI API
 * 2024-02-08: Graduation to Beta.
+* 2025-01-27: Graduation to GA.
 
 ## Drawbacks
 

--- a/keps/sig-node/2008-forensic-container-checkpointing/kep.yaml
+++ b/keps/sig-node/2008-forensic-container-checkpointing/kep.yaml
@@ -7,7 +7,7 @@ participating-sigs:
   - TBD
 status: implementable
 creation-date: 2020-09-16
-last-updated: 2024-02-08
+last-updated: 2025-02-27
 reviewers:
   - "@mrunalp"
   - "@elfinhe"
@@ -15,12 +15,12 @@ approvers:
   - "@dchen1107"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
As defined in the existing KEP the steps to graduate from Beta to GA are

  CRI-O as well as containerd have to have implemented the corresponding CRI APIs:
  - [x] CRI-O
  - [x] containerd

  Ensure that e2e tests are working with
  - [x] CRI-O
  - [x] containerd

Both requirements are fulfilled. containerd supports the corresponding CRI APIs since 2.0 and CRI-O since 1.25.

Tests are also running according to
https://storage.googleapis.com/k8s-triage/index.html?test=checkpoint#a3361808c39a7eb28162

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Graduate "Forensic Container Checkpointing" to GA

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2008