### PR TITLE
KEP-3243: Update milestone v1.33 to v1.34 and add the new feature gate to control the design change of TopologySpreadConstraint's matchLabelKeys

### DIFF
--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
@@ -897,7 +897,8 @@ Pick one more of these and delete the rest.
 Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
 implementation difficulties, etc.).
 -->
-No.
+Yes, [there were](https://github.com/kubernetes/kubernetes/issues/110643), and it's been implemented in 
+[#115082](https://github.com/kubernetes/kubernetes/pull/115082) and [#118025](https://github.com/kubernetes/kubernetes/pull/118025).
 
 ### Dependencies
 

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
@@ -1081,6 +1081,7 @@ Major milestones might include:
  - 2022-06-08: KEP merged
  - 2023-01-16: Graduate to Beta
  - 2025-01-23: Change the implementation design to be aligned with PodAffinity's `matchLabelKeys`
+ - 2025-04-07: Add a new feature flag `MatchLabelKeysInPodTopologySpreadSelectorMerge` and update milestone
 
 ## Drawbacks
 

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
@@ -897,8 +897,7 @@ Pick one more of these and delete the rest.
 Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
 implementation difficulties, etc.).
 -->
-Yes. It's helpful if we have the metrics to see which plugins affect to scheduler's decisions in Filter/Score phase. 
-There is the related issue: https://github.com/kubernetes/kubernetes/issues/110643 . It's very big and still on the way.
+No.
 
 ### Dependencies
 

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/README.md
@@ -420,7 +420,8 @@ from the default constraints, but also all incoming pods during v1.34.
 We're going to change kube-scheduler to only concern `matchLabelKeys` from the default constraints at v1.35 for efficiency, 
 assuming kube-apiserver handles `matchLabelKeys` of all incoming pods.
 
-This implementation change can be disabled by the `MatchLabelKeysInPodTopologySpreadSelectorMerge` feature flag.
+Also, in case of bugs in this new design, users can disable this feature through a new feature flag, 
+`MatchLabelKeysInPodTopologySpreadSelectorMerge` (enabled by default).
 (See more details in [Feature Enablement and Rollback](#feature-enablement-and-rollback))
 
 ### Test Plan
@@ -655,14 +656,18 @@ you need any help or guidance.
 This section must be completed when targeting alpha to a release.
 -->
 
-- `MatchLabelKeysInPodTopologySpread` feature flag will toggle enabling `MatchLabelKeys` in `TopologySpreadConstraint`.
-- `MatchLabelKeysInPodTopologySpreadSelectorMerge` feature flag will toggle merging the key-value labels 
-  corresponding to `MatchLabelKeys` into `LabelSelector` of `TopologySpreadConstraint`.
-  This flag cannot be enabled on its own, and has to be enabled together with `MatchLabelKeysInPodTopologySpread`.
+- `MatchLabelKeysInPodTopologySpread` feature flag enables the `MatchLabelKeys` feature in `TopologySpreadConstraint`.
+- `MatchLabelKeysInPodTopologySpreadSelectorMerge` feature flag enables the new design described at 
+   [[v1.34] design change and a safe upgrade path](#v134-design-change-and-a-safe-upgrade-path). 
+  - If `MatchLabelKeysInPodTopologySpreadSelectorMerge` is disabled while `MatchLabelKeysInPodTopologySpread` is enabled, 
+    Kubernetes handles `MatchLabelKeys` with the classic design, kube-scheduler handles it. 
+    However, that's basically not recommended unless you encounter a bug in a new design behavior.
+  - This flag cannot be enabled on its own, and has to be enabled together with `MatchLabelKeysInPodTopologySpread`. 
+    Enabling `MatchLabelKeysInPodTopologySpreadSelectorMerge` alone has no effect, and `matchLabelKeys` will be ignored.
 
 The `MatchLabelKeysInPodTopologySpreadSelectorMerge` feature flag has been added in v1.34 and enabled by default.
 This flag can be disabled to revert [the implementation design change in v1.34](#v134-design-change-and-a-safe-upgrade-path) 
-and go back to the previous behavior.
+and go back to the previous behavior in case of bug.
 
 ###### How can this feature be enabled / disabled in a live cluster?
 

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/kep.yaml
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/kep.yaml
@@ -22,13 +22,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.25"
   beta: "v1.27"
-  stable: "v1.35"
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -37,6 +37,9 @@ feature-gates:
     components:
       - kube-apiserver
       - kube-scheduler
+  - name: MatchLabelKeysInPodTopologySpreadSelectorMerge
+    components:
+      - kube-apiserver
 
 disable-supported: true
 

--- a/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/kep.yaml
+++ b/keps/sig-scheduling/3243-respect-pod-topology-spread-after-rolling-upgrades/kep.yaml
@@ -7,8 +7,14 @@ status: implementable
 creation-date: 2022-03-17
 reviewers:
   - "@ahg-g"
+  - "@sanposhiho"
+  - "@macsko"
+  - "@dom4ha"
 approvers:
   - "@ahg-g"
+  - "@sanposhiho"
+  - "@macsko"
+  - "@dom4ha"
 
 see-also:
   - "/keps/sig-scheduling/895-pod-topology-spread"


### PR DESCRIPTION
One-line PR description: Update KEP milestone v1.33 to v1.34 since [the code change](https://github.com/kubernetes/kubernetes/pull/129874) have not meet the v1.33 code freeze, and  I've added the new feature gate for [#129874](https://github.com/kubernetes/kubernetes/pull/129874) as discussed in https://github.com/kubernetes/kubernetes/pull/129874#issuecomment-2714245915.
Issue link: https://github.com/kubernetes/enhancements/issues/3243
Other comments: