### PR TITLE
KEP-3257: fix ClusterRole example

### DIFF
--- a/keps/sig-auth/3257-cluster-trust-bundles/README.md
+++ b/keps/sig-auth/3257-cluster-trust-bundles/README.md
@@ -447,7 +447,7 @@ rules:
 - apiGroups:
   - certificates.k8s.io
   resources:
-  - signer
+  - signers
   resourceNames:
   - example.com/my-signer
   verbs:


### PR DESCRIPTION


<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Corrects the example ClusterRole in the README.md of KEP-3257

<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/3257

<!-- other comments or additional information -->
- Other comments:
It was using singular "signer" which doesn't work. It has to be "signers", like in the tests: https://github.com/kubernetes/kubernetes/blob/6b8e5a9457a015e5568d7ae21b94d8a4eeb41bb3/test/integration/clustertrustbundles/admission_establishtrust_test.go#L142