### PR TITLE
Fix github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,3 +1,11 @@
+---
+name: Enhancement tracking issue
+about: Template for enhancement issues
+title: ""
+labels: ""
+assignees: 
+---
+
 ### Enhancement Description
 
 - One-line enhancement description (can be used as a release note):


### PR DESCRIPTION
GitHub issue templates must now be put into the ISSUE_TEMPLATE dir and have the metadata at the top.