### PR TITLE
KEP-5270: Graduate custom.metrics.k8s.io to stable

### DIFF
--- a/keps/sig-instrumentation/5270-graduate-custom-metrics-k8s-io-to-stable/README.md
+++ b/keps/sig-instrumentation/5270-graduate-custom-metrics-k8s-io-to-stable/README.md
@@ -1,0 +1,979 @@
+<!--
+**Note:** When your KEP is complete, all of these comment blocks should be removed.
+
+To get started with this template:
+
+- [ ] **Pick a hosting SIG.**
+  Make sure that the problem space is something the SIG is interested in taking
+  up. KEPs should not be checked in without a sponsoring SIG.
+- [ ] **Create an issue in kubernetes/enhancements**
+  When filing an enhancement tracking issue, please make sure to complete all
+  fields in that template. One of the fields asks for a link to the KEP. You
+  can leave that blank until this KEP is filed, and then go back to the
+  enhancement and add the link.
+- [ ] **Make a copy of this template directory.**
+  Copy this template into the owning SIG's directory and name it
+  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
+  leading-zero padding) assigned to your enhancement above.
+- [ ] **Fill out as much of the kep.yaml file as you can.**
+  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
+  "Status", and date-related fields.
+- [ ] **Fill out this file as best you can.**
+  At minimum, you should fill in the "Summary" and "Motivation" sections.
+  These should be easy if you've preflighted the idea of the KEP with the
+  appropriate SIG(s).
+- [ ] **Create a PR for this KEP.**
+  Assign it to people in the SIG who are sponsoring this process.
+- [ ] **Merge early and iterate.**
+  Avoid getting hung up on specific details and instead aim to get the goals of
+  the KEP clarified and merged quickly. The best way to do this is to just
+  start with the high-level sections and fill out details incrementally in
+  subsequent PRs.
+
+Just because a KEP is merged does not mean it is complete or approved. Any KEP
+marked as `provisional` is a working document and subject to change. You can
+denote sections that are under active debate as follows:
+
+```
+<<[UNRESOLVED optional short context or usernames ]>>
+Stuff that is being argued.
+<<[/UNRESOLVED]>>
+```
+
+When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
+focused. If you disagree with what is already in a document, open a new PR
+with suggested changes.
+
+One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
+You do not need a new KEP to move from beta to GA, for example. If
+new details emerge that belong in the KEP, edit the KEP. Once a feature has become
+"implemented", major changes should get new KEPs.
+
+The canonical place for the latest set of instructions (and the likely source
+of this file) is [here](/keps/NNNN-kep-template/README.md).
+
+**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
+it is marked `implementable`, must be approved by each of the KEP approvers.
+If none of those approvers are still appropriate, then changes to that list
+should be approved by the remaining approvers and/or the owning SIG (or
+SIG Architecture for cross-cutting KEPs).
+-->
+# KEP-5270: Graduate custom.metrics.k8s.io to Stable
+
+<!--
+This is the title of your KEP. Keep it short, simple, and descriptive. A good
+title can help communicate what the KEP is and should be considered as part of
+any review.
+-->
+
+<!--
+A table of contents is helpful for quickly jumping to sections of a KEP and for
+highlighting any additional information provided beyond the standard KEP
+template.
+
+Ensure the TOC is wrapped with
+  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
+tags, and then generate with `hack/update-toc.sh`.
+-->
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+    - [Story 2](#story-2)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge code into a release, there must be an
+issue in [kubernetes/enhancements] referencing this KEP and targeting a release
+milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
+of the targeted release**.
+
+For enhancements that make changes to code or processes/procedures in core
+Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
+Signoff checklist to be completed.
+
+Check these off as they are completed for the Release Team to track. These
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [X] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [X] (R) Graduation criteria is in place
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+<!--
+This section is incredibly important for producing high-quality, user-focused
+documentation such as release notes or a development roadmap. It should be
+possible to collect this information before implementation begins, in order to
+avoid requiring implementors to split their attention between writing release
+notes and implementing the feature itself. KEP editors and SIG Docs
+should help to ensure that the tone and content of the `Summary` section is
+useful for a wide audience.
+
+A good summary is probably at least a paragraph in length.
+
+Both in this section and below, follow the guidelines of the [documentation
+style guide]. In particular, wrap lines to a reasonable length, to make it
+easier for reviewers to cite specific portions, and to minimize diff churn on
+updates.
+
+[documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
+-->
+
+Promote the `custom.metrics.k8s.io` API to stable, which has been in perma-beta
+for a while now (`v1beta2`'s last change was ~7y ago). This is also in-line with
+the fact that owing to such a lengthy soak period, we can safely say that this
+is doing well in production environments all over the world, for instance,
+Prometheus Adapter has been utilized by the community since its incubation in
+2017, which heavily relies on the same API. We believe that, owing to such
+factors, it makes sense to graduate the API to stable.
+
+## Motivation
+
+<!--
+This section is for explicitly listing the motivation, goals, and non-goals of
+this KEP.  Describe why the change is important and the benefits to users. The
+motivation section can optionally provide links to [experience reports] to
+demonstrate the interest in a KEP within the wider Kubernetes community.
+
+[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
+-->
+
+### Goals
+
+<!--
+List the specific goals of the KEP. What is it trying to achieve? How will we
+know that this has succeeded?
+-->
+
+- Graduate `custom.metrics.k8s.io` to stable, by introducing the same API under
+  `v1` as exists currently under `v1beta2`.
+- The graduation (and thus the migration to the newer version) should be
+  non-breaking.
+
+### Non-Goals
+
+<!--
+What is out of scope for this KEP? Listing non-goals helps to focus discussion
+and make progress.
+-->
+
+- Introduce `v1` version of the API that differs from `v1beta2` in any way,
+  except naming.
+- Drop support for any of the existing `v1beta1` and/or `v1beta2` version(s).
+
+## Proposal
+
+<!--
+This is where we get down to the specifics of what the proposal actually is.
+This should have enough detail that reviewers can understand exactly what
+you're proposing, but should not include things like API designs or
+implementation. What is the desired outcome and how do we measure success?.
+The "Design Details" section below is for the real
+nitty-gritty.
+-->
+
+The proposal broadly entails two efforts:
+- Introducing `custom.metrics.k8s.io/v1` for the `k8s.io/metrics` package, and,
+- Migrating in-house components and sub-projects to utilize the stable version.
+
+The former will more-or-less be a cosmetic change, essentially bumping `v1beta2`
+to `v1`, as such, the latter will be exactly the same as the former as far as
+the API surface is concerned, with the only difference being the version names
+themselves.
+
+The latter will focus on utilizing the stable version in the
+`custom.metrics.k8s.io`'s client, as well as `pkg/controller/podautoscaler`,
+which is currently on the latest beta version. However, please note that we do
+not plan on doing the same for Prometheus Adapter, as it is slated for
+deprecation in the near future.
+
+### Risks and Mitigations
+
+<!--
+What are the risks of this proposal, and how do we mitigate? Think broadly.
+For example, consider both security and how this will impact the larger
+Kubernetes ecosystem.
+
+How will security be reviewed, and by whom?
+
+How will UX be reviewed, and by whom?
+
+Consider including folks who also work outside the SIG or subproject.
+-->
+
+For the purpose of explaining the risks, we'll assume two entities here.
+
+First, a requester (e.g., HPAs), which utilizes the `custom.metrics.k8s.io`
+client, and second, a custom metrics adapter (e.g., Prometheus Adapter) which
+utilizes the type definitions exposed by
+`k8s.io/metrics/pkg/apis/custom_metrics` to wrap over and expose the metrics
+recieved from the metrics backend in a manner that's is consumable by the
+requester. 
+
+The requester and the adapter are linked through an `APIService` object, which
+allows the latter to act as addon APIServer through the aggregation layer for
+all requests from the requester towards that `GroupVersion`. Note that while the
+APIServer will promote or fallback between versions that support conversions,
+that is not the case within the aggregation layer.
+
+Now, let's consider the different scenarios that can arise from varying
+configurations of the two:
+
+| Requester's `custom.metrics.k8s.io` client version | APIService's `GroupVersion` | Adapter's `k8s.io/metrics/pkg/apis/custom_metrics` type definitions' version | Working version       |
+| -------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------- | --------------------- |
+| Beta                                               | Stable                      | No effect (as both API surfaces are interchangeable)                         | 404 for client's verb |
+| Stable                                             | Beta                        | No effect (as both API surfaces are interchangeable)                         | 404 for client's verb |
+| Stable                                             | Stable                      | No effect (as both API surfaces are interchangeable)                         | Stable                |
+| Beta                                               | Beta                        | No effect (as both API surfaces are interchangeable)                         | Beta                  |
+
+Therefore, users need to ensure that the same version is being used between the
+requester and the adapter in order for the migration to be successful.
+
+## Design Details
+
+<!--
+This section should contain enough information that the specifics of your
+change are understandable. This may include API specs (though not always
+required) or even code snippets. If there's any ambiguity about HOW your
+proposal will be implemented, this is the place to discuss them.
+-->
+
+The `custom.metrics.k8s.io` API enables operations based on metric(s) associated
+with **any** object inside the cluster in a manner that is adapter-agnostic. As
+a part of the aggregation layer, adapters instrumenting the API benefit from
+APIServer's authentication and authorization measures out-of-the-box (on top of
+their own), while the API itself servers as a standardized interface for such
+operations within the ecosystem.
+
+The diagram below gives a general idea on the flow:
+
+```mermaid
+graph TD
+A[Requester] -- GET custom.metrics.k8s.io/v1beta1/... --> B[API Server]
+B -- v1beta1.custom.metrics.k8s.io APIService --> C[Adapter]
+C -- v1beta2.MetricValue (instantaneous) OR v1beta2.MetricValueList (ranged) --> B
+C -- metric resolution --> D[Metrics backend]
+```
+
+- The requester, through the `custom.metrics.k8s.io` client, sends out a verb
+  request. The format of the request is implicitly dictated by
+  `k8s.io/metrics/pkg/apis/custom_metrics` as this conformance ensures that the
+  adapter understands it. It takes the shape of:
+  ```
+  GET /apis/custom.metrics.k8s.io/v1beta2/namespaces/{ns}/{resourceType}/{resourceName}/{metricName}?{params}
+  ```
+  For e.g., to fetch data from all pods for a metric that match a certain
+  `labelSelector`:
+  ```
+  GET /apis/custom.metrics.k8s.io/v1beta2/namespaces/{ns}/pods/*/{metricName}?labelSelector=foo=bar
+  ```
+- The responsible addon APIServer is identified based on the registered
+  APIService object that matches the request's API. For e.g., for Prometheus
+  adapter, the APIService object would be as follows:
+  ```yaml
+  apiVersion: apiregistration.k8s.io/v1
+  kind: APIService
+  metadata:
+    name: v1beta2.custom.metrics.k8s.io
+  spec:
+    group: custom.metrics.k8s.io
+    groupPriorityMinimum: 100
+    insecureSkipTLSVerify: true
+    service:
+      name: prometheus-adapter
+      namespace: monitoring
+    version: v1beta2
+    versionPriority: 100
+  ```
+- The aggregator adds the `X-Remote-User: system:admin` header to the request,
+  then verifies the adapter's certificates (using the `caBundle` APIService
+  field), as well as submitting its own to identify itself to the adapter.
+- The adapter queries the metrics backend for the metrics requested, while
+  resolving them first on its own end, when needed, for e.g., the following
+  `rules` element defines how Prometheus adapter resolves `http-requests`:
+  ```
+  rules:
+  custom:
+    - seriesQuery: 'http_requests_total{namespace!="",pod!=""}'
+      resources:
+        overrides:
+          namespace:
+            resource: "namespace"
+          pod:
+            resource: "pod"
+      name:
+        matches: "http_requests_total"
+        as: "http-requests"
+      metricsQuery: 'sum(rate(http_requests_total{<<.LabelMatchers>>}[1m])) by (namespace, pod)'
+  ```
+  If no such `matches` exists for the requested metric, it is fetched as is,
+  given it exactly matches a metric name, and has the appropriate labels.
+- The requested metric resolves to one or more metrics in the matching metric
+  family, and the returned response from the adapter takes the form of a
+  `k8s.io/metrics/pkg/apis/external_metrics`.MetricValueList:
+  ```
+  {
+    "apiVersion": "custom.metrics.k8s.io/v1beta2",
+    "kind": "MetricValueList",
+    "items": [
+      {
+        "describedObject": { "kind": "Service", "name": "kubernetes", ... },
+        "metric": { "name": "test-metric", ... },
+        "timestamp": "...", 
+        "value": "300m"
+      }
+    ]
+  }
+  ```
+  Note that the `windowSeconds` is optional and typically omitted or set to zero
+  for instantaneous metrics (guages).
+- Using the recieved metrics, the requester can execute operations based on
+  defined behaviors as it wants.
+
+### Test Plan
+
+<!--
+**Note:** *Not required until targeted at a release.*
+The goal is to ensure that we don't accept enhancements with inadequate testing.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
+when drafting this test plan.
+
+[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+
+[X] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+Since the change only encompasses the API surface which remains unchanged going
+into stable, we believe that the existing testing should suffice.
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+
+#### Alpha
+
+- Feature implemented behind a feature flag
+- Initial e2e tests completed and enabled
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Complete features A, B, C
+- Additional tests are in Testgrid and linked in KEP
+
+#### GA
+
+- N examples of real-world usage
+- N installs
+- More rigorous forms of testing—e.g., downgrade tests and scalability tests
+- Allowing time for feedback
+
+**Note:** Generally we also wait at least two releases between beta and
+GA/stable, because there's no opportunity for user feedback, or even bug reports,
+in back-to-back releases.
+
+**For non-optional features moving to GA, the graduation criteria must include
+[conformance tests].**
+
+[conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
+
+#### Deprecation
+
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+
+#### GA
+
+- Migrate `pkg/controller/podautoscaler` to use
+  `k8s.io/metrics/pkg/apis/custom_metrics`'s `v1`.
+- Publish the effort on the website to spread awareness and encourage folks to
+  move onto the newer version, allowing us to additionally deprecate the older
+  ones in the late future.
+
+Please note that the ALPHA and BETA sections were left out here as those
+pre-date the KEP process in k/k. For more information, please see the KEP issue.
+
+### Upgrade / Downgrade Strategy
+
+<!--
+If applicable, how will the component be upgraded and downgraded? Make sure
+this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to maintain previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to make use of the enhancement?
+-->
+
+The primary area of focus when upgrading or downgrading is ensuring that a
+registered APIService exists for the same version that the
+`custom.metrics.k8s.io`'s client is using, i.e., if the latter is on an older
+version ensure that the APIServer knows where to route requests based on that,
+and vice versa.
+
+Do note that the version used in the adapter (assuming it's one
+of `v1beta2` or `v1`) does not affect its interoperability with the version
+defined in the APIService or the requester. Refer to the table above for more
+details.
+
+### Version Skew Strategy
+
+<!--
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- Does this enhancement involve coordinating behavior in the control plane and nodes?
+- How does an n-3 kubelet or kube-proxy without this feature available behave when this feature is used?
+- How does an n-1 kube-controller-manager or kube-scheduler without this feature available behave when this feature is used?
+- Will any other components on the node change? For example, changes to CSI,
+  CRI or CNI may require updating that component before the kubelet.
+-->
+
+In the sections above, as established, the compability between the requester and
+the APIService versions is what really matters here. Within the scope of k/k, an
+upgraded `pkg/controller/podautoscaler` (the only affected component) with the
+newer API version may fail to fetch any data whatsoever from the adapter, as the
+existing APIService would still be pointing to the older API version. While
+there are no two in-tree components involved in this scenario, HPAs could still
+fail to work with, say, Prometheus adapter, a sub-project under SIG
+Instrumentation, which follows a similar release cadence as k/k. Note that an
+upgraded `pkg/controller/podautoscaler` could still work with the same
+Prometheus adapter instance, given that an APIService object exists for the
+newer API.
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+<!--
+This section must be completed when targeting alpha to a release.
+-->
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+<!--
+Pick one of these and delete the rest.
+
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
+
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
+
+- [ ] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name: N/A
+  - Components depending on the feature gate: N/A
+- [ ] Other
+  - Describe the mechanism: The newer API may be enabled or disabled by ensuring
+    the newer or older versions exist across the HPA controller
+    (controller-manager) and the registered APIService, respectively.
+  - Will enabling / disabling the feature require downtime of the control
+    plane? No.
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node? No.
+
+###### Does enabling the feature change any default behavior?
+
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+
+No.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+
+To disable the usage of the newer version of the API, rollback the
+`controller-manager` and make sure an APIService with the older `v1beta2`
+version of the API is registered.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+No breaking behaviors, as soon as the `controller-manager` is back up with the
+newer `custom.metrics.k8s.io` API version and a corresponding APIService object,
+the observed workflow should be unchanged from its previous exhibition.
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+
+N/A
+
+### Rollout, Upgrade and Rollback Planning
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
+
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
+
+A version mismatch between the `custom.metrics.k8s.io` version being used by the
+client in the HPA controller and the available APIService objects could disrupt
+the workflow, as discussed above, in addition to some downtime until the
+upgraded `controller-manager` is spun up to support the newer API version.
+
+###### What specific metrics should inform a rollback?
+
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
+
+- `horizontal_pod_autoscaler_controller_metric_computation_total{error="internal"}`
+- `horizontal_pod_autoscaler_controller_metric_computation_duration_seconds{error="internal"}`
+
+Both of the above are true for a subset of errors for which the controller fails
+to fetch metrics. See
+[pkg/controller/podautoscaler/horizontal.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/podautoscaler/horizontal.go)
+for more information.
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+TODO.
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+No deprecations or removals, only the introduction of a newer API version.
+
+### Monitoring Requirements
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+N/A
+
+###### How can an operator determine if the feature is in use by workloads?
+
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
+
+N/A
+
+###### How can someone using this feature know that it is working for their instance?
+
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [X] API .status
+  - Condition name: AbleToScale
+  - Other field: `.status == True`
+- [X] API .status
+  - Condition name: ScalingActive
+  - Other field: `.reason == ValidMetricFound`
+- [X] Other 
+  - Details: Registered versions can be listed by quering `/apis`:
+  ```
+  kubectl get --raw /apis/custom.metrics.k8s.io/ | jq .
+  ```
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+N/A
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+N/A
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+No.
+
+### Dependencies
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+Currently, `controller-manager` relies on this API, and in order to establish an
+overall workflow, needs the aggregation layer to route the requests accordingly.
+
+### Scalability
+
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
+
+For beta, this section is required: reviewers must answer these questions.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### Will enabling / using this feature result in any new API calls?
+
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
+
+No.
+
+###### Will enabling / using this feature result in introducing new API types?
+
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
+
+Yes, `v1.custom.metrics.k8s.io` (w.r.t. the registered APIService object).
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
+
+No.
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
+
+By one. An APIService object needs to be created to register the newer API
+version.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+
+No.
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+
+No.
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+No.
+
+### Troubleshooting
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+Initially, when establishing trust, APIServer being down impacts the ability to
+register the addon APIServer (adapter), and thus disrupts the HPA controller.
+
+###### What are other known failure modes?
+
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+N/A
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+N/A
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of a KEP should be tracked in this section.
+Major milestones might include:
+- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
+- the `Proposal` section being merged, signaling agreement on a proposed design
+- the date implementation started
+- the first Kubernetes release where an initial version of the KEP was available
+- the version of Kubernetes where the KEP graduated to general availability
+- when the KEP was retired or superseded
+-->
+
+TODO.
+
+<!-- - Graduate `custom.metrics.k8s.io` to stable, by introducing the same API under -->
+<!--   `v1` as exists currently under `v1beta2`. -->
+<!-- - Migrate `pkg/controller/podautoscaler` to use -->
+<!--   `k8s.io/metrics/pkg/apis/custom_metrics`'s `v1`. -->
+<!-- - Publish the effort on the website to spread awareness and encourage folks to -->
+<!--   move onto the newer version, allowing us to additionally deprecate the older -->
+<!--   ones in the late future. -->
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+N/A
+
+## Alternatives
+
+<!--
+What other approaches did you consider, and why did you rule them out? These do
+not need to be as detailed as the proposal, but should include enough
+information to express the idea and why it was not acceptable.
+-->
+
+N/A

--- a/keps/sig-instrumentation/5270-graduate-custom-metrics-k8s-io-to-stable/kep.yaml
+++ b/keps/sig-instrumentation/5270-graduate-custom-metrics-k8s-io-to-stable/kep.yaml
@@ -1,0 +1,38 @@
+title: Graduate custom.metrics.k8s.io to Stable
+kep-number: 5270
+authors:
+  - "@rexagod"
+owning-sig: sig-instrumentation
+participating-sigs:
+  - sig-instrumentation
+status: implementable
+creation-date: "2025-05-02"
+reviewers:
+  - "@dgrisonnet"
+approvers:
+  - "@dgrisonnet"
+
+see-also:
+  - "https://github.com/kubernetes/metrics/tree/master/pkg/apis/custom_metrics"
+
+# The target maturity stage in the current dev cycle for this KEP.
+# If the purpose of this KEP is to deprecate a user-visible feature
+# and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
+stage: stable
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.34"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha:  "v1.16"   # No alpha graduation KEP exists
+  beta:   "v1.16"   # No beta graduation KEP exists
+  stable: "v1.35"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:  # Not gated since the (beta) custom.metrics.k8s.io has been in
+                # production for a good while now.
+disable-supported: false


### PR DESCRIPTION

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: "custom.metrics.k8s.io" has been in beta longer than we'd hoped it to be, but this gradutes it to stable as it's been used extensively in production environments in the ecosystem.

<!-- link to the k/enhancements issue -->
- Issue link: #5270