### PR TITLE
KEP-647: update stable milestone to 1.33

### DIFF
--- a/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
+++ b/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
@@ -21,11 +21,11 @@ see-also:
 replaces:
 stage: stable
 last-updated: 2023-11-10
-latest-milestone: "v1.30"
+latest-milestone: "v1.33"
 milestone:
   alpha: "v1.22"
   beta: "v1.27"
-  stable: "v1.30"
+  stable: "v1.33"
 feature-gates:
   - name: APIServerTracing
 disable-supported: true


### PR DESCRIPTION
- One-line PR description: update milestone for stable to 1.33

- Issue link: https://github.com/kubernetes/enhancements/issues/647

- Other comments: