### PR TITLE
KEP-5067: correct details about mirror pod implementation

### DIFF
--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -231,7 +231,6 @@ and make progress.
 -->
 
 * Expand the set of mutable fields.
-* Populate `metadata.generation` and `status.ObservedGeneration` on mirror pods.
 
 ## Proposal
 
@@ -458,19 +457,12 @@ regressions back to decreasing values.
 
 #### Mirror pods
 
-We will consider populating `metadata.generation` and `status.observedGeneration` out of scope for mirror 
-pods. This means:
-
-* The API server never sets `metadata.generation` for mirror pods.
-* If there is `metadata.generation` or `status.observedGeneration` set in the incoming config for a static pod, we ignore and drop them on the API side.
-* Kubelet never sets `status.observedGeneration` for mirror pods (it will need to explicitly exclude them).
-
-This is because the kubelet currently computes the internal pod UID of a mirror pod
-using a hash of the podspec, meaning that any update to the podspec results in the kubelet
-seeing it as a pod deletion followed by creation of a new pod. This defeats the
-purpose of generation tracking, since the generation of a mirror pod will always
-be 1. To fully support generation for mirror pods, more changes to the kubelet's
-logic will be expected.
+The kubelet currently computes the internal pod UID of a mirror pod using a hash of the podspec, 
+meaning that any update to the podspec results in the kubelet seeing it as a pod deletion followed 
+by creation of a new pod. To fully support generation for mirror pods more changes to the kubelet's logic 
+will be expected. For now, we will not treat mirror pods in any special way. This means that due
+to the way that mirror pods are implemented, the generation (and observedGeneration) of a mirror pod 
+will always be 1.
 
 #### Future enhancements
 


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Correcting the details about how generation / observedGeneration are handled for mirror pods. Based on discussion in the kep and implementation prs we aren't doing anything special, so generation and observedGeneration on a mirror pod will always be 1. 

Discussion comments: 
- https://github.com/kubernetes/enhancements/pull/5068#discussion_r1945426421
- https://github.com/kubernetes/kubernetes/pull/130181#discussion_r1956715409
- https://github.com/kubernetes/kubernetes/pull/130352#discussion_r1974174831

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5067

/sig node
/assign @mrunalp 