### PR TITLE
KEP-4444: Graduate trafficDistribution:PreferClose to GA

### DIFF
--- a/keps/prod-readiness/sig-network/4444.yaml
+++ b/keps/prod-readiness/sig-network/4444.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-network/4444-service-traffic-distribution/README.md
+++ b/keps/sig-network/4444-service-traffic-distribution/README.md
@@ -305,8 +305,10 @@ the value configured for `trafficDistribution`
 
 #### `PreferClose`
 * **Meaning:** Attempts to route traffic to endpoints within the same zone as
-  the client. If no endpoints are available within the zone, traffic would be
-  routed to other zones.
+  the client. A zone represents a logical failure domain and has the same
+  meaning as in the well-known label `topology.kubernetes.io/zone`. If no
+  endpoints are available within the zone, traffic would be routed to other
+  zones.
 * This preference will be implemented by the use of Hints within EndpointSlices.
 * We already use Hints to implement `service.kubernetes.io/topology-mode: Auto`
   In a similar manner, the EndpointSlice controller will now also populate hints

--- a/keps/sig-network/4444-service-traffic-distribution/kep.yaml
+++ b/keps/sig-network/4444-service-traffic-distribution/kep.yaml
@@ -20,17 +20,18 @@ see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2086-service-internal-traffic-policy"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.30"
   beta: "v1.31"
+  stable: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -42,6 +43,6 @@ feature-gates:
       - kube-apiserver
 disable-supported: true
 
-# The following PRR answers are required at beta release
-# metrics:
-#   - my_feature_metric
+metrics:
+  - endpoint_slice_controller_services_count_by_traffic_distribution
+  - endpoint_slice_controller_endpointslices_changed_per_sync


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Rename PreferClose option to PreferSameZone

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4444

<!-- other comments or additional information -->
- Other comments: None

/assign @aojea @danwinship @thockin 