### PR TITLE
1710: selinux: Update the KEP for 1.33 and graduate to Beta

### DIFF
--- a/keps/prod-readiness/sig-storage/1710.yaml
+++ b/keps/prod-readiness/sig-storage/1710.yaml
@@ -5,3 +5,6 @@ alpha:
   # @deads2k for SELinuxChangePolicy alpha 1.32
 beta:
   approver: "@deads2k"
+  # SELinuxMountReadWriteOncePod is beta since 1.29
+  # @deads2k for SELinuxMount beta in 1.33
+  # @deads2k for SELinuxChangePolicy beta 1.33

--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -647,13 +647,16 @@ No existing / new tests for volume mounting there.
 
 * Check no recursive `chcon` is done on a volume when not needed.
 * Check recursive `chcon` is done on a volume when needed.
-* Check that proper metric is emitted when kubelet can't start two pods with different SELinux labels using the same volume on the same node._
-  * These tests might use only CSI volumes, GCE PD in-tree volume plugin that we use for e2e tests might be already migrated to CSI by that time.
+* Check that kubelet emits proper metrics when it can't start two pods with different SELinux labels using the same volume on the same node._
+* Check that the SELinux warning controller emits events when pods conflict + emit the described metrics.
 * Prepare e2e job that runs with SELinux in Enforcing mode.
   * Done:
     * https://testgrid.k8s.io/kops-k8s-ci#kops-aws-selinux: for features enabled by default.
-    * https://testgrid.k8s.io/kops-k8s-ci#kops-aws-selinux-alpha: for alpha features.
+    * https://testgrid.k8s.io/kops-k8s-ci#kops-aws-selinux-alpha: for all alpha features enabled.
+    * https://testgrid.k8s.io/kops-distro-rhel8#kops-aws-selinux-changepolicy: for `SELinuxChangePolicy` enabled + `SELinuxMount` disabled.
     * https://testgrid.k8s.io/presubmits-kubernetes-nonblocking#pull-kubernetes-e2e-gce-storage-selinux: for PRs (needs explicit `/test ` in a PR).
+
+All these e2e tests use only CSI volumes. All in-tree volume types that support SELinux and dynamic provisioning were migrated to CSI already.
 
 ### Graduation Criteria
 

--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -606,7 +606,12 @@ Drawbacks:
 * The controller may report a conflict when two Pods are scheduled to the same node, but they will run serially there.
   For example, one pod is already being deleted and the other has just been scheduled there.
   Kubelet's `volume_manager_selinux_volume_context_mismatch_warnings_total` metric is more accurate in this case.
-  
+* The controller cannot read the SELinux default container labels from the operating system.
+  KCM often runs in a container and does not have access to `/etc/selinux` on the worker nodes.
+  As consequence, two labels that are equivalent from the SELinux point of view, may be reported as different, such as these two `seLinuxOptions` snippets: `{"type": "container_t", "level": "s0:c10,c0"}` and `{"level": "s0:c10,c1"}`.
+  `container_t` is the default type label for containers on Fedora, so kubelet is able to fill it in the `seLinuxOptions` when it is not set and see they're equivalent.
+  KCM does not know the default on nodes and treats these `seLinuxOptions` as different.
+
 ### Implementation phases
 
 Due to change of Kubernetes behavior, we will implement the feature only for cases where it can't break anything first.

--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -610,7 +610,7 @@ Drawbacks:
   KCM often runs in a container and does not have access to `/etc/selinux` on the worker nodes.
   As consequence, two labels that are equivalent from the SELinux point of view, may be reported as different, such as these two `seLinuxOptions` snippets: `{"type": "container_t", "level": "s0:c10,c0"}` and `{"level": "s0:c10,c1"}`.
   `container_t` is the default type label for containers on Fedora, so kubelet is able to fill it in the `seLinuxOptions` when it is not set and see they're equivalent.
-  KCM does not know the default on nodes and treats these `seLinuxOptions` as different.
+  KCM does not know the default on nodes and treats empty fields in `seLinuxOptions` as *uncomparable* - it does not emit any event in the above example.
 
 ### Implementation phases
 

--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -682,12 +682,19 @@ All these e2e tests use only CSI volumes. All in-tree volume types that support 
   * Implemented SELinuxController.
 * Beta of Phase 2 + 3 (`SELinuxChangePolicy` is beta and enabled by default; `SELinuxMount` is beta, but disabled by default).
   * Telemetry numbers from OpenShift show that <5% of clusters would need to change any of their Pods.
