### PR TITLE
KEP-4265: move to on by default beta

### DIFF
--- a/keps/sig-node/4265-proc-mount/README.md
+++ b/keps/sig-node/4265-proc-mount/README.md
@@ -508,6 +508,7 @@ Major milestones might include:
 2024-02-26: [Update](https://github.com/kubernetes/kubernetes/pull/123520) Unmasked ProcMountType to fail validation without a pod level user namespace.
 2024-05-31: Added e2e [tests](https://github.com/kubernetes/kubernetes/pull/123303)
 2024-05-31: KEP updated to Beta
+2025-01-31: KEP updated to on by default Beta
 
 ## Drawbacks
 

--- a/keps/sig-node/4265-proc-mount/kep.yaml
+++ b/keps/sig-node/4265-proc-mount/kep.yaml
@@ -20,12 +20,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.12"
-  beta: "v1.31"
+  beta: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
update timeline and release to reflect it will go on by default in 1.33, in line with user namespaces
<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4265

<!-- other comments or additional information -->
- Other comments: