### PR TITLE
KEP-5018: move to beta in 1.34

### DIFF
--- a/keps/prod-readiness/sig-auth/5018.yaml
+++ b/keps/prod-readiness/sig-auth/5018.yaml
@@ -4,3 +4,5 @@
 kep-number: 5018
 alpha:
   approver: "soltysh" 
+beta:
+  approver: "soltysh" 

--- a/keps/sig-auth/5018-dra-adminaccess/README.md
+++ b/keps/sig-auth/5018-dra-adminaccess/README.md
@@ -44,13 +44,13 @@
 Items marked with (R) are required _prior to targeting to a milestone /
 release_.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in
       [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and
       SIG Testing input (including test refactors)
-  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [x] e2e Tests for all Beta API Operations (endpoints)
   - [ ] (R) Ensure GA e2e tests meet requirements for
         [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
@@ -59,12 +59,12 @@ release_.
         [all GA Endpoints](https://github.com/kubernetes/community/pull/1806)
         must be hit by
         [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
-- [ ] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
+- [x] (R) Production readiness review completed
+- [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for
+- [x] User-facing documentation has been created in [kubernetes/website], for
       publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to
+- [x] Supporting documentation—e.g., additional design documents, links to
       mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
@@ -182,7 +182,7 @@ objects as privileged. This feature includes:
        resource.kubernetes.io/admin-access: "true"
    ```
 
-   Note: This label has been updated from `resource.k8s.io/admin-access` while the feature was in alpha in v1.33.
+   Note: This label has been updated from `resource.k8s.io/admin-access` while the feature was in alpha.
 
    Assumptions:
 
@@ -405,19 +405,15 @@ The scheduler plugin and resource claim controller are covered by the workloads
 in
 https://github.com/kubernetes/kubernetes/blob/master/test/integration/scheduler_perf/dra/performance-config.yaml
 
-Those tests run in:
+Additional test cases have been added to `test/integration/scheduler_perf` to
+ensure `ResourceClaim` or `ResourceClaimTemplate` with `adminAccess: true`
+requests are only authorized if their namespace has the
+`resource.kubernetes.io/admin-access: "true"` label as described in this KEP.
 
-- [pre-submit](https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-integration)
-  and
-  [periodic](https://testgrid.k8s.io/sig-release-master-blocking#integration-master)
-  integration testing under
-  `k8s.io/kubernetes/test/integration/scheduler_perf.scheduler_perf` and
-  `k8s.io/kubernetes/test/integration/scheduler_perf.dra.dra` and the
-  `DRAAdminAccess` feature gate is already enabled.
-- Additional test cases will be added to `test/integration/scheduler_perf` to
-  ensure `ResourceClaim` or `ResourceClaimTemplate` with `adminAccess: true`
-  requests are only authorized if their namespace has the
-  `resource.kubernetes.io/admin-access: "true"` label as described in this KEP.
+These tests run as part of the following with the `DRAAdminAccess` feature gate enabled.
+
+- `k8s.io/kubernetes/test/integration/scheduler_perf.scheduler_perf`: [pre-submit](https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-integration&include-filter-by-regex=scheduler_perf.scheduler_perf), [periodic](https://testgrid.k8s.io/sig-release-master-blocking#integration-master&include-filter-by-regex=scheduler_perf.scheduler_perf), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=scheduler_perf)
+- `k8s.io/kubernetes/test/integration/scheduler_perf.dra.dra`: [pre-submit](https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-integration&include-filter-by-regex=scheduler_perf.dra.dra),[periodic](https://testgrid.k8s.io/sig-release-master-blocking#integration-master&include-filter-by-regex=scheduler_perf.dra.dra), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=scheduler_perf)
 
 ##### e2e tests
 
@@ -451,11 +447,8 @@ ResourceClaimTemplate and ResourceClaim for admin access
 [Feature:DRAAdminAccess] [FeatureGate:DRAAdminAccess] [Alpha]
 [FeatureGate:DynamicResourceAllocation] [Beta]
 
-- AdminAccess related tests in
-  https://github.com/kubernetes/kubernetes/blob/69ab91a5c59617872c9f48737c64409a9dec2957/test/e2e/dra/dra.go#L976
-  and
-  https://github.com/kubernetes/kubernetes/blob/69ab91a5c59617872c9f48737c64409a9dec2957/test/e2e/dra/dra.go#L1095
-  will be updated.
+- `cluster validate ResourceClaimTemplate and ResourceClaim for admin access`, [SIG Node](https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#pull-kubernetes-kind-dra-all), [triage search](https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=admin%20access)
+- `cluster DaemonSet with admin access`, [SIG Node](https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#pull-kubernetes-kind-dra-all), [triage search](https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=admin%20access)
 
 ### Graduation Criteria
 
@@ -466,13 +459,23 @@ ResourceClaimTemplate and ResourceClaim for admin access
 
 #### Beta
 
-- Gather feedback
+- Gather feedback from developers and surveys via implementations in the kubernetes-sigs/dra-example-driver: https://github.com/kubernetes-sigs/dra-example-driver/issues/97 and potentially other drivers
+- Complete feature AdminAccess
 - Additional tests are in Testgrid and linked in KEP
-- Implementations in the kubernetes-sigs/dra-example-driver: https://github.com/kubernetes-sigs/dra-example-driver/issues/97
+- More rigorous forms of testing—e.g., downgrade tests and scalability tests
+- All functionality completed
+- All security enforcement completed
+- All monitoring requirements completed
+- All testing requirements completed
+- All known pre-release issues and gaps resolved 
+**Note:** Beta criteria must include all functional, security, monitoring, and testing requirements along with resolving all issues and gaps identified
+
 
 #### GA
-
+- 1 example of real-world usage
 - Allowing time for feedback
+- All issues and gaps identified as feedback during beta are resolved
+**Note:** GA criteria must not include any functional, security, monitoring, or testing requirements.  Those must be beta requirements.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-auth/5018-dra-adminaccess/README.md
+++ b/keps/sig-auth/5018-dra-adminaccess/README.md
@@ -466,7 +466,7 @@ ResourceClaimTemplate and ResourceClaim for admin access
 
 - Gather feedback
 - Additional tests are in Testgrid and linked in KEP
-- Implementations in the kubernetes-sigs/dra-example-driver: https://github.com/kubernetes-sigs/dra-example-driver/issues/97 and the NVIDIA dra driver: https://github.com/NVIDIA/k8s-dra-driver-gpu/issues/337
+- Implementations in the kubernetes-sigs/dra-example-driver: https://github.com/kubernetes-sigs/dra-example-driver/issues/97
 
 #### GA
 
@@ -542,7 +542,7 @@ will rollout across nodes.
 -->
 
 - kube-controller-manager: If the kube-controller-manager fails to create `ResourceClaim` objects from `ResourceClaimTemplate` due to misconfigurations or permission issues relating to `adminAccess`, then the associated Pods will remain in a pending state and won't be scheduled.
-- kube-scheduler: Bugs in the scheduler might lead to Pods not being scheduled even when resources are available or, scheduling Pods that shouldn't be scheduled due to unmet `adminAccess` requirements. If the `DRAAdminAccess` feature gate isn't enabled or is misconfigured, the scheduler might not recognize ResourceClaim requirements, leading to scheduling failures.
+- kube-scheduler: Bugs in the scheduler might lead to Pods not being scheduled even when resources are available or, scheduling Pods that shouldn't be scheduled due to unmet `adminAccess` requirements, all this should be part of the generic scheduler backoff behavior. It will not affect running workloads.
 - Workloads Without `ResourceClaims` will remain unaffected as the adminAccess feature doesn't interact with them. The new code paths introduced for adminAccess only engage when `ResourceClaims` are present in the Pod specification.
 - New Pods requiring `ResourceClaims` with `adminAccess` might remain unscheduled if the control plane components fail to process the claims correctly.
 - Existing Pods continue to run unaffected since `ResourceClaim` and `ResourceClaimTemplate`'s spec is immutable, including the adminAccess field, cannot be altered.
@@ -603,7 +603,7 @@ checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
 
-".status.allocation.devices.results[*].adminaccess" will be set to true for a claim using adminAccess when needed by a pod.
+".status.allocation.devices.results[*].adminAccess" will be set to true for a claim using adminAccess when needed by a pod.
 
 Metrics in kube-controller-manager about total (resourceclaim_controller_resource_claims_adminaccess) and allocated ResourceClaims with adminAccess (resourceclaim_controller_allocated_resource_claims_adminaccess).
 
@@ -718,7 +718,7 @@ and creating new ones, as well as about cluster-level services (e.g. DNS):
 -->
 
 - The DynamicResourceAllocation feature gate must be enabled to create ResourceClaim, ResourceClaimTemplate. More details at [KEP-4381 - DRA Structured Parameters](https://github.com/kubernetes/enhancements/issues/4381)
-- A third-party DRA driver is required for how the driver should interpret the AdminAcess field to get acess to device specific resources without allocating them.
+- A third-party DRA driver is required for how the driver should interpret the AdminAccess field to get acess to device specific resources without allocating them.
 
 ### Scalability
 

--- a/keps/sig-auth/5018-dra-adminaccess/README.md
+++ b/keps/sig-auth/5018-dra-adminaccess/README.md
@@ -179,8 +179,10 @@ objects as privileged. This feature includes:
    ```yaml
    metadata:
      labels:
-       resource.k8s.io/admin-access: "true"
+       resource.kubernetes.io/admin-access: "true"
    ```
+
+   Note: This label has been updated from `resource.k8s.io/admin-access` while the feature was in alpha in v1.33.
 
    Assumptions:
 
@@ -194,7 +196,7 @@ objects as privileged. This feature includes:
 
    In the REST storage layer, validate requests to create and update
    `ResourceClaim` or `ResourceClaimTemplate` objects with `adminAccess: true`.
-   Only authorize if namespace has the `resource.k8s.io/admin-access: "true"` label.
+   Only authorize if namespace has the `resource.kubernetes.io/admin-access: "true"` label.
 
 1. Grants privileged access to the requested device:
 
@@ -212,7 +214,7 @@ objects as privileged. This feature includes:
 ### Workflow
 
 1. A cluster administrator labels an admin namespace with
-   `resource.k8s.io/admin-access: "true"`.
+   `resource.kubernetes.io/admin-access: "true"`.
 
 1. Users who are authorized to create `ResourceClaim` or `ResourceClaimTemplate`
    objects in this admin namespace can set `adminAccess: true` field if they
@@ -284,7 +286,7 @@ shouldn't have allowed unrestricted access.
 Starting in Kubernetes 1.33 (when this KEP was introduced), a validation has
 been added to the REST storage layer to only authorize `ResourceClaim` or
 `ResourceClaimTemplate` with `adminAccess: true` requests if their namespace has
-the `resource.k8s.io/admin-access: "true"` label to only allow it for users with
+the `resource.kubernetes.io/admin-access: "true"` label to only allow it for users with
 additional privileges.
 
 The below flowchart starts with `ResourceClaim` creation from
@@ -415,7 +417,7 @@ Those tests run in:
 - Additional test cases will be added to `test/integration/scheduler_perf` to
   ensure `ResourceClaim` or `ResourceClaimTemplate` with `adminAccess: true`
   requests are only authorized if their namespace has the
-  `resource.k8s.io/admin-access: "true"` label as described in this KEP.
+  `resource.kubernetes.io/admin-access: "true"` label as described in this KEP.
 
 ##### e2e tests
 
@@ -436,7 +438,7 @@ was developed as part of the overall DRA development effort. We have extended
 this test driver to enable `DRAAdminAccess` feature gate and added tests to
 ensure `ResourceClaim` or `ResourceClaimTemplate` with `adminAccess: true`
 requests are only authorized if their namespace has the
-`resource.k8s.io/admin-access: "true"` label as described in this KEP.
+`resource.kubernetes.io/admin-access: "true"` label as described in this KEP.
 
 Test links:
 
@@ -798,7 +800,7 @@ For each of them, fill in the following information by copying the below templat
     To troubleshoot, "kubectl describe" can be used on (in this order) Pod
     and ResourceClaim.
 
-  - Mitigations: When ResourceClaims or ResourceClaimTemplates the `AdminAccess`
+  - Mitigations: When ResourceClaims or ResourceClaimTemplates with the `AdminAccess`
 field don't get created, debugging should focus on the namespace labels. The kube-controller-manager logs should have more information.
 
   - Diagnostics: Audit Policy can be created to ensure all create operations on ResourceClaim, ResourceClaimTemplate, and Namespace resources are logged at the metadata level to review successful and denied attempts to set the `AdminAccess`

--- a/keps/sig-auth/5018-dra-adminaccess/kep.yaml
+++ b/keps/sig-auth/5018-dra-adminaccess/kep.yaml
@@ -17,12 +17,12 @@ see-also:
   - "/keps/sig-node/4381-dra-structured-parameters"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update KEP to prepare for beta in 1.34

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5018

<!-- other comments or additional information -->
- Other comments: Some of the material is already covered in [KEP-4381: DRA Structure Parameters](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters), so that KEP is referenced in some places.

/wg device-management
/assign @liggitt for sig auth
/assign @pohly
/assign @soltysh for PRR