### PR TITLE
KEP 4818: Promote zero value for Pod Lifecycle Sleep action to beta

### DIFF
--- a/keps/prod-readiness/sig-node/4818.yaml
+++ b/keps/prod-readiness/sig-node/4818.yaml
@@ -2,4 +2,4 @@ kep-number: 4818
 alpha:
   approver: "@wojtek-t"
 beta:
-  approver: ""
+  approver: "@wojtek-t"

--- a/keps/prod-readiness/sig-node/4818.yaml
+++ b/keps/prod-readiness/sig-node/4818.yaml
@@ -1,3 +1,5 @@
 kep-number: 4818
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: ""

--- a/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/README.md
+++ b/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/README.md
@@ -1,74 +1,4 @@
-<!--
-**Note:** When your KEP is complete, all of these comment blocks should be removed.
-
-To get started with this template:
-
-- [x] **Pick a hosting SIG.**
-  Make sure that the problem space is something the SIG is interested in taking
-  up. KEPs should not be checked in without a sponsoring SIG.
-- [x] **Create an issue in kubernetes/enhancements**
-  When filing an enhancement tracking issue, please make sure to complete all
-  fields in that template. One of the fields asks for a link to the KEP. You
-  can leave that blank until this KEP is filed, and then go back to the
-  enhancement and add the link.
-- [x] **Make a copy of this template directory.**
-  Copy this template into the owning SIG's directory and name it
-  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
-  leading-zero padding) assigned to your enhancement above.
-- [x] **Fill out as much of the kep.yaml file as you can.**
-  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
-  "Status", and date-related fields.
-- [x] **Fill out this file as best you can.**
-  At minimum, you should fill in the "Summary" and "Motivation" sections.
-  These should be easy if you've preflighted the idea of the KEP with the
-  appropriate SIG(s).
-- [x] **Create a PR for this KEP.**
-  Assign it to people in the SIG who are sponsoring this process.
-- [ ] **Merge early and iterate.**
-  Avoid getting hung up on specific details and instead aim to get the goals of
-  the KEP clarified and merged quickly. The best way to do this is to just
-  start with the high-level sections and fill out details incrementally in
-  subsequent PRs.
-
-Just because a KEP is merged does not mean it is complete or approved. Any KEP
-marked as `provisional` is a working document and subject to change. You can
-denote sections that are under active debate as follows:
-
-```
-<<[UNRESOLVED optional short context or usernames ]>>
-Stuff that is being argued.
-<<[/UNRESOLVED]>>
-```
-
-When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
-focused. If you disagree with what is already in a document, open a new PR
-with suggested changes.
-
-One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
-You do not need a new KEP to move from beta to GA, for example. If
-new details emerge that belong in the KEP, edit the KEP. Once a feature has become
-"implemented", major changes should get new KEPs.
-
-The canonical place for the latest set of instructions (and the likely source
-of this file) is [here](/keps/NNNN-kep-template/README.md).
-
-**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
-it is marked `implementable`, must be approved by each of the KEP approvers.
-If none of those approvers are still appropriate, then changes to that list
-should be approved by the remaining approvers and/or the owning SIG (or
-SIG Architecture for cross-cutting KEPs).
--->
 # KEP-4818: Allow zero value for Sleep Action of PreStop Hook
-
-<!--
-A table of contents is helpful for quickly jumping to sections of a KEP and for
-highlighting any additional information provided beyond the standard KEP
-template.
-
-Ensure the TOC is wrapped with
-  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
-tags, and then generate with `hack/update-toc.sh`.
--->
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
@@ -110,26 +40,12 @@ tags, and then generate with `hack/update-toc.sh`.
 
 ## Release Signoff Checklist
 
-<!--
-**ACTION REQUIRED:** In order to merge code into a release, there must be an
-issue in [kubernetes/enhancements] referencing this KEP and targeting a release
-milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
-of the targeted release**.
-
-For enhancements that make changes to code or processes/procedures in core
-Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
-Signoff checklist to be completed.
-
-Check these off as they are completed for the Release Team to track. These
-checklist items _must_ be updated for the enhancement to be released.
--->
-
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
   - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
@@ -231,13 +147,6 @@ As a Kubernetes user, I want to to be able to have a PreStop hook defined in my 
 
 ### Notes/Constraints/Caveats (Optional)
 
-<!--
-What are the caveats to the proposal?
-What are some important details that didn't come across above?
-Go in to as much detail as necessary here.
-This might be a good place to talk about core concepts and how they relate.
--->
-
 ### Risks and Mitigations
 
 The change is opt-in, since it requires configuring a PreStop hook with sleep action of 0 second duration. So there is no risk beyond the upgrade/downgrade risks which are addressed in the Proposal section.
