### PR TITLE
KEP-4601: Graduate authorize with selector to stable

### DIFF
--- a/keps/prod-readiness/sig-auth/4601.yaml
+++ b/keps/prod-readiness/sig-auth/4601.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-auth/4601-authorize-with-selectors/README.md
+++ b/keps/sig-auth/4601-authorize-with-selectors/README.md
@@ -929,6 +929,7 @@ Test if eliminating use of the CEL selector functions in the offending CEL expre
 
 - v1.31: Alpha release
 - v1.32: Beta release
+- v1.34: Stable release
 
 ## Drawbacks
 

--- a/keps/sig-auth/4601-authorize-with-selectors/kep.yaml
+++ b/keps/sig-auth/4601-authorize-with-selectors/kep.yaml
@@ -21,13 +21,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.32"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.31"
   beta: "v1.32"
-  stable: "TBD"
+  stable: "v1.34"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -42,4 +42,5 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - find-metric-for-failed-authorization
+  - apiserver_authorization_decisions_total
+  - apiserver_authorization_webhook_duration_seconds


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Graduate KEP-4601 to stable

<!-- link to the k/enhancements issue -->
- Issue link: #4601

<!-- other comments or additional information -->
- Other comments: No changes since beta in 1.32

/sig auth

/cc @deads2k 
for sig-auth

/cc @wojtek-t 
for PRR