### PR TITLE
KEP-5073: Declarative Validation: Explain subresources

### DIFF
--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
@@ -955,7 +955,7 @@ The linter will flag any violations of these rules, ensuring consistent zero-val
 These subresources have the following characteristics:
 
 * They operate on the same underlying storage object as the primary resource (i.e., same `kind`, same object in etcd).
-* Updates via these subresources are typically scoped to specific fields within the object. Changes to field values not in scope are tyipcally reset, or "wiped", before validation.
+* Updates via these subresources are typically scoped to specific fields within the object. Changes to field values not in scope are typically reset, or "wiped", before validation.
 * In some cases, they permit updates to fields that cannot be changed via the primary resource.
 
 **Examples:**
@@ -1004,7 +1004,7 @@ These subresources have the following characteristics:
 **Support required:**
 
 * Declarative validation will need to provide a easy way for a storage layer to map the internal type of a subresource to the
-  requested versioned type of that resource.  For primary resoruce validation, the information is present in the requestInfo of
+  requested versioned type of that resource.  For primary resource validation, the information is present in the requestInfo of
   the context, but for these validations, the storage layer typically [manages a mapping](https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/pkg/registry/core/replicationcontroller/storage/storage.go#L170-L177) which will need to
   be used. https://github.com/jpbetz/kubernetes/pull/141 provides an example of migrating a `/scale` subresource and 
   introduces utilities for managing the subresource mapping.

--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
@@ -971,7 +971,7 @@ These subresources have the following characteristics:
 1.  **Field Wiping (Pre-Validation):** Declarative Validation *does not* scope which fields a subresource operation can write. Instead, this responsibility lies with the resource's strategy implementation. The strategy modifies the incoming object *before* validation, "wiping" or resetting any fields the specific subresource operation is not allowed to change. Once wiped, the ratcheting mechanism (below) will skip validation of these fields, since wiping ensures that they are unchanged.
 2.  **Full Resource Validation:** The *entire*, modified resource object is validated against the primary resource's versioned type. That is, *same* set of declarative validation rules applied to the primary resource and to status-type subresources.
 3.  **Conditional Validation:** Validation rules can use a special `subresource` parameter (e.g., `subresource == '/status'`) to apply conditional logic. This allows rules to behave differently depending on whether the update comes via the primary resource or a specific subresource.
-4.  **Ratcheting:** Declarative Validation uses ratcheting, meaning it skips validation checks on fields that have not changed from the existing stored object. Combined with field wiping, this scopes validation to only the subset of fields that the subresource operation is intended and permitted to modify.
+4.  **Ratcheting:** Declarative Validation uses ratcheting, meaning validation does not fail for fields that have not changed from the existing stored object. Combined with field wiping, this scopes validation to only the subset of fields that the subresource operation is intended and permitted to modify.
 
 **Validation Examples:**
 

--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
@@ -976,11 +976,11 @@ These subresources have the following characteristics:
 **Validation Examples:**
 
 * An update via `pods/status` first has its `spec` field changes wiped by the Pod strategy. Then, the entire Pod object is validated using the standard Pod validation rules. Ratcheting skips checks on unchanged `metadata` or `status` fields.
-* An update via `pods/resize` is validated using the standard Pod rules. However, a rule on `spec.container[*].resources` might look like `+k8s:if('subresource != "/resize"')=+k8s:immutable`, effectively enforcing immutability *unless* the update comes via the `resize` subresource.
+* An update via `pods/resize` is validated using the standard Pod rules. However, a rule on `spec.container[*].resources` might look like `+k8s:exceptSubresource("/resize"')=+k8s:immutable`, effectively enforcing immutability *unless* the update comes via the `resize` subresource.
 
 **Support required:**
 
-* To enable conditional validation, declarative validation provides access to the `subresources` parameter within validation rule expressions.
+* Conditional validation, provided by dedicated `+k8s:subresource` and `+k8s:exceptSubresource` tags and a `subresources` parameter within validation rule expressions (e.g. `+k8s:if('subresource != "/resize"')=+k8s:immutable`).
 
 #### Scale-Type Subresources
 
@@ -1008,10 +1008,15 @@ These subresources have the following characteristics:
   the context, but for these validations, the storage layer typically [manages a mapping](https://github.com/kubernetes/kubernetes/blob/30469e180361d7da07b0fee6d47c776fa2cf3e86/pkg/registry/core/replicationcontroller/storage/storage.go#L170-L177) which will need to
   be used. https://github.com/jpbetz/kubernetes/pull/141 provides an example of migrating a `/scale` subresource and 
   introduces utilities for managing the subresource mapping.
+* Conditional validation, provided by dedicated `+k8s:subresource` and `+k8s:exceptSubresource` tags and a `subresources` parameter within validation rule expressions (e.g. `+k8s:if('subresource != "/scale"')=...`).
 
 #### Streaming Subresources
 
-Subresources such as `pods/exec`, `pods/attach`, and `pods/portforward` do not require declarative validation, as they operate on data streams, not structured resource data.
+Subresources such as `pods/exec`, `pods/attach`, and `pods/portforward` often have "options" as structured resource data. Declarative
+validation will support validation of such resources using the same mechanisms as scale-type subresources, only since the resource
+is not stored, the use case is much simpler and only requires the "Subresource Validation" step.
+
+The streamed data does not require declarative validation, as it is not structured resource data.
 
 ### Ratcheting
 


### PR DESCRIPTION
This addresses how we intend to handle subresources with Declarative Validation.

A separate PR will update the ratcheting section to address the need to skip unchanged fields when validating.