### PR TITLE
kep-3695-beta update

### DIFF
--- a/keps/prod-readiness/sig-node/3695.yaml
+++ b/keps/prod-readiness/sig-node/3695.yaml
@@ -4,3 +4,5 @@
 kep-number: 3695
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/3695-pod-resources-for-dra/README.md
+++ b/keps/sig-node/3695-pod-resources-for-dra/README.md
@@ -274,8 +274,9 @@ These cases will be added in the existing e2e tests:
 
 #### Beta
 
-- [ ] Gather feedback from consumers of the DRA feature.
-- [ ] No major bugs reported in the previous cycle.
+- [x] Gather feedback from consumers of the DRA feature.
+  - Integration with DCGM exporter (WIP)
+- [x] No major bugs reported in the previous cycle.
 
 #### GA
 
@@ -437,6 +438,10 @@ N/A.
 - 2023-01-12: KEP created
 
 - 2024-09-10: KEP Updated to reflect the current state of the implementation.
+
+- Kubernetes 1.27: Alpha version of the KEP.
+
+- Kubernetes 1.34: Beta version of the KEP.
 
 ## Drawbacks
 

--- a/keps/sig-node/3695-pod-resources-for-dra/kep.yaml
+++ b/keps/sig-node/3695-pod-resources-for-dra/kep.yaml
@@ -18,12 +18,12 @@ see-also:
 replaces: []
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.27"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Update KEP to prepare for beta in 1.34

- Issue link: https://github.com/kubernetes/enhancements/issues/3695

/wg device-management
/assign @moshe010
/assign @klueska 
/assign @@johnbelamaric for PRR