### PR TITLE
KEP-2625: Promote the CPUManager Policy Option `full-pcpus-only` to GA

### DIFF
--- a/keps/prod-readiness/sig-node/2625.yaml
+++ b/keps/prod-readiness/sig-node/2625.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/README.md
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/README.md
@@ -7,26 +7,25 @@
 - [Summary](#summary)
 - [Motivation](#motivation)
   - [Goals](#goals)
+  - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
     - [Latency-sensitive applications runtime guarantees](#latency-sensitive-applications-runtime-guarantees)
     - [Improve the density of running containers](#improve-the-density-of-running-containers)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
-  - [Proposed Change](#proposed-change)
   - [Implementation strategy of full-pcpus-only CPU Manager policy option](#implementation-strategy-of-full-pcpus-only-cpu-manager-policy-option)
   - [Resource Accounting](#resource-accounting)
-  - [Alternatives](#alternatives)
-    - [Add extra resources](#add-extra-resources)
-    - [Add a new unit for CPU resources](#add-a-new-unit-for-cpu-resources)
-  - [Future extension](#future-extension)
-    - [Allowing external agents to detect the cpumanager behaviour](#allowing-external-agents-to-detect-the-cpumanager-behaviour)
-    - [Emulating Non-SMT on SMT systems](#emulating-non-smt-on-smt-systems)
   - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Test Plan](#test-plan-1)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
-    - [Alpha to Beta Graduation](#alpha-to-beta-graduation)
-    - [Beta to G.A Graduation](#beta-to-ga-graduation)
+    - [Beta](#beta)
+    - [GA](#ga)
   - [Graduation Criteria of Options](#graduation-criteria-of-options)
     - [Graduation of Options to <code>Beta-quality</code> (non-hidden)](#graduation-of-options-to-beta-quality-non-hidden)
     - [Graduation of Options from <code>Beta-quality</code> to <code>G.A-quality</code>](#graduation-of-options-from-beta-quality-to-ga-quality)
@@ -40,22 +39,36 @@
   - [Scalability](#scalability)
   - [Troubleshooting](#troubleshooting)
 - [Implementation History](#implementation-history)
+- [Alternatives](#alternatives)
+    - [Add extra resources](#add-extra-resources)
+    - [Add a new unit for CPU resources](#add-a-new-unit-for-cpu-resources)
+  - [Future extension (obsolete, recorded for the sake of history)](#future-extension-obsolete-recorded-for-the-sake-of-history)
+    - [Allowing external agents to detect the cpumanager behaviour](#allowing-external-agents-to-detect-the-cpumanager-behaviour)
+    - [Emulating Non-SMT on SMT systems](#emulating-non-smt-on-smt-systems)
 <!-- /toc -->
 
 ## Release Signoff Checklist
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements](https://github.com/kubernetes/enhancements/issues/2404)
-- [X] (R) KEP approvers have approved the KEP status as `implementable`
+- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ X (R) KEP approvers have approved the KEP status as `implementable`
 - [X] (R) Design details are appropriately documented
-- [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
+- [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [X] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [X] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [X] (R) Graduation criteria is in place
+  - [X] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
 - [X] (R) Production readiness review completed
-- [X] Production readiness review approved
+- [X] (R) Production readiness review approved
 - [X] "Implementation History" section is up-to-date for milestone
-- ~~ [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io] ~~
-- [X] Supporting documentation e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [X] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
 
 [kubernetes.io]: https://kubernetes.io/
 [kubernetes/enhancements]: https://git.k8s.io/enhancements
@@ -78,6 +91,10 @@ to consider thread-level allocation, to avoid physical CPU sharing and prevent p
 * Prevent workloads from requesting cores that don't consume a full CPU by rejecting them.
   This guarantees that no physical core is shared among different containers, which improves cache efficiency and mitigates the interference
   with other workloads that can consume resources of the same physical core, e.g. first level caches.
+
+### Non-Goals
+
+TBD
 
 ## Proposal
 
@@ -112,8 +129,6 @@ The impact in the shared codebase will be addressed enhancing the current testsu
 
 
 ## Design Details
-
-### Proposed Change
 
 We propose to
 - add a new flag in Kubelet called `CPUManagerPolicyOptions` in the kubelet config or command line argument called `cpumanager-policy-options` which allows the user to specify the CPU Manager policy option.
@@ -183,7 +198,238 @@ With `threads_per_cpu` is typical 2 on x86_64 with SMT enabled - but this number
 In order to make the resource reporting consistent, and avoiding cascading changes in the system, we enforce the request constraints at admission time.
 This approach follows what the Topology Manager already does.
 
-### Alternatives
+### Test Plan
+
+[ ] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+TBD
+
+##### Unit tests
+
+- `<package>`: `<date>` - `<test coverage>`
+
+##### Integration tests
+
+- <test>: <link to test coverage>
+
+##### e2e tests
+
+- <test>: <link to test coverage>
+
+### Test Plan
+
+The [implementation PR](https://github.com/kubernetes/kubernetes/pull/101432) will extend both the unit test suite and the E2E test suite to cover the policy changes described in this KEP.
+
+### Graduation Criteria
+
+#### Alpha
+- [X] Implement the new policy.
+- [X] Ensure proper e2e node tests are in place.
+
+#### Beta
+- [X] Gather feedback from the consumer of the policy.
+- [X] No major bugs reported in the previous cycle.
+- [X] Use of this policy option to further configure the behavior of CPU manager. Another CPUManager policy option `distribute-cpus-across-numa` is being proposed in 1.23 release to distribute CPUs across NUMA nodes instead of packing them.
+
+#### GA
+- [X] Allowing time for feedback (1 year).
+- [X] Risks have been addressed.
+
+### Graduation Criteria of Options
+
+In 1.23 release, as we are graduating this feature to Beta meaning `CPUManagerPolicyOptions` is enabled by default allowing the user to configure CPU Manager static policy with the option `full-pcpus-only`.
+NOTE: Even though the feature gate is enabled by default the user still has to explicitly use the Kubelet flag called `CPUManagerPolicyOptions` in the kubelet config or command line argument called `cpumanager-policy-options` along with a specific policy option to use this feature.
+- In addition to this, in order to not have all alpha-quality experimental options introduced in the future available by default, we are introducing an additional feature gates called `CPUManagerPolicyAlphaOptions` and `CPUManagerPolicyBetaOptions`.
+  These feature gates control all the non-stable options. We introduce feature gates guarding groups of options to avoid the proliferation of feature gates, and to make the management easier: tracking a feature gate per option would be too cumbersome.
+  The alpha-quality options are hidden by default and only if the `CPUManagerPolicyAlphaOptions` feature gate is enabled the user has the ability to use them.
+  The beta-quality options are visible by default, and the feature gate allows a positive acknowledgement that non stable features are being used, and also allows to optionally turn them off.
+  Based on the graduation criteria described below, a policy option will graduate from a group to the other (alpha to beta).
+  We plan to removete the `CPUManagerPolicyAlphaOptions` and `CPUManagerPolicyBetaOptions` after all options graduated to stable, after a feature cycle passes without new planned options, and not before 1.28, to give ample time to the work in progress option to graduate at least to beta.
+- Since the feature that allows the ability to customize the behaviour of CPUManager static policy as well as the CPUManager Policy option `full-pcpus-only` were both introduced in 1.22 release and meet the above graduation criterion, `full-pcpus-only` would be considered as a non-hidden option i.e. available to be used when explicitly used along with `CPUManagerPolicyOptions` Kubelet flag in the kubelet config or command line argument called `cpumanager-policy-options` .
+-  The introduction of this new feature gate gives us the ability to move the feature to beta and later stable without implying all that the options are beta or stable.
+
+The graduation Criteria of options is described below:
+
+#### Graduation of Options to `Beta-quality` (non-hidden)
+- [X] Gather feedback from the consumer of the policy option.
+- [X] No major bugs reported in the previous cycle.
+
+#### Graduation of Options from `Beta-quality` to `G.A-quality`
+- [X] Allowing time for feedback (1 year) on the policy option.
+- [X] Risks have been addressed.
+
+### Upgrade / Downgrade Strategy
+
+We expect no impact. The new policies are opt-in and separated by the existing ones.
+
+### Version Skew Strategy
+
+No changes needed
+
+## Production Readiness Review Questionnaire
+
+### Feature enablement and rollback
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+- [X] Feature gate (also fill in values in `kep.yaml`)
+    - Feature gate name: `CPUManagerPolicyOptions` - going to be locked to true once GA.
+    - Feature gate name: `CPUManagerPolicyBetaOptions`.
+    - Feature gate name: `CPUManagerPolicyAlphaOptions`.
+    - Components depending on the feature gate: kubelet
+- [X] Other
+  - Change the kubelet configuration adding the CPUManager policy option to `full-pcpus-only`
+  - Will enabling / disabling the feature require downtime of the control
+    plane? No
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node? No
+
+###### Does enabling the feature change any default behavior?
+  - Enabling the `CPUManagerPolicyOptions` makes the behaviour of the CPUManager static policy more restrictive and can lead to pod admission rejection.
+  - Enabling the `CPUManagerPolicyAlphaOptions` provides the ability to use alpha-quality options which can change the behaviour of the CPUManager static policy.
+  - Enabling the `CPUManagerPolicyBetaOptions` provides the ability to use beta-quality options which can change the behaviour of the CPUManager static policy.
+    This allows a positive acknowledgment from the cluster admin that they are using a non-stable feature; additionally, the feature gate allows to _disable_ a set of options.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+  - Yes, disabling the `CPUManagerPolicyOptions` feature gate shuts down the feature completely; alternatively through kubelet configuration - switch to a different policy.
+  - Also, disabling `CPUManagerPolicyAlphaOptions` or `CPUManagerPolicyBetaOptions` feature gates disables the use of non-stable options, respectively alpha or beta quality,
+    and the behavior would depend on how `CPUManagerPolicyOptions` feature gate is configured.
+  - Disabling both the feature gates would allow complete rollback of this enablement.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+No changes. Existing containers will not see their allocation changed. New containers will.
+
+###### Are there any tests for feature enablement/disablement?
+
+A specific e2e test will demonstrate that the default behaviour is preserved when the `CPUManagerPolicyOptions` feature gate is disabled, or when the feature is not used (2 separate tests)
+
+### Rollout, Upgrade and Rollback Planning
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+Kubelet may fail to start. The kubelet may crash.
+
+###### What specific metrics should inform a rollback?
+
+The number of pod ending up in Failed for SMTAlignmentError could be used to decide a rollback.
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+Not Applicable.
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+No.
+
+### Monitoring requirements
+
+###### How can an operator determine if the feature is in use by workloads?
+
+- Inspect the kubelet configuration of the nodes: check feature gates and usage of the new options
+
+###### How can someone using this feature know that it is working for their instance?
+
+- [ ] Events
+  - Event Reason:
+- [ ] API .status
+  - Condition name:
+  - Other field:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+N/A.
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+- [ ] Metrics
+  - Metric name:
+  - [Optional] Aggregation method:
+  - Components exposing the metric:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+TBD
+
+
+### Dependencies
+
+###### Does this feature depend on any specific services running in the cluster?
+
+No.
+
+### Scalability
+
+###### Will enabling / using this feature result in any new API calls?
+
+No.
+
+###### Will enabling / using this feature result in introducing new API types?
+
+No.
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+No.
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+No.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+No.
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+No.
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+TBD
+
+### Troubleshooting
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+No effect.
+
+###### What are other known failure modes?
+
+No known failure mode. (TBD)
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+N/A (TBD)
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+
+## Implementation History
+
+- 2021-04-14: KEP created
+- 2021-04-16: KEP updated with the `smtisolate` policy
+- 2021-04-19: KEP updated to capture implementation details of the `smtaware` policy; clarified the resource accounting vs admission requirements
+- 2021-04-22: KEP updated to clarify the `smtaware` policy after discussion on sig-node and to postpone the `smtisolate` policy
+- 2021-05-04: KEP updated to change name from `smtaware` to `smtalign`. In addition to this we capture changes in the implmentation details including the introduction of a new flag in Kubelet called `cpumanager-policy-options` to allow the user to specify `smtalign` as a value to enable this capability.
+- 2021-05-06: KEP update to add the feature gate and clarify PRR answers.
+- 2021-05-10: KEP update to add to rename the `smtalign` to `reject-non-smt-aligned` for better clarity and address review comments
+- 2021-05-11: KEP update to add to the `configurable` alias and address review comments
+- 2021-05-13: KEP update to postpone the `configurable` alias, per review comments
+- 2021-09-02: KEP update to capture the policy name `full-pcpus-only` based on the implementation merged in 1.22, explain how this feature is being used for introduction of another policy option and updates pertaining to promotion of the feature to Beta.
+- 2021-09-08: KEP update to introduce `CPUManagerPolicyExperimentalOptions` feature gate to prevent alpha-quality options from being non-hidden (available) by default and explain the graduation criteria of the options.
+- 2021-09-27: KEP update to split `CPUManagerPolicyExperimentalOptions` feature gate into `CPUManagerPolicyAlphaOptions` and `CPUManagerPolicyBetaOptions` after discussion on [sig-arch](https://groups.google.com/u/1/g/kubernetes-sig-architecture/c/Nxsc7pfe5rw)
+- 2025-01-30: KEP update to align with most recent template and add changes for GA graduation
+
+## Alternatives
 
 We acknowledge few drawbacks of the proposed approach:
 - pods that are rejected due to an AdmissionError do not get automatically rescheduled. Workloads which wants to make sure to be rescheduled need to
@@ -236,7 +482,8 @@ SMT can usually be disabled via software (kernel parameter, firmware settings), 
 Hence, the ratio between virtual and physical CPUs is not fixed and is not predictable, subject to changes in future.
 Furthermore, this new unit would make sense only for CPU resources, and not for all the other resources.
 
-### Future extension
+
+### Future extension (obsolete, recorded for the sake of history)
 
 #### Allowing external agents to detect the cpumanager behaviour
 
@@ -257,131 +504,3 @@ Another policy option, or a further refinement of `full-pcpus-only`, which enabl
 as described above. Furthermore, at the moment of writing we are still assessing how large is the set of the classes which benefit of these extra guarantees.
 
 For all these reasons we postponed this work to a later date.
-
-### Test Plan
-
-The [implementation PR](https://github.com/kubernetes/kubernetes/pull/101432) will extend both the unit test suite and the E2E test suite to cover the policy changes described in this KEP.
-
-### Graduation Criteria
-
-#### Alpha
-- [X] Implement the new policy.
-- [X] Ensure proper e2e node tests are in place.
-
-#### Alpha to Beta Graduation
-- [X] Gather feedback from the consumer of the policy.
-- [X] No major bugs reported in the previous cycle.
-- [X] Use of this policy option to further configure the behavior of CPU manager. Another CPUManager policy option `distribute-cpus-across-numa` is being proposed in 1.23 release to distribute CPUs across NUMA nodes instead of packing them.
-
-#### Beta to G.A Graduation
-- [X] Allowing time for feedback (1 year).
-- [X] Risks have been addressed.
-
-### Graduation Criteria of Options
-
-In 1.23 release, as we are graduating this feature to Beta meaning `CPUManagerPolicyOptions` is enabled by default allowing the user to configure CPU Manager static policy with the option `full-pcpus-only`.
-NOTE: Even though the feature gate is enabled by default the user still has to explicitly use the Kubelet flag called `CPUManagerPolicyOptions` in the kubelet config or command line argument called `cpumanager-policy-options` along with a specific policy option to use this feature.
-- In addition to this, in order to not have all alpha-quality experimental options introduced in the future available by default, we are introducing an additional feature gates called `CPUManagerPolicyAlphaOptions` and `CPUManagerPolicyBetaOptions`.
-  These feature gates control all the non-stable options. We introduce feature gates guarding groups of options to avoid the proliferation of feature gates, and to make the management easier: tracking a feature gate per option would be too cumbersome.
-  The alpha-quality options are hidden by default and only if the `CPUManagerPolicyAlphaOptions` feature gate is enabled the user has the ability to use them.
-  The beta-quality options are visible by default, and the feature gate allows a positive acknowledgement that non stable features are being used, and also allows to optionally turn them off.
-  Based on the graduation criteria described below, a policy option will graduate from a group to the other (alpha to beta).
-  We plan to removete the `CPUManagerPolicyAlphaOptions` and `CPUManagerPolicyBetaOptions` after all options graduated to stable, after a feature cycle passes without new planned options, and not before 1.28, to give ample time to the work in progress option to graduate at least to beta.
-- Since the feature that allows the ability to customize the behaviour of CPUManager static policy as well as the CPUManager Policy option `full-pcpus-only` were both introduced in 1.22 release and meet the above graduation criterion, `full-pcpus-only` would be considered as a non-hidden option i.e. available to be used when explicitly used along with `CPUManagerPolicyOptions` Kubelet flag in the kubelet config or command line argument called `cpumanager-policy-options` .
--  The introduction of this new feature gate gives us the ability to move the feature to beta and later stable without implying all that the options are beta or stable.
-
-The graduation Criteria of options is described below:
-
-#### Graduation of Options to `Beta-quality` (non-hidden)
-- [X] Gather feedback from the consumer of the policy option.
-- [X] No major bugs reported in the previous cycle.
-
-#### Graduation of Options from `Beta-quality` to `G.A-quality`
-- [X] Allowing time for feedback (1 year) on the policy option.
-- [X] Risks have been addressed.
-
-### Upgrade / Downgrade Strategy
-
-We expect no impact. The new policies are opt-in and separated by the existing ones.
-
-### Version Skew Strategy
-
-No changes needed
-
-## Production Readiness Review Questionnaire
-### Feature enablement and rollback
-
-* **How can this feature be enabled / disabled in a live cluster?**
-  - [X] Feature gate (also fill in values in `kep.yaml`).
-    - Feature gate name: `CPUManagerPolicyOptions`.
-    - Feature gate name: `CPUManagerPolicyBetaOptions`.
-    - Feature gate name: `CPUManagerPolicyAlphaOptions`.
-    - Components depending on the feature gate: kubelet
-  - [X] Change the kubelet configuration adding the CPUManager policy option to `full-pcpus-only`
-* **Does enabling the feature change any default behavior?**
-  - Enabling the `CPUManagerPolicyOptions` makes the behaviour of the CPUManager static policy more restrictive and can lead to pod admission rejection.
-  - Enabling the `CPUManagerPolicyAlphaOptions` provides the ability to use alpha-quality options which can change the behaviour of the CPUManager static policy.
-  - Enabling the `CPUManagerPolicyBetaOptions` provides the ability to use beta-quality options which can change the behaviour of the CPUManager static policy.
-    This allows a positive acknowledgment from the cluster admin that they are using a non-stable feature; additionally, the feature gate allows to _disable_ a set of options.
-* **Can the feature be disabled once it has been enabled (i.e. can we rollback the enablement)?**
-  - Yes, disabling the `CPUManagerPolicyOptions` feature gate shuts down the feature completely; alternatively through kubelet configuration - switch to a different policy.
-  - Also, disabling `CPUManagerPolicyAlphaOptions` or `CPUManagerPolicyBetaOptions` feature gates disables the use of non-stable options, respectively alpha or beta quality,
-    and the behavior would depend on how `CPUManagerPolicyOptions` feature gate is configured.
-  - Disabling both the feature gates would allow complete rollback of this enablement. 
-* **What happens if we reenable the feature if it was previously rolled back?** No changes. Existing container will not see their allocation changed. New containers will.
-* **Are there any tests for feature enablement/disablement?**
-  - A specific e2e test will demonstrate that the default behaviour is preserved when the `CPUManagerPolicyOptions` feature gate is disabled, or when the feature is not used (2 separate tests)
-
-### Rollout, Upgrade and Rollback Planning
-
-* **How can a rollout fail? Can it impact already running workloads?** Kubelet may fail to start. The kubelet may crash.
-* **What specific metrics should inform a rollback?**
-  - the number of pod ending up in Failed for SMTAlignmentError could be used to decide a rollback.
-* **Were upgrade and rollback tested? Was upgrade->downgrade->upgrade path tested?** Not Applicable.
-* **Is the rollout accompanied by any deprecations and/or removals of features,  APIs, fields of API types, flags, etc.?** No.
-
-### Monitoring requirements
-* **How can an operator determine if the feature is in use by workloads?**
-  - Inspect the kubelet configuration of the nodes: check feature gates and usage of the new options
-* **What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?**
-  - No change
-* **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?** N/A.
-* **Are there any missing metrics that would be useful to have to improve observability if this feature?** N/A.
-
-
-### Dependencies
-
-* **Does this feature depend on any specific services running in the cluster?** No.
-
-### Scalability
-
-* **Will enabling / using this feature result in any new API calls?** No.
-* **Will enabling / using this feature result in introducing new API types?** No.
-* **Will enabling / using this feature result in any new calls to cloud provider?** No.
-* **Will enabling / using this feature result in increasing size or count of the existing API objects?** No.
-* **Will enabling / using this feature result in increasing time taken by any operations covered by [existing SLIs/SLOs][]?** No.
-* **Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?** No.
-
-### Troubleshooting
-
-* **How does this feature react if the API server and/or etcd is unavailable?**: No effect.
-* **What are other known failure modes?** No known failure mode.
-* **What steps should be taken if SLOs are not being met to determine the problem?** N/A
-
-[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
-[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
-
-## Implementation History
-
-- 2021-04-14: KEP created
-- 2021-04-16: KEP updated with the `smtisolate` policy
-- 2021-04-19: KEP updated to capture implementation details of the `smtaware` policy; clarified the resource accounting vs admission requirements
-- 2021-04-22: KEP updated to clarify the `smtaware` policy after discussion on sig-node and to postpone the `smtisolate` policy
-- 2021-05-04: KEP updated to change name from `smtaware` to `smtalign`. In addition to this we capture changes in the implmentation details including the introduction of a new flag in Kubelet called `cpumanager-policy-options` to allow the user to specify `smtalign` as a value to enable this capability.
-- 2021-05-06: KEP update to add the feature gate and clarify PRR answers.
-- 2021-05-10: KEP update to add to rename the `smtalign` to `reject-non-smt-aligned` for better clarity and address review comments
-- 2021-05-11: KEP update to add to the `configurable` alias and address review comments
-- 2021-05-13: KEP update to postpone the `configurable` alias, per review comments
-- 2021-09-02: KEP update to capture the policy name `full-pcpus-only` based on the implementation merged in 1.22, explain how this feature is being used for introduction of another policy option and updates pertaining to promotion of the feature to Beta.
-- 2021-09-08: KEP update to introduce `CPUManagerPolicyExperimentalOptions` feature gate to prevent alpha-quality options from being non-hidden (available) by default and explain the graduation criteria of the options.
-- 2021-09-27: KEP update to split `CPUManagerPolicyExperimentalOptions` feature gate into `CPUManagerPolicyAlphaOptions` and `CPUManagerPolicyBetaOptions` after discussion on [sig-arch](https://groups.google.com/u/1/g/kubernetes-sig-architecture/c/Nxsc7pfe5rw)

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
@@ -1,43 +1,51 @@
 title: SMT aware cpumanager policy
 kep-number: 2625
 authors:
-  - "@fromanirh"
+  - "@ffromani"
   - "@swatisehgal"
 owning-sig: sig-node
 participating-sigs: []
-status: implementable
+status: implemented
 creation-date: "2021-04-14"
-last-updated: "2021-09-08"
+last-updated: "2025-01-30"
 reviewers:
   - "@klueska"
+  - "@swatisehgal"
 approvers:
   - "@sig-node-tech-leads"
 see-also:
 - "keps/sig-node/2902-cpumanager-distribute-cpus-policy-option/"
+- "keps/sig-node/3545-improved-multi-numa-alignment/"
+- "keps/sig-node/4176-cpumanager-spread-cpus-preferred-policy/"
+- "keps/sig-node/4540-strict-cpu-reservation"
+- "keps/sig-node/4622-topologymanager-max-allowable-numa-nodes/"
+- "keps/sig-node/4800-cpumanager-split-uncorecache/"
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.23"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.22"
   beta: "v1.23"
-  stable: "v1.25"
+  stable: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: "CPUManagerPolicyOptions"
-  - name: "CPUManagerPolicyExperimentalOptions"
+  - name: "CPUManagerPolicyAlphaOptions"
+  - name: "CPUManagerPolicyBetaOptions"
     components:
       - kubelet
 disable-supported: true
 
 # The following PRR answers are required at beta release
-metrics: []
+metrics:
+  - container_aligned_compute_resources_count

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
@@ -5,7 +5,7 @@ authors:
   - "@swatisehgal"
 owning-sig: sig-node
 participating-sigs: []
-status: implemented
+status: implementable
 creation-date: "2021-04-14"
 last-updated: "2025-01-30"
 reviewers:


### PR DESCRIPTION
- One-line PR description: CPU Manager Policy option `full-pcpus-only` 1.33 GA
- Issue link: https://github.com/kubernetes/enhancements/issues/2625
- Other comments:
  * Introduced as an alpha feature in 1.22 https://github.com/kubernetes/kubernetes/pull/101432
  * Graduated as beta feature in 1.23 https://github.com/kubernetes/enhancements/pull/2933
  * The GA graduation would mean:
    *  the `full-pcpus-only` option [will graduate to GA](https://github.com/kubernetes/kubernetes/blob/v1.32.1/pkg/kubelet/cm/cpumanager/policy_options.go#L51)
    * the `CPUManagerPolicyOptions` [master FG](https://github.com/kubernetes/kubernetes/blob/v1.32.1/pkg/features/kube_features.go#L125) will be locked to true, and removed 3 versions later