### PR TITLE
Drop the beta stage from the KEP readme

### DIFF
--- a/keps/README.md
+++ b/keps/README.md
@@ -3,8 +3,6 @@
 A Kubernetes Enhancement Proposal (KEP) is a way to propose, communicate and coordinate on new efforts for the Kubernetes project.
 You can read the full details of the project in [KEP-0000](sig-architecture/0000-kep-process/README.md).
 
-This process is still in a _beta_ state and is mandatory for all enhancements beginning release 1.14.
-
 ## Quick start for the KEP process
 
 1. Socialize an idea with a sponsoring SIG.


### PR DESCRIPTION
This updates the `keps/README.md` file to drop the information about the process being in beta. Shoutout to @brandtkeller for noticing this one. 

/assign @johnbelamaric 