### PR TITLE
KEP-19: match title to issue title

### DIFF
--- a/keps/sig-apps/19-Graduate-CronJob-to-Stable/README.md
+++ b/keps/sig-apps/19-Graduate-CronJob-to-Stable/README.md
@@ -1,4 +1,4 @@
-# KEP-19: Graduate CronJob to stable
+# KEP-19: CronJobs (previously ScheduledJobs)
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)

--- a/keps/sig-apps/19-Graduate-CronJob-to-Stable/kep.yaml
+++ b/keps/sig-apps/19-Graduate-CronJob-to-Stable/kep.yaml
@@ -1,4 +1,4 @@
-title: Graduate CronJob to Stable
+title: CronJobs (previously ScheduledJobs)
 kep-number: 19
 authors:
   - "@barney-s"


### PR DESCRIPTION
Align with the title of KEP #19 -  which at the time of writing is: "**CronJobs (previously ScheduledJobs)**". This changes the KEP document and metadata to match.

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Make the title in the repo match the title of the tracking issue.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/19

<!-- other comments or additional information -->
- Other comments:

The _feature_ we added was scheduled jobs (the CronJob API); graduating it to stable was just one part of the overall journey.