### PR TITLE
Move KEP-5116 to GA

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/5116.yaml
+++ b/keps/prod-readiness/sig-api-machinery/5116.yaml
@@ -1,3 +1,5 @@
 kep-number: 5116
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/5116-streaming-response-encoding/README.md
+++ b/keps/sig-api-machinery/5116-streaming-response-encoding/README.md
@@ -197,8 +197,9 @@ The tests will cover the following properties:
 * Different content type JSON (default), Proto, CBOR, YAML.
 * Different API kinds, eg ConfigMap, Pod, custom resources
 
-In first iteration we expect we will overallocate the resources needed for apiserver to ensure passage, 
-however after the improvement is implemented we will tune down the resources to detect regressions.
+The tests turned not only a great way to visualize the impact of the work, but also were able to catch [regression in Audit logs memory usage](https://github.com/kubernetes/kubernetes/issues/131720).
+To ensure long term sustainability we propose to introduce a release blocking test, that will detect memory regression in apiserver handling large resources.
+The test will run a known set of efficient requests and validate that apiserver memory didn't grow above certain threshold.
 
 ### Graduation Criteria
 
@@ -232,7 +233,7 @@ Via feature gates
 
 
 - [X] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: StreamingCollectionEncodingToJSON, StreamingCollectionEncodingToProto
+  - Feature gate name: StreamingCollectionEncodingToJSON, StreamingCollectionEncodingToProtobuf
   - Components depending on the feature gate: kube-apiserver
 
 ###### Does enabling the feature change any default behavior?

--- a/keps/sig-api-machinery/5116-streaming-response-encoding/kep.yaml
+++ b/keps/sig-api-machinery/5116-streaming-response-encoding/kep.yaml
@@ -9,14 +9,15 @@ reviewers:
   - liggitt
 approvers:
   - deads2k
-stage: beta
-latest-milestone: "v1.33"
+stage: stable
+latest-milestone: "v1.34"
 milestone:
   beta: "v1.33"
+  stable: "v1.34"
 feature-gates:
   - name: StreamingCollectionEncodingToJSON
     components:
       - kube-apiserver
-  - name: StreamingCollectionEncodingToProto
+  - name: StreamingCollectionEncodingToProtobuf
     components:
       - kube-apiserver


### PR DESCRIPTION
Ref https://github.com/kubernetes/enhancements/issues/5116

Proposing to move the KEP-5116 to GA. 

There were no issues discovered in the implementation, so the only pending work is preventing regressions.
Added some information about regression we have already caught by just eyeballing the graph.

Don't think there is a need to block the GA on implementation of other serialization formats. While they are supported by apiserver, they are not used in Kubernetes core projects (`kubectl get pod -o yaml` will request JSON and generate yaml on client side) and should not be recommended. 

/assign @deads2k @liggitt 