-  * This phase signalizes that the feature is ready for real testing. Only non-breaking parts (`SELinuxChangePolicy`) are enabled by default.
-* GA of Phase 2 (`SELinuxChangePolicy` + `SELinuxMountReadWriteOncePod` are GA and locked to default):
+  * This phase signalizes that the feature is ready for real testing.
+    Only non-breaking parts (`SELinuxChangePolicy`) are enabled by default.
+    Users willing to test `SELinuxMount` must enable it explicitly.
+* GA of Phase 2 (`SELinuxChangePolicy` + `SELinuxMountReadWriteOncePod` are GA and locked to default, `SELinuxMount` is beta and disabled by default):
   * All known issues fixed. Otherwise, we will GA Phase 1 only.
+  * Users can update their clusters safely, there is no breaking change yet.
+    Users willing to test `SELinuxMount` must enable it explicitly.
+  * This phase allows production clusters to check what Pods (Deployments, StatefulSets) need update and fix them before the breaking part (`SELinuxMount`) is enabled by default in the next phase.
 * GA of Phase 3 (`SELinuxMount` is GA and locked to default):
   * At least 1 release after `SELinuxChangePolicy` is GA to give cluster admins enough time to apply `SELinuxChangePolicy` to their Pods.
   * Telemetry numbers from OpenShift show that <2% of clusters would need to change any of their Pods (i.e. most clusters already applied opt-out).
+  * This is the phase that may break existing applications during cluster upgrade.
+    Users that use SELinux should carefully evaluate the metrics emitted by kubelet and SELinuxWarningController and fix their workloads before upgrade to this version.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -673,6 +673,7 @@ All these e2e tests use only CSI volumes. All in-tree volume types that support 
   * Provided all tests defined above are passing and gated by the feature gate `SELinuxMountReadWriteOncePod` and set to a default of `false`.
   * Documentation exists.
 * Beta of Phase 1:
+  * E2e tests implemented + green.
   * The feature gate is `true` by default.
 * Evaluation:
   * During the next release after Phase 1 is beta (= the feature is enabled by default), collect reports from users about possible breakage.
@@ -681,6 +682,7 @@ All these e2e tests use only CSI volumes. All in-tree volume types that support 
   * Implemented `SELinuxChangePolicy` **with a separate alpha feature gate `SELinuxChangePolicy`** as preparation for `SELinuxMount` feature gate graduation.
   * Implemented SELinuxController.
 * Beta of Phase 2 + 3 (`SELinuxChangePolicy` is beta and enabled by default; `SELinuxMount` is beta, but disabled by default).
+  * E2e tests implemented + green.
   * Telemetry numbers from OpenShift show that <5% of clusters would need to change any of their Pods.
   * This phase signalizes that the feature is ready for real testing.
     Only non-breaking parts (`SELinuxChangePolicy`) are enabled by default.

--- a/keps/sig-storage/1710-selinux-relabeling/kep.yaml
+++ b/keps/sig-storage/1710-selinux-relabeling/kep.yaml
@@ -18,8 +18,8 @@ approvers:
   - "@saad-ali"
 see-also:
   - /keps/sig-storage/695-skip-permission-change/README.md
-stage: alpha
-latest-milestone: "v1.32"
+stage: beta
+latest-milestone: "v1.33"
 milestone:
   alpha: "v1.24"  # SELinuxMountReadWriteOncePod
   beta: "v1.27"   # SELinuxMountReadWriteOncePod
@@ -27,7 +27,8 @@ milestone:
 
   # alpha: "v1.30"  # SELinuxMount
   # alpha: "v1.32"  # SELinuxChangePolicy
-
+  # beta: "v1.33"   # SELinuxChangePolicy (enabled by default)
+  # beta: "v1.33"   # SELinuxMount (disabled by default)
 feature-gates:
   - name: SELinuxMountReadWriteOncePod
     components:


### PR DESCRIPTION
- One-line PR description: Update the KEP with current development (1.32/33) and a plan to graduate to Beta in 1.33


<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1710

<!-- other comments or additional information -->
- Other comments: See individual small commits.
  * Specify SELinux controller tests.
  * Add notes about other Linux distros (tested on Debian).
  * Add a note that the controller / KCM cannot implement SELinux label defaulting.