### PR TITLE
KEP-1027: Fix Markdown formatting caused by missing backtick

### DIFF
--- a/keps/sig-api-machinery/1027-api-unions/README.md
+++ b/keps/sig-api-machinery/1027-api-unions/README.md
@@ -247,7 +247,7 @@ kubebuilder types):
   discriminator values). This field MUST be required if there is no default
   option, omitempty if the default option is the empty string, or optional and
   omitempty if a default value is specified with the `// +default` marker.
-- `// +unionMember[=<memberName>][,optional] before a field means that this
+- `// +unionMember[=<memberName>][,optional]` before a field means that this
   field is a member of a union. The `<memberName>` is the name of the field that will be set as the discriminator value.
   It MUST correspond to one of the valid enum values of the discriminator's enum
   type. It defaults to the go (i.e `CamelCase`) representation of the field name if not specified.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Fixes Markdown formatting problems caused by an unmatched backtick

<!-- link to the k/enhancements issue -->
- Issue link: n/a

<!-- other comments or additional information -->
- Other comments:

**Before:**

> 
![image](https://github.com/user-attachments/assets/ee7e0f75-13cb-4a67-9e67-8de706234547)

**After:**

> 
![image](https://github.com/user-attachments/assets/47e95f24-e3ae-408c-87b4-2512d434c9c8)
