### PR TITLE
KEP-961: Bump Statefulset MaxUnavailable to beta (built on top of #4474)

### DIFF
--- a/keps/prod-readiness/sig-apps/961.yaml
+++ b/keps/prod-readiness/sig-apps/961.yaml
@@ -1,3 +1,5 @@
 kep-number: 961
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-apps/3335-statefulset-slice/README.md
+++ b/keps/sig-apps/3335-statefulset-slice/README.md
@@ -391,7 +391,7 @@ In the main control loop, StatefulSet will attempt to create pod replicas `[k, N
 *   When scaling down pods: If ordinal `j` exists but is not in range `[k, N+k-1]`), pod `j` will be terminated.
 **RollingUpdate Partition Changes**
 
-Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid.
+Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid. 
 
 ### Test Plan
 

--- a/keps/sig-apps/3335-statefulset-slice/README.md
+++ b/keps/sig-apps/3335-statefulset-slice/README.md
@@ -391,7 +391,7 @@ In the main control loop, StatefulSet will attempt to create pod replicas `[k, N
 *   When scaling down pods: If ordinal `j` exists but is not in range `[k, N+k-1]`), pod `j` will be terminated.
 **RollingUpdate Partition Changes**
 
-Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid. 
+Since `ordinals.start` changes the offset of the replica ordinals, this affects the `partition` field used for RollingUpdate. As `partition` specifies an ordinal index, the partition field must be in the range `[k, N+k-1]`, to be valid.
 
 ### Test Plan
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -705,7 +705,8 @@ No, the default behavior remains the same.
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
 Yes, you can disable the feature-gate manually once it's in Beta, this will affect StatefulSets that are in the middle of a rollout when the feature gets disabled.
-If the feature is disabled in the middle of the rollout, the rollout will continue as if maxUnavailable is 1.
+If the feature is disabled in the middle of the rollout, the rollout will continue as if maxUnavailable is 1. If there is more than one pod 
+undergoing an update, it will wait for them to complete their update, and continue as if maxUnavailable is 1.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -252,7 +252,7 @@ Go in to as much detail as necessary here.
 This might be a good place to talk about core concepts and how they relate.
 -->
 
-With `maxUnavailable` feature enabled, we'll bring down more than one pod at a time, if your application can't tolerate
+With `maxUnavailable` field set, we'll bring down more than one pod at a time, if your application can't tolerate
 this behavior, you should absolutely leave the field unset or use 1, which will match default behavior.
 
 ### Risks and Mitigations

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -325,7 +325,7 @@ type RollingUpdateStatefulSetStrategy struct {
       will remain untouched due the partition. In this choice, the number of pods terminating is not always
       maxUnavailable, but sometimes less than that. For e.g. if pod with ordinal 3 is running and available but 4 is not, we still wait for 4 to be running and available before moving on to 2. This implementation avoids
       out of order Terminations of pods.
-  2.  Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When any of 4 or 3 are running and available, pods with ordinal 2 will start Terminating. This could violate
+  2.  Pods with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). When any of 4 or 3 are running and available, pods with ordinal 2 will start Terminating. This could violate
       ordering guarantees, since if 3 is running and available, then both 4 and 2 are terminating at the same
       time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation, guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
   3.  Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -272,7 +272,7 @@ Consider including folks who also work outside the SIG or subproject.
 We are proposing a new field called `maxUnavailable` whose default value will be 1. In this mode, StatefulSet will behave exactly like its current behavior.
 It's possible we introduce a bug in the implementation. The mitigation currently is that this feature is disabled by default in Alpha phase for people to try out and give
 feedback.
-In Beta phase when its enabled by default, people will only see issues or bugs when `maxUnavailable` is set to something greater than 1. Since people have
+In Beta phase when its enabled by default, users will only see issues or bugs when `maxUnavailable` is set to something greater than 1. Since people have
 tried this feature in Alpha, we would have time to fix issues.
 
 ## Design Details

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -331,7 +331,7 @@ type RollingUpdateStatefulSetStrategy struct {
   3.  Pod with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
       running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
       only 1 is unavailable although we requested 2.
-  4.  (Implemented approach) Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further
+  4.  (Implemented approach) Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they don't care. To simplify this further
       PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesn't apply to Rolling Updates. So instead of coming up
       with a new field, we could use the PodManagementPolicy to choose the behavior the User wants.
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -270,7 +270,7 @@ Consider including folks who also work outside the SIG or subproject.
 -->
 
 We are proposing a new field called `maxUnavailable` whose default value will be 1. In this mode, StatefulSet will behave exactly like its current behavior.
-Its possible we introduce a bug in the implementation. The mitigation currently is that is disabled by default in Alpha phase for people to try out and give
+It's possible we introduce a bug in the implementation. The mitigation currently is that this feature is disabled by default in Alpha phase for people to try out and give
 feedback.
 In Beta phase when its enabled by default, people will only see issues or bugs when `maxUnavailable` is set to something greater than 1. Since people have
 tried this feature in Alpha, we would have time to fix issues.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -774,7 +774,7 @@ that might indicate a serious problem?
 Administrators should monitor the following metrics to assess the need for a rollback:
 
 - `statefulset_unavailability_violation`: Ths metric reflects the number of times the maxUnavailable condition is violated (i.e. spec.replicas - availableReplicas > maxUnavailable).
-Mutiple violations of maxUnavailable might indicate issues with feature behavior.
+Multiple violations of maxUnavailable might indicate issues with feature behavior.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -654,7 +654,7 @@ enhancement:
 - If we try to set this field, it will be silently dropped.
 - If the object with this field already exists, we maintain is as it is, but the controller
   will just ignore this field.
-- downgrade of kube-apiserver to a version with the feature flag was disabled, when the field was previously set - the field gets ignored by controller, and controller behaves as if the field is not set
+- downgrade of kube-apiserver to a version with the feature flag was disabled, when the field was previously set - the field gets ignored by apiserver, and controller behaves as if the field is not set
 - downgrade of kube-controller-manager to version with the feature flag disabled, when the field was previously set - the field gets ignored by controller, and controller behaves as if the field is not set
 - downgrade of either kube-apiserver or kube-controller-manager to a version with the feature flag was disabled, when the field was not set the behavior doesn't change
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -598,7 +598,6 @@ on feature enable and disabled
 A rollout or rollback of this feature can fail if there is a bug which causes the kube-apiserver or
 the kube-controller-manager to start crashing when the feature flag is enabled.
 
-
 Yes, it can impact already running workloads.
 
 If a rolling update is in progress for a StatefulSet, while this feature is being enabled in kube-apiserver
@@ -610,7 +609,8 @@ maxUnavailable pods with the same identity and never more than maxUnavailable be
 ###### What specific metrics should inform a rollback?
 
 When feature enabled but rolling update in a unexpected phenomenon like the update pods at a time is not equal to the
-`maxUnavailable` value or rolling update in a unexpected order.
+`maxUnavailable` value (we may have some other factors impacting this, but this should apply for most of the time) or
+rolling update in a unexpected order.
 
 Or we can refer to the `rolling-update-duration` metric for observation, if it didn't decrease when setting the `maxUnavailable`
 great than 1 or the duration increased abnormally, then we should rollback.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -328,7 +328,7 @@ type RollingUpdateStatefulSetStrategy struct {
   2.  Pods with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). When any of 4 or 3 are running and available, pods with ordinal 2 will start Terminating. This could violate
       ordering guarantees, since if 3 is running and available, then both 4 and 2 are terminating at the same
       time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
-  3.  Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
+  3.  Pod with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
       running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
       only 1 is unavailable although we requested 2.
   4.  (Implemented approach) Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -321,7 +321,7 @@ type RollingUpdateStatefulSetStrategy struct {
   updated when the StatefulSet’s .spec.template is updated. Lets say total replicas is 5 and partition is set to 2 and maxUnavailable is set to 2. If the image is changed in this scenario, following
   are the possible behavior choices we have:
 
-  1.  Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). Once they are both running and available, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
+  1.  Pods with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). Once they are both running and available, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
       will remain untouched due the partition. In this choice, the number of pods terminating is not always
       maxUnavailable, but sometimes less than that. For e.g. if pod with ordinal 3 is running and available but 4 is not, we still wait for 4 to be running and available before moving on to 2. This implementation avoids
       out of order Terminations of pods.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -766,7 +766,7 @@ Yes, you can disable the feature-gate manually once it's in Beta, this will affe
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
-If we disable the feature-gate and reenable it again, then the `maxUnavailable` will take effect again. [Even if this is a new field, it only gets cleared if it was not set before (if it was nil). So if it is set it continues to exist and is enforced.](https://github.com/kubernetes/kubernetes/blob/bb67eb5bd237334d6d0343aa382b351002653404/pkg/registry/apps/statefulset/strategy.go#L120-L137). This will affect StatefulSets that are in the middle of a rollout when the feature gets re-enabled.
+If we disable the feature-gate and reenable it again, then the `maxUnavailable` will take effect again. [Even if this is a new field, it only gets cleared if it was not set before (if it was nil). So if it is set it continues to exist and is enforced.](https://github.com/kubernetes/kubernetes/blob/bb67eb5bd237334d6d0343aa382b351002653404/pkg/registry/apps/statefulset/strategy.go#L120-L137) This will affect StatefulSets that are in the middle of a rollout when the feature gets re-enabled.
 
 ###### Are there any tests for feature enablement/disablement?
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -365,7 +365,7 @@ For PMP=Parallel, we will use Choice 2.
 For PMP=OrderedReady, the plan for alpha was to go with Choice 3 to ensure we can support ordering guarantees while also
 making sure the rolling updates are fast, but for simplicity Choice 1 was implemented instead.
 
-We are keeping implementation the same for beta release, going the simpler route, but instead of checking for healthy pods in the part of the code that decides what is a `unavailablePod`, we check for `isUnavailable`, fixing https://github.com/kubernetes/kubernetes/issues/112307.
+We are keeping implementation the same for beta release, going the simpler route, but instead of checking for healthy pods in the part of the code that decides what is a `unavailablePod`, we check for `isUnavailable`, so that `minReadySeconds` is respected.
 
 https://github.com/kubernetes/kubernetes/blob/eb8f3f194fed16484162aebdaab69168e02f8cb4/pkg/controller/statefulset/stateful_set_control.go#L740
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -320,12 +320,12 @@ type RollingUpdateStatefulSetStrategy struct {
 ```
 
 - By Default, if maxUnavailable is not specified, its value will be assumed to be 1 and StatefulSets
-  will follow their old behavior. This will also help while upgrading from a release which doesnt support maxUnavailable to a release which supports this field.
+  will follow their old behavior. This will also help while upgrading from a release which doesn't support maxUnavailable to a release which supports this field.
 - If maxUnavailable is specified, it cannot be greater than total number of replicas.
 - If maxUnavailable is specified and partition is also specified, MaxUnavailable cannot be greater than `replicas-partition`
 - If a partition is specified, maxUnavailable will only apply to all the pods which are staged by the
   partition. Which means all Pods with an ordinal that is greater than or equal to the partition will be
-  updated when the StatefulSet’s .spec.template is updated. Lets say total replicas is 5 and partition is set to 2 and maxUnavailable is set to 2. If the image is changed in this scenario, following
+  updated when the StatefulSet’s .spec.template is updated. Let's say total replicas is 5 and partition is set to 2 and maxUnavailable is set to 2. If the image is changed in this scenario, following
   are the possible behavior choices we have:
 
   1.  Pods with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). Once they are both running and available, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -332,7 +332,7 @@ type RollingUpdateStatefulSetStrategy struct {
       running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
       only 1 is unavailable although we requested 2.
   4.  (Implemented approach) Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further
-      PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesnt apply to Rolling Updates. So instead of coming up
+      PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesn't apply to Rolling Updates. So instead of coming up
       with a new field, we could use the PodManagementPolicy to choose the behavior the User wants.
 
               1. PMP=Parallel will now apply to RollingUpdate. This will choose behavior described in 2 above.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -319,7 +319,7 @@ type RollingUpdateStatefulSetStrategy struct {
 - If a partition is specified, maxUnavailable will only apply to all the pods which are staged by the
   partition. Which means all Pods with an ordinal that is greater than or equal to the partition will be
   updated when the StatefulSet’s .spec.template is updated. Lets say total replicas is 5 and partition is set to 2 and maxUnavailable is set to 2. If the image is changed in this scenario, following
-  are the possible behavior choices we have:-
+  are the possible behavior choices we have:
 
   1.  Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). Once they are both running and available, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
       will remain untouched due the partition. In this choice, the number of pods terminating is not always

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -941,12 +941,12 @@ For each of them, fill in the following information by copying the below templat
 
 - Incorrect Handling of minReadySeconds During StatefulSet Updates with Parallel Pod Management
   - Detection:
-    - Monitor the status.availableReplicas of the StatefulSet during rolling updates. A significant drop below the expected number of available replicas, considering the maxUnavailable setting, could indicate the issue.
+    - Monitor the `statefulset_unavailability_violation` metric of the StatefulSet during rolling updates. A large value of this metric could indicate the issue.
     - Review StatefulSet events or controller logs for rapid succession of pod updates without adherence to minReadySeconds, which could confirm that the delay is not being respected.
   - Mitigations:
     - Temporarily adjust the podManagementPolicy to OrderedReady as a workaround to ensure minReadySeconds is respected during updates, though this may slow down the rollout process.
     - Setting maxUnavailable back to 1 or disabling the feature is a possibility.
-    - Upgrade your cluster to 1.31, where this feature is promoted to beta, and the issue is fixed.
+    - Upgrade your cluster to 1.34, where this feature is promoted to beta, and the issue is fixed.
   - Diagnostics:
     - Events should be the first place one should look when trying to diagnose this failure mode.
     - If events are not sufficient, detailed logging could be enabled for the StatefulSet controller to capture the sequence and timing of pod updates during a rollout.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -523,7 +523,7 @@ when drafting this test plan.
 [testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
 -->
 
-[x] I/we understand the owners of the involved components may require updates to
+- [x] I/we understand the owners of the involved components may require updates to
 existing tests to make this code solid enough prior to committing the changes necessary
 to implement this enhancement.
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -169,7 +169,7 @@ demonstrate the interest in a KEP within the wider Kubernetes community.
 [experience reports]: https://github.com/golang/go/wiki/ExperienceReports
 -->
 
-Consider the following scenarios:-
+Consider the following scenarios:
 
 1. My containers publish metrics to a time series system. If I am using a Deployment, each rolling
    update creates a new pod name and hence the metrics published by this new pod starts a new time series

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -327,7 +327,7 @@ type RollingUpdateStatefulSetStrategy struct {
       out of order Terminations of pods.
   2.  Pods with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). When any of 4 or 3 are running and available, pods with ordinal 2 will start Terminating. This could violate
       ordering guarantees, since if 3 is running and available, then both 4 and 2 are terminating at the same
-      time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation, guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
+      time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
   3.  Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
       running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
       only 1 is unavailable although we requested 2.

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -331,7 +331,7 @@ type RollingUpdateStatefulSetStrategy struct {
   3.  Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
       running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
       only 1 is unavailable although we requested 2.
-  4.  Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further
+  4.  (Implemented approach) Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further
       PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesnt apply to Rolling Updates. So instead of coming up
       with a new field, we could use the PodManagementPolicy to choose the behavior the User wants.
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -510,11 +510,11 @@ New testcases being added:
 
 Coverage:
 
-- `pkg/apis/apps/v1`: `2023-05-26` - `71.7%`
-- `pkg/apis/apps/v1beta2`: `2023-05-26` - `76.7%`
-- `pkg/apis/apps/validation`: `2023-05-26` - `92.3%`
-- `pkg/controller/statefulset`: `2023-05-26` - `85.7%`
-- `pkg/registry/apps/statefulset`: `2023-05-26` - `63.9%`
+- `pkg/apis/apps/v1`: `2025-06-12` - `31.1%`
+- `pkg/apis/apps/v1beta2`: `2025-06-12` - `31.1%`
+- `pkg/apis/apps/validation`: `2025-06-12` - `92.5%`
+- `pkg/controller/statefulset`: `2025-06-12` - `86.5%`
+- `pkg/registry/apps/statefulset`: `2025-06-12` - `81.4%`
 
 ##### Integration tests
 

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -320,15 +320,15 @@ partition. Which means all Pods with an ordinal that is greater than or equal to
 updated when the StatefulSet’s .spec.template is updated. Lets say total replicas is 5 and partition is set to 2 and maxUnavailable is set to 2. If the image is changed in this scenario, following
   are the possible behavior choices we have:-
 
-  1. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). Once they are both running and ready, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
+  1. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). Once they are both running and available, pods with ordinal 2 will start Terminating. Pods with ordinal 0 and 1
 will remain untouched due the partition. In this choice, the number of pods terminating is not always
-maxUnavailable, but sometimes less than that. For e.g. if pod with ordinal 3 is running and ready but 4 is not, we still wait for 4 to be running and ready before moving on to 2. This implementation avoids
+maxUnavailable, but sometimes less than that. For e.g. if pod with ordinal 3 is running and available but 4 is not, we still wait for 4 to be running and available before moving on to 2. This implementation avoids
 out of order Terminations of pods.
-  2. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When any of 4 or 3 are running and ready, pods with ordinal 2 will start Terminating. This could violate
-ordering guarantees, since if 3 is running and ready, then both 4 and 2 are terminating at the same
-time out of order. If 4 is running and ready, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation, guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
-  3. Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and ready, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
-running and ready before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
+  2. Pods with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When any of 4 or 3 are running and available, pods with ordinal 2 will start Terminating. This could violate
+ordering guarantees, since if 3 is running and available, then both 4 and 2 are terminating at the same
+time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation, guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
+  3. Pod with ordinal 4 and 3 will start Terminating at the same time(because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
+running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
 only 1 is unavailable although we requested 2.
   4. Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they dont care. To simplify this further
 PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesnt apply to Rolling Updates. So instead of coming up
@@ -387,7 +387,7 @@ https://github.com/kubernetes/kubernetes/blob/eb8f3f194fed16484162aebdaab69168e0
     }
 
     // Collect all targets in the range between getStartOrdinal(set) and getEndOrdinal(set). Count any targets in that range
-    // that are unhealthy i.e. terminated or not running and ready as unavailable). Select the
+    // that are unhealthy i.e. terminated or not running and available as unavailable). Select the
     // (MaxUnavailable - Unavailable) Pods, in order with respect to their ordinal for termination. Delete
     // those pods and count the successful deletions. Update the status with the correct number of deletions.
     unavailablePods := 0

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/README.md
@@ -329,7 +329,7 @@ type RollingUpdateStatefulSetStrategy struct {
       ordering guarantees, since if 3 is running and available, then both 4 and 2 are terminating at the same
       time out of order. If 4 is running and available, then both 3 and 2 are Terminating at the same time and no ordering guarantees are violated. This implementation guarantees, that always there are maxUnavailable number of Pods Terminating except the last batch.
   3.  Pod with ordinal 4 and 3 will start Terminating at the same time (because of maxUnavailable). When 4 is running and available, 2 will start Terminating. At this time both 2 and 3 are terminating. If 3 is
-      running and available before 4, 2 wont start Terminating to preserve ordering semantics. So at this time,
+      running and available before 4, 2 won't start Terminating to preserve ordering semantics. So at this time,
       only 1 is unavailable although we requested 2.
   4.  (Implemented approach) Introduce a field in Rolling Update, which decides whether we want maxUnavailable with ordering or without ordering guarantees. Depending on what the user wants, this Choice can either choose behavior 1 or 3 if ordering guarantees are needed or choose behavior 2 if they don't care. To simplify this further
       PodManagementPolicy today supports `OrderedReady` or `Parallel`. The `Parallel` mode only supports scale up and tear down of StatefulSets and currently doesn't apply to Rolling Updates. So instead of coming up

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -4,6 +4,7 @@ authors:
   - "@krmayankk"
   - "@kerthcet"
   - "@knelasevero"
+  - "@edwinhr716"
 owning-sig: sig-apps
 participating-sigs: []
 status: implementable

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -2,30 +2,43 @@ title: Implement maxUnavailable for StatefulSets
 kep-number: 961
 authors:
   - "@krmayankk"
+  - "@kerthcet"
 owning-sig: sig-apps
-participating-sigs:
-  - sig-apps
+participating-sigs: []
+status: implementable
+creation-date: 2018-12-29
 reviewers:
   - "@janetkuo"
   - "@kow3ns"
 approvers:
   - "@janetkuo"
   - "@kow3ns"
-editor: TBD
-creation-date: 2018-12-29
-last-updated: 2022-01-01
-status: implementable
-see-also:
-  - n/a
-replaces:
-  - n/a
-superseded-by:
-  - n/a
+
+see-also: []
+replaces: []
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.28"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.25"
-  stable: "v1.26"
-latest-milestone: "v1.24"
-stage: "alpha"
+  beta: "v1.28"
+  stable: TBD
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: MaxUnavailableStatefulSet
+    components:
+      - kube-controller-manager
+      - kube-apiserver
+
+# The following PRR answers are required at beta release
+metrics:
+  - rolling-update-duration

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 961
 authors:
   - "@krmayankk"
   - "@kerthcet"
+  - "@knelasevero"
 owning-sig: sig-apps
 participating-sigs: []
 status: implementable
@@ -25,12 +26,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.28"
+latest-milestone: "v1.30"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.28"
+  beta: "v1.30"
   stable: TBD
 
 # The following PRR answers are required at alpha release
@@ -44,4 +45,4 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - rolling-update-duration-seconds
+  - kube_statefulset_spec_strategy_rollingupdate_max_unavailable

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -40,7 +40,8 @@ feature-gates:
     components:
       - kube-controller-manager
       - kube-apiserver
+disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - rolling-update-duration
+  - rolling-update-duration-seconds

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -27,12 +27,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.30"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.24"
-  beta: "v1.30"
+  beta: "v1.34"
   stable: TBD
 
 # The following PRR answers are required at alpha release
@@ -46,4 +46,4 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - kube_statefulset_spec_strategy_rollingupdate_max_unavailable
+  - statefulset_unavailability_violation

--- a/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
+++ b/keps/sig-apps/961-maxunavailable-for-statefulset/kep.yaml
@@ -10,9 +10,11 @@ creation-date: 2018-12-29
 reviewers:
   - "@janetkuo"
   - "@kow3ns"
+  - "@soltysh"
 approvers:
   - "@janetkuo"
   - "@kow3ns"
+  - "@soltysh"
 
 see-also: []
 replaces: []


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->
Supersedes #4474 

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bump Statefulset MaxUnavailable to beta

<!-- link to the k/enhancements issue -->
- Issue link: #961 

<!-- other comments or additional information -->
- Other comments: kept @kerthcet's and @knelasevero's commits here. My commits: adding metric information

Metrics PR: https://github.com/kubernetes/kubernetes/pull/130951