@@ -247,17 +156,6 @@ The change is opt-in, since it requires configuring a PreStop hook with sleep ac
 Refer to the Proposal section.
 
 ### Test Plan
-
-<!--
-**Note:** *Not required until targeted at a release.*
-The goal is to ensure that we don't accept enhancements with inadequate testing.
-
-All code is expected to have adequate tests (eventually with coverage
-expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
-when drafting this test plan.
-
-[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
--->
 
 [x] I/we understand the owners of the involved components may require updates to
 existing tests to make this code solid enough prior to committing the changes necessary
@@ -272,25 +170,6 @@ implementing this enhancement to ensure the enhancements have also solid foundat
 
 ##### Unit tests
 
-<!--
-In principle every added code should have complete unit test coverage, so providing
-the exact set of tests will not bring additional value.
-However, if complete unit test coverage is not possible, explain the reason of it
-together with explanation why this is acceptable.
--->
-
-<!--
-Additionally, for Alpha try to enumerate the core package you will be touching
-to implement this enhancement and provide the current unit coverage for those
-in the form of:
-- <package>: <date> - <current test coverage>
-The data can be easily read from:
-https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
-
-This can inform certain test coverage improvements that we want to do before
-extending the production code to implement this enhancement.
--->
-
 Alpha:
 
 - Test that the runSleepHandler function returns immediately when given a duration of zero.
@@ -298,6 +177,9 @@ Alpha:
 - Test that the validation fails when given a zero duration with the feature gate disabled.
 - Test that the validation returns the appropriate error messages when given an invalid duration value (e.g., a negative value) with the feature gate disabled and enabled.
 - Unit tests for testing the disabling of the feature gate after it was enabled and the feature was used.
+- Unit tests for pod with zero grace period duration and zero sleep duration with zero value enabled.
+- Unit test for pod with nil grace period with zero value disabled
+- Unit test for pod with nil grace period with zero value enabled
 
 Current coverages:
 
@@ -342,6 +224,12 @@ Basic functionality
 - Delete the pod and observe the time it takes for the container to terminate.
 - Verify that the container terminates immediately without sleeping.
 
+Additional e2e tests for beta:
+  - Test that pods with sleep value of 0 in PreStop hook can be created
+  - Test that pods with sleep value of 0 in PostStart hook can be created
+  - Test that pods with sleep value of 0 in PreStop hook can be updated
+  - Test that pods with sleep value of 0 in PostStart hook can be updated
+
 ### Graduation Criteria
 
 #### Alpha
@@ -350,7 +238,7 @@ Basic functionality
 
 #### Beta
 - Gather feedback from developers and surveys
-- Additional e2e tests are completed (if needed)
+- Additional e2e tests are completed
 - No trouble reports from alpha release
 
 #### GA
@@ -564,6 +452,9 @@ Major milestones might include:
 - the version of Kubernetes where the KEP graduated to general availability
 - when the KEP was retired or superseded
 -->
+
+- 2024-09-26: Alpha KEP PR opened for v1.32
+- 2025-02-06: KEP updated targeting to beta in v1.33
 
 ## Drawbacks
 

--- a/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/README.md
+++ b/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/README.md
@@ -453,7 +453,11 @@ Major milestones might include:
 - when the KEP was retired or superseded
 -->
 
-- 2024-09-26: Alpha KEP PR opened for v1.32
+- 2024-09-16: Alpha KEP PR opened for v1.32
+- 2024-10-03: Summary, Motivation and Proposal sections merged
+- 2024-09-03: [Alpha code implementation PR](https://github.com/kubernetes/kubernetes/pull/127094) opened
+- 2024-11-01: Alpha code PR merged
+- 2024-12-11: Kubernetes v1.32 release with PodLifecycleSleepActionAllowZero in alpha stage
 - 2025-02-06: KEP updated targeting to beta in v1.33
 
 ## Drawbacks

--- a/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/kep.yaml
+++ b/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/kep.yaml
@@ -9,19 +9,20 @@ creation-date: "2024-09-16"
 
 reviewers:
   - "@kannon92"
+  - "@ffromani"
 approvers:
   - "@SergeyKanzhelev"
 
 see-also:
   - "/keps/sig-node/3960-pod-lifecycle-sleep-action"
 
-stage: alpha
+stage: beta
 
-latest-milestone: "v1.32"
+latest-milestone: "v1.33"
 
 milestone:
   alpha: "v1.32"
-  beta: ""
+  beta: "v1.33"
   stable: ""
 
 feature-gates:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP update for KEP #4818 for beta graduation

<!-- link to the k/enhancements issue -->
- Issue link: #4818

<!-- other comments or additional information -->