### PR TITLE
KEP-5055: DRA: admin-controlled attributes and device taints in 1.33

### DIFF
--- a/keps/sig-scheduling/5027-dra-admin-controlled-device-attributes/README.md
+++ b/keps/sig-scheduling/5027-dra-admin-controlled-device-attributes/README.md
@@ -788,7 +788,7 @@ For each of them, fill in the following information by copying the below templat
 
 ## Implementation History
 
-- 1.33: first KEP revision and implementation
+- 1.33: first KEP revision, implementation postponed until there is a more specific need for it
 
 ## Drawbacks
 

--- a/keps/sig-scheduling/5027-dra-admin-controlled-device-attributes/kep.yaml
+++ b/keps/sig-scheduling/5027-dra-admin-controlled-device-attributes/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 5027
 authors:
   - "@pohly"
 owning-sig: sig-scheduling
-status: implementable
+status: provisional
 creation-date: 2024-01-10
 reviewers:
   - "@dom4ha"
@@ -23,7 +23,6 @@ latest-milestone: "v1.33"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.33"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: DRA: admin-controlled attributes and device taints in 1.33

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5055, https://github.com/kubernetes/enhancements/issues/5027

<!-- other comments or additional information -->
- Other comments:

This documents the actual work that happened (for device taints and tolerations) and that didn't happen (for admin-controlled attributes).

Plans for 1.34 will follow in a separate PR.

/assign @dom4ha 