### PR TITLE
KEP 4381: DRA structured parameters: updates, promotion to GA

### DIFF
--- a/keps/sig-node/4381-dra-structured-parameters/README.md
+++ b/keps/sig-node/4381-dra-structured-parameters/README.md
@@ -1,64 +1,3 @@
-<!--
-**Note:** When your KEP is complete, all of these comment blocks should be removed.
-
-To get started with this template:
-
-- [ ] **Pick a hosting SIG.**
-  Make sure that the problem space is something the SIG is interested in taking
-  up. KEPs should not be checked in without a sponsoring SIG.
-- [ ] **Create an issue in kubernetes/enhancements**
-  When filing an enhancement tracking issue, please make sure to complete all
-  fields in that template. One of the fields asks for a link to the KEP. You
-  can leave that blank until this KEP is filed, and then go back to the
-  enhancement and add the link.
-- [ ] **Make a copy of this template directory.**
-  Copy this template into the owning SIG's directory and name it
-  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
-  leading-zero padding) assigned to your enhancement above.
-- [ ] **Fill out as much of the kep.yaml file as you can.**
-  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
-  "Status", and date-related fields.
-- [ ] **Fill out this file as best you can.**
-  At minimum, you should fill in the "Summary" and "Motivation" sections.
-  These should be easy if you've preflighted the idea of the KEP with the
-  appropriate SIG(s).
-- [ ] **Create a PR for this KEP.**
-  Assign it to people in the SIG who are sponsoring this process.
-- [ ] **Merge early and iterate.**
-  Avoid getting hung up on specific details and instead aim to get the goals of
-  the KEP clarified and merged quickly. The best way to do this is to just
-  start with the high-level sections and fill out details incrementally in
-  subsequent PRs.
-
-Just because a KEP is merged does not mean it is complete or approved. Any KEP
-marked as `provisional` is a working document and subject to change. You can
-denote sections that are under active debate as follows:
-
-```
-<<[UNRESOLVED optional short context or usernames ]>>
-Stuff that is being argued.
-<<[/UNRESOLVED]>>
-```
-
-When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
-focused. If you disagree with what is already in a document, open a new PR
-with suggested changes.
-
-One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
-You do not need a new KEP to move from beta to GA, for example. If
-new details emerge that belong in the KEP, edit the KEP. Once a feature has become
-"implemented", major changes should get new KEPs.
-
-The canonical place for the latest set of instructions (and the likely source
-of this file) is [here](/keps/NNNN-kep-template/README.md).
-
-**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
-it is marked `implementable`, must be approved by each of the KEP approvers.
-If none of those approvers are still appropriate, then changes to that list
-should be approved by the remaining approvers and/or the owning SIG (or
-SIG Architecture for cross-cutting KEPs).
--->
-
 # [KEP-4381](https://github.com/kubernetes/enhancements/issues/4381): Dynamic Resource Allocation with Structured Parameters
 
 <!-- toc -->
@@ -149,40 +88,22 @@ SIG Architecture for cross-cutting KEPs).
 
 ## Release Signoff Checklist
 
-<!--
-**ACTION REQUIRED:** In order to merge code into a release, there must be an
-issue in [kubernetes/enhancements] referencing this KEP and targeting a release
-milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
-of the targeted release**.
-
-For enhancements that make changes to code or processes/procedures in core
-Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
-Signoff checklist to be completed.
-
-Check these off as they are completed for the Release Team to track. These
-checklist items _must_ be updated for the enhancement to be released.
--->
-
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
-  - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
-- [ ] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-- [ ] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
-
-<!--
-**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
--->
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [x] e2e Tests for all Beta API Operations (endpoints)
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [x] (R) Graduation criteria is in place
+  - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+- [x] (R) Production readiness review completed
+- [x] (R) Production readiness review approved
+- [x] "Implementation History" section is up-to-date for milestone
+- [x] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 [kubernetes.io]: https://kubernetes.io/
 [kubernetes/enhancements]: https://git.k8s.io/enhancements
@@ -255,17 +176,10 @@ structured parameters is as follows:
 
 This KEP defines a way to describe devices with a name and some associated
 attributes that are used to select devices.
+[Other KEPs](https://github.com/kubernetes/enhancements/issues?q=is%3Aissue%20DRA)
+add additional features on top of this base functionality.
 
 ## Motivation
-
-<!--
-This section is for explicitly listing the motivation, goals, and non-goals of
-this KEP.  Describe why the change is important and the benefits to users. The
-motivation section can optionally provide links to [experience reports] to
-demonstrate the interest in a KEP within the wider Kubernetes community.
-
-[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
--->
 
 Originally, Kubernetes and its scheduler only tracked CPU and RAM as
 resources for containers. Later, support for storage and discrete,
@@ -626,18 +540,6 @@ the ResourceClaim status.
 
 ### Risks and Mitigations
 
-<!--
-What are the risks of this proposal, and how do we mitigate? Think broadly.
-For example, consider both security and how this will impact the larger
-Kubernetes ecosystem.
-
-How will security be reviewed, and by whom?
-
-How will UX be reviewed, and by whom?
-
-Consider including folks who also work outside the SIG or subproject.
--->
-
 #### Feature not used
 
 In a cluster where the feature is not used (no DRA driver installed, no
@@ -752,7 +654,10 @@ A DRA driver can have the following components:
 
 A [utility library](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/dynamic-resource-allocation) for DRA drivers was developed.
 It does not have to be used by drivers, therefore it is not described further
-in this KEP.
+in this KEP. It's documentation and code describe best practices for
+developing a DRA driver. It is used by the
+[example DRA driver](https://github.com/kubernetes-sigs/dra-example-driver)
+which is meant to be a starting point for developing new DRA drivers.
 
 ### State and communication
 
@@ -938,28 +843,19 @@ more experimental parts of the API in the future. The new fields in the
 PodSpec are gated by the DynamicResourceAllocation feature gate and can only be
 set when it is enabled. Initially, they are declared as alpha. Even though they
 are alpha, changes to their schema are discouraged and would have to be done by
-using new field names.
-
-After promotion to beta they are still disabled by default unless the feature
-gate explicitly gets enabled. The feature gate remains off by default because
-DRA depends on a new API group which following the
-[convention](https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default)
-is off by default.
+using new field names. After promotion to GA they are always available.
 
 ResourceClaim, DeviceClass and ResourceClaimTemplate are built-in types
-in `resource.k8s.io/v1beta1`. This beta group must be explicitly enabled in
-the apiserver's runtime configuration. Using builtin types was chosen instead
+in `resource.k8s.io`. Using builtin types was chosen instead
 of using CRDs because core Kubernetes components must interact with the new
 objects and installation of CRDs as part of cluster creation is an unsolved
 problem.
 
-The storage version of this API group is `v1beta1`. This enables a potential
-future removal of the `v1alpha3` version. `v1alpha3` is still supported for
-clients via conversion. This enables version skew testing (kubelet from 1.31
-with 1.32 control plane, incremental update) and makes DRA drivers written for
-1.31 immediately usable with 1.32. Cluster upgrades from 1.31 are supported,
-downgrades only if DRA is not enabled in the downgraded cluster or no resources
-exist in the cluster which use the `v1beta1` format.
+The storage version of this API group is `v1beta1`, the version introduced in
+1.32. Only the `v1` version is served by default. `v1beta1` must remain
+supported for encoding/decoding. Other betas remain available
+as long as required by the [deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+but need to be enabled explicitly.
 
 Secrets are not part of this API: if a DRA driver needs secrets, for
 example to access its own backplane, then it can define custom parameters for
@@ -1000,9 +896,6 @@ needed and there is a single owner.
 //
 // For resources that are not local to a node, the node name is not set. Instead,
 // the driver may use a node selector to specify where the devices are available.
-//
-// This is an alpha type and requires enabling the DynamicResourceAllocation
-// feature gate.
 type ResourceSlice struct {
     metav1.TypeMeta
     // Standard object metadata
@@ -1154,22 +1047,6 @@ type Device struct {
     // +required
     Name string
 
-    // Basic defines one device instance.
-    //
-    // +optional
-    // +oneOf=deviceType
-    Basic *BasicDevice
-}
-```
-
-Future KEPs may define devices with other, more complex
-descriptions. Schedulers which don't support those will see a device with just
-a name, which indicates that the scheduler cannot allocate that device because
-it doesn't support the new device type yet.
-
-```go
-// BasicDevice defines one device instance.
-type BasicDevice struct {
     // Attributes defines the set of attributes for this device.
     // The name of each attribute must be unique in that set.
     //
@@ -1268,14 +1145,7 @@ type DeviceCapacity struct {
     // capacity (= share a single device between different consumers).
 ```
 
-The `v1alpha3` API directly mapped to a `resource.Quantity` instead of this
-`DeviceCapacity`. Semantically the two are currently equivalent, therefore
-custom conversion code makes it possible to continue supporting `v1alpha3`. At
-the time that "consumable capacity" gets added (if it gets added!) the alpha
-API probably can be removed because all clients will use the beta API.
-
 ###### ResourceClaim
-
 
 ```go
 // ResourceClaim describes a request for access to resources in the cluster,
@@ -1283,9 +1153,6 @@ API probably can be removed because all clients will use the beta API.
 // with specific properties, this is how that request is expressed. The status
 // stanza tracks whether this claim has been satisfied and what specific
 // resources have been allocated.
-//
-// This is an alpha type and requires enabling the DynamicResourceAllocation
-// feature gate.
 type ResourceClaim struct {
     metav1.TypeMeta
     // Standard object metadata
@@ -1445,12 +1312,8 @@ type DeviceRequest struct {
     // all ordinary claims to the device with respect to access modes and
     // any resource allocations.
     //
-    // This is an alpha field and requires enabling the DRAAdminAccess
-    // feature gate.
-    //
     // +optional
     // +default=false
-    // +featureGate=DRAAdminAccess
     AdminAccess bool
 }
 ```
@@ -1727,9 +1590,6 @@ more user-friendly "kind".
 // device configuration and selectors. It can be referenced in
 // the device requests of a claim to apply these presets.
 // Cluster scoped.
-//
-// This is an alpha type and requires enabling the DynamicResourceAllocation
-// feature gate.
 type DeviceClass struct {
     metav1.TypeMeta
     // Standard object metadata
@@ -1848,18 +1708,6 @@ type DeviceRequestAllocationResult struct {
     //
     // +required
     Device string
-
-    // AdminAccess indicates that this device was allocated for
-    // administrative access. See the corresponding request field
-    // for a definition of mode.
-    //
-    // This is an alpha field and requires enabling the DRAAdminAccess
-    // feature gate. Admin access is disabled if this field is unset or
-    // set to false, otherwise it is enabled.
-    //
-    // +optional
-    // +featureGate=DRAAdminAccess
-    AdminAccess *bool
 }
 
 // DeviceAllocationConfiguration gets embedded in an AllocationResult.
@@ -1894,9 +1742,6 @@ const (
 
 ```go
 // ResourceClaimTemplate is used to produce ResourceClaim objects.
-//
-// This is an alpha type and requires enabling the DynamicResourceAllocation
-// feature gate.
 type ResourceClaimTemplate struct {
     metav1.TypeMeta
     // Standard object metadata
@@ -1938,12 +1783,8 @@ type PodSpec {
     // will be made available to those containers which consume them
     // by name.
     //
-    // This is an alpha field and requires enabling the
-    // DynamicResourceAllocation feature gate.
-    //
     // This field is immutable.
     //
-    // +featureGate=DynamicResourceAllocation
     // +optional
     ResourceClaims []PodResourceClaim
    ...
@@ -2175,6 +2016,32 @@ This checks whether the given node has access to those ResourceClaims which
 were already allocated. For ResourceClaims that were not, it checks that the
 allocation can succeed for a node.
 
+This check can become time consuming. The cost of individual CEL expressions is
+limited, but how often they need to be evaluated is not limited because it
+depends on the number of requests per ResourceClaim, number of ResourceClaims,
+number of published devices in ResourceSlices, and the complexity of the
+requests. Other checks besides CEL evaluation also take time (usage checks,
+match attributes, etc.).
+
+Therefore the scheduler plugin supports a configurable timeout that is
+applied to the entire Filter call for each node. In case of a timeout,
+Filter returns Unschedulable. If Filter succeeds for some other node(s),
+scheduling continues with those. If Filter fails for all of them,
+the Pod is placed in the unschedulable queue. It will get checked again
+if changes in e.g. ResourceSlices or ResourceClaims indicate that
+another scheduling attempt might succeed. If this fails repeatedly,
+exponential backoff slows down future attempts.
+
+`scheduler_perf` results show Filter durations
+around 10 milliseconds
+([steady state](http://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=scheduler_framework_extension_point_duration_seconds&Name=BenchmarkPerfScheduling%2FSteadyStateClusterResourceClaimTemplate%2Fempty_500nodes%2Ftest&event=not%20applicable&extension_point=Filter&plugin=not%20applicable&result=not%20applicable))
+and up to 200 milliseconds ([filling up a cluster](http://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=scheduler_framework_extension_point_duration_seconds&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes%2Ftest&event=not%20applicable&extension_point=Filter&plugin=not%20applicable&result=not%20applicable)).
+The default timeout is 10 seconds, which is orders of magnitude higher than
+what is expected in practice to support also other, more complex workloads
+out-of-the-box. Administrators can reduce the timeout after checking the
+`scheduler_framework_extension_point_duration_seconds` metrics for the Filter
+operation in their cluster to prevent unexpectedly long Filter operations.
+
 #### Post-filter
 
 This is called when no suitable node could be found. If the Pod depends on ResourceClaims with delayed
@@ -2256,11 +2123,16 @@ k8s.io/kubelet/pkg/apis/dra gRPC interface. It was inspired by
 [CSI](https://github.com/container-storage-interface/spec/blob/master/spec.md),
 with “volume” replaced by “resource” and volume specific parts removed.
 
-Versions v1alpha4 and v1beta1 are supported by kubelet. Both are identical.
-DRA drivers should implement both because support for v1alpha4 might get
-removed.
+Versions v1beta1 and v1 are supported by kubelet. Both are identical.
+DRA drivers should implement both because support for v1beta will get
+removed eventually.
 
-The following metric mirrors the `csi_operations_seconds`:
+A DRA driver may use
+[seamless upgrades](https://github.com/kubernetes/kubernetes/blob/582b421393d0fad2ad4a83feba88977ac4434662/pkg/kubelet/pluginmanager/pluginwatcher/README.md#seamless-upgrade)
+to ensure that there is always a running driver instance on a node.
+
+The following metric mirrors the `csi_operations_seconds`, i.e.
+provides information about gRPC calls issued by the kubelet:
 - Metric name: `dra_operations_seconds`
 - Description: Dynamic Resource Allocation interface operation duration with gRPC error code status total
 - Type: Histogram
@@ -2319,6 +2191,18 @@ resource instance, then NodeUnprepareResource (see below) must have been called
 successfully before allowing the pod to be deleted. This ensures that network-attached resource are available again
 for other Pods, including those that might get scheduled to other nodes. It
 also signals that it is safe to deallocate and delete the ResourceClaim.
+
+This implies that a DRA driver must not get removed while it is in use on a
+node because otherwise pods get stuck while the kubelet (re)tries to call
+NodeUnprepareResources. A driver is in use if it has ResourceClaims which
+were prepared. The kubelet exposes that in a metric:
+- Metric name: `dra_resource_claims_in_use`
+- Description: The number of ResourceClaims that are currently in use on the node, by driver name (`driver_name` label value) and across all drivers (special value `<any>` for `driver_name`). Note that the sum of all by-driver counts is not the total number of in-use ResourceClaims because the same ResourceClaim might use devices from different drivers. Instead, use the count for the `<any>` driver_name.
+- Type: Histogram
+- Labels: `driver_name`
+
+Checking usage and removing a driver is inherently racy. See below
+under ["Troubleshooting"](#troubleshooting) for mitigations.
 
 ![kubelet](./kubelet.png)
 
@@ -2585,25 +2469,6 @@ None.
 
 ##### Unit tests
 
-<!--
-In principle every added code should have complete unit test coverage, so providing
-the exact set of tests will not bring additional value.
-However, if complete unit test coverage is not possible, explain the reason of it
-together with explanation why this is acceptable.
--->
-
-<!--
-Additionally, for Alpha try to enumerate the core package you will be touching
-to implement this enhancement and provide the current unit coverage for those
-in the form of:
-- <package>: <date> - <current test coverage>
-The data can be easily read from:
-https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
-
-This can inform certain test coverage improvements that we want to do before
-extending the production code to implement this enhancement.
--->
-
 2022-05-24:
 
 - `k8s.io/kubernetes/pkg/scheduler`: 75.0%
@@ -2653,41 +2518,35 @@ End of v1.32 development cycle (~ https://github.com/kubernetes/kubernetes/pull/
 - `k8s.io/kubernetes/pkg/kubelet/cm/dra/state`: 46.2%
 - `k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources`: 77.4%
 
+v1.33.0:
+
+- `k8s.io/dynamic-resource-allocation/cel`: 88.2%
+- `k8s.io/dynamic-resource-allocation/structured`: 91.3%
+- `k8s.io/kubernetes/pkg/apis/resource/validation`: 97.8%
+- `k8s.io/kubernetes/pkg/controller/resourceclaim`: 74.2%
+- `k8s.io/kubernetes/pkg/kubelet/cm/dra`: 78.4%
+- `k8s.io/kubernetes/pkg/kubelet/cm/dra/plugin`: 90.3%
+- `k8s.io/kubernetes/pkg/kubelet/cm/dra/state`: 46.2%
+- `k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources`: 79.3%
+
 ##### Integration tests
-
-<!--
-This question should be filled when targeting a release.
-For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
-
-For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
-https://storage.googleapis.com/k8s-triage/index.html
--->
 
 The scheduler plugin and resource claim controller are covered by the workloads
 in
-https://github.com/kubernetes/kubernetes/blob/master/test/integration/scheduler_perf/config/performance-config.yaml
-with "Structured" in the name. Those tests run in:
+https://github.com/kubernetes/kubernetes/blob/master/test/integration/scheduler_perf/dra/performance-config.yaml
+Several other integration tests exist in
+https://github.com/kubernetes/kubernetes/blob/master/test/integration/dra.
+
+Those tests run in:
 
 - [pre-submit](https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-integration) and [periodic](https://testgrid.k8s.io/sig-release-master-blocking#integration-master) integration testing under `k8s.io/kubernetes/test/integration/scheduler_perf.scheduler_perf`
-- [periodic performance testing](https://testgrid.k8s.io/sig-scalability-benchmarks#scheduler-perf) which populates [http://perf-dash.k8s.io](http://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfResults&Metric=SchedulingThroughput&Name=SchedulingBasic%2F5000Nodes_10000Pods%2Fnamespace-2&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable&event=not%20applicable)
-
-**TODO**: link to "Structured" once https://github.com/kubernetes/kubernetes/pull/127277) is merged.
+- [periodic performance testing](https://testgrid.k8s.io/sig-scalability-benchmarks#scheduler-perf) which populates [http://perf-dash.k8s.io](http://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfScheduling&Metric=SchedulingThroughput&Name=BenchmarkPerfScheduling%2FSchedulingWithResourceClaimTemplate%2F5000pods_500nodes%2Ftest&event=not%20applicable&extension_point=not%20applicable&plugin=not%20applicable&result=not%20applicable)
 
 The periodic performance testing prevents performance regressions by tracking
 performance over time and by failing the test if performance drops below a
 threshold defined for each workload.
 
 ##### e2e tests
-
-<!--
-This question should be filled when targeting a release.
-For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
-
-For Beta and GA, add links to added tests together with links to k8s-triage for those tests:
-https://storage.googleapis.com/k8s-triage/index.html
-
-We expect no non-infra related flakes in the last month as a GA graduation criteria.
--->
 
 End-to-end testing depends on a working DRA driver and a container runtime
 with CDI support. A [test driver](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/dra/test-driver)
@@ -2706,7 +2565,7 @@ calls happens inside the E2E test.
 
 All tests that don't involve actually running a Pod can become part of
 conformance testing. Those tests that run Pods cannot be because CDI support in
-runtimes is not required.
+runtimes and plugin support in the kubelet are not required for conformance.
 
 Test links:
 - [E2E](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/dra): https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-dra
@@ -2740,10 +2599,9 @@ Test links:
   or [example driver](https://github.com/kubernetes-sigs/dra-example-driver)
   changes based on above analysis
 - Address existing in-flight work and bugs ex.
-    [PR#129799](https://github.com/kubernetes/kubernetes/pull/129799),
-    [kubernetes#128964](https://github.com/kubernetes/kubernetes/issues/128964),
-    [kubernetes#129402](https://github.com/kubernetes/kubernetes/issues/129402).
-
+  - [PR#129799](https://github.com/kubernetes/kubernetes/pull/129799),
+  - [kubernetes#128964](https://github.com/kubernetes/kubernetes/issues/128964),
+  - [kubernetes#129402](https://github.com/kubernetes/kubernetes/issues/129402) (replaced by https://github.com/kubernetes/website/issues/51012).
 
 [conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
 
@@ -2761,6 +2619,11 @@ version.
 Ideally, the latest release of a DRA driver should be used and it should
 support a wide range of structured type versions. Then problems due to version
 skew are less likely to occur.
+
+DRA drivers using the
+[dynamic-resource-allocation helper package](https://github.com/pohly/kubernetes/tree/3b5cfeaf204b0d836fc6881e07cd439ab57e22d1/staging/src/k8s.io/dynamic-resource-allocation/client)
+automatically make API calls with a version of the resource.k8s.io that is supported
+by the apiserver.
 
 ## Production Readiness Review Questionnaire
 
@@ -2784,9 +2647,15 @@ No.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes. Applications that were already deployed and are running will continue to
+Yes, by downgrading to a version where the feature was not yet locked to on,
+or by emulating an older release.
+
+Applications that were already deployed and are running will continue to
 work, but they will stop working when containers get restarted because those
 restarted containers won't have the additional resources.
+
+Without a downgrade, a DRA driver can be deinstalled. Workloads depending on DRA
+then no longer get scheduled.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
@@ -2855,13 +2724,6 @@ No.
 
 ### Monitoring Requirements
 
-<!--
-This section must be completed when targeting beta to a release.
-
-For GA, this section is required: approvers should be able to confirm the
-previous answers based on experience in the field.
--->
-
 ###### How can an operator determine if the feature is in use by workloads?
 
 There will be pods which have a non-empty PodSpec.ResourceClaims field and ResourceClaim objects.
@@ -2869,6 +2731,8 @@ There will be pods which have a non-empty PodSpec.ResourceClaims field and Resou
 Metrics in kube-controller-manager about total
 (`resourceclaim_controller_resource_claims`) and allocated ResourceClaims
 (`resourceclaim_controller_allocated_resource_claims`).
+
+Metrics in kubelet about prepared, in-use ResourceClaims (`dra_resource_claims_in_use`).
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -2955,16 +2819,6 @@ preparing resources on a node.
 
 ### Scalability
 
-<!--
-For alpha, this section is encouraged: reviewers should consider these questions
-and attempt to answer them.
-
-For beta, this section is required: reviewers must answer these questions.
-
-For GA, this section is required: approvers should be able to confirm the
-previous answers based on experience in the field.
--->
-
 ###### Will enabling / using this feature result in any new API calls?
 
 For Pods not using ResourceClaims, not much changes. The following components
@@ -3039,17 +2893,6 @@ The kubelet needs a gRPC connection to each DRA driver running on the node.
 
 ### Troubleshooting
 
-<!--
-This section must be completed when targeting beta to a release.
-
-For GA, this section is required: approvers should be able to confirm the
-previous answers based on experience in the field.
-
-The Troubleshooting section currently serves the `Playbook` role. We may consider
-splitting it into a dedicated `Playbook` document (potentially with some monitoring
-details). For now, we leave it here.
--->
-
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
 The Kubernetes control plane will be down, so no new Pods get
@@ -3117,6 +2960,25 @@ already received all the relevant updates (Pod, ResourceClaim, etc.).
   - Testing: An E2E test covers the expected retry mechanism in kubelet when
     `NodePrepareResources` fails intermittently.
 
+- A DRA driver prepares a ResourceClaim for a pod, then fails or gets uninstalled.
+  The driver is needed to tear down the Pod.
+
+  - Detection: A Pod does not reach a final phase ("Succeeded" or "Failed") and
+    cannot be deleted. The `dra_resource_claims_in_use` for the node and driver
+    is larger than zero. The `dra_operations_seconds` metric for
+    `method_name: NodeUnprepareResources` with non-zero `grpc_status_code` increases.
+
+  - Mitigations: driver failure scenarios and mitigations must be documented by
+    the vendor. If it got deinstalled, it needs to be reinstalled.
+
+    With [device taints](https://github.com/kubernetes/enhancements/issues/5055),
+    admins can be sure that a driver is not needed anymore before removing it:
+    - Taint devices of a driver, optionally evicting pods.
+    - Check `dra_resource_claims_in_use`.
+    - When zero, remove the driver.
+
+  - Testing: An E2E test covers the expected retry mechanism in kubelet when
+    `NodeUnprepareResources` fails intermittently.
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
@@ -3135,6 +2997,9 @@ Major milestones might include:
 
 - Kubernetes 1.30: Code merged as extension of v1alpha2
 - Kubernetes 1.31: v1alpha3 with new API and several new features
+- Kubernetes 1.32: promotion to beta with v1beta1
+- Kubernetes 1.33: revised v1beta2 API with the same structure as intended for GA
+- Kubernetes 1.34: promotion to GA (tentative)
 
 ## Drawbacks
 

--- a/keps/sig-node/4381-dra-structured-parameters/kep.yaml
+++ b/keps/sig-node/4381-dra-structured-parameters/kep.yaml
@@ -25,12 +25,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.30"
   beta: "v1.32"
+  stable: "v1.34"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -51,3 +52,4 @@ metrics:
   - resourceclaim_controller_resource_claims
   - resourceclaim_controller_allocated_resource_claims
   - dra_operations_seconds in kubelet
+  - dra_resource_claims_in_use in kubelet


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: DRA structured parameters: updates, promotion to GA

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4381

<!-- other comments or additional information -->
- Other comments:

Some of the existing content was a bit stale, for example the v1beta2 API changes were missing. Seamless upgrades were already added in 1.33.

New for 1.34 are the dra_resource_claims_in_use metrics and the Filter timeout. They are part of filling gaps identified for GA. With those gaps closed, the criteria for GA should be satisfied, so promotion to GA gets proposed for 1.34.