### PR TITLE
Add priority-based coordinated leader election proposal

### DIFF
--- a/keps/sig-api-machinery/4355-coordinated-leader-election/README.md
+++ b/keps/sig-api-machinery/4355-coordinated-leader-election/README.md
@@ -76,6 +76,7 @@ SIG Architecture for cross-cutting KEPs).
       - [Creating a new LeaseConfiguration resource](#creating-a-new-leaseconfiguration-resource)
       - [YAML/CLI configuration on the kube-apiserver](#yamlcli-configuration-on-the-kube-apiserver)
       - [Strategy propagated from LeaseCandidate](#strategy-propagated-from-leasecandidate)
+  - [Priority-based Coordinated Leader Election](#priority-based-coordinated-leader-election)
   - [Enabling on a component](#enabling-on-a-component)
   - [Migrations](#migrations)
   - [API](#api)
@@ -439,6 +440,105 @@ set of candidates and selected strategy is the same as before.
 
 The obvious drawback is the need for a consensus protocol and extra information
 in the `LeaseCandidate` object that may be unnecessary.
+
+### Priority-based Coordinated Leader Election
+
+#### Overview
+In the current Coordinated Leader Election (CLE) system, leader selection among candidates for a given lease is typically governed by a predefined strategy. A common strategy is OldestEmulatedVersion, where the candidate with the numerically lowest (oldest) emulation version is selected.
+While this strategic approach works well for general leader election, there are operational scenarios requiring more direct and temporary control over which candidate becomes the leader. For instance, during phased software rollouts, for targeted testing of specific instances, or for manual intervention during incident mitigation, a mechanism to deterministically pick a lease candidate without the overhead of defining and deploying a new, temporary strategy is highly desirable. Currently, such a fine-grained, temporary override capability does not exist.
+
+#### Goals
+To design and introduce a mechanism that allows for explicit, temporary selection of a preferred lease candidate for a given lease.
+This mechanism will provide finer-grained control over leader selection, overriding the existing strategy when an explicit preference is specified.
+To facilitate smoother operational procedures such as targeted testing, controlled instance upgrades, specific debugging scenarios, and manual leader assignment during incidents.
+
+#### Non-Goals
+This proposal does not aim to replace the existing CoordinatedLeaseStrategy mechanism entirely but to provide an optional override layer.
+It does not introduce dynamic priority adjustments based on system load or other automated metrics in this iteration.
+
+#### Proposal: Priority Field
+We propose introducing an optional Priority field to the LeaseCandidateSpec. This field will allow operators or automated tooling to designate a preference for a specific lease candidate.
+
+#### Proto Update
+The LeaseCandidateSpec will be updated as follows:
+```Protocol Buffers
+message LeaseCandidateSpec {
+  string lease_name = 1;
+  metav1.MicroTime ping_time = 2;
+  metav1.MicroTime renew_time = 3;
+  string binary_version = 4;
+  string emulation_version = 5;
+  v1.CoordinatedLeaseStrategy strategy = 6;
+  int32 priority = 7; // New field: Higher value means higher priority. Default 0 (no explicit priority).
+}
+```
+
+#### Behavior of the Priority Field
+Priority Value: The Priority field is an int32. A higher numerical value indicates a higher priority.
+Default Value: If a LeaseCandidateSpec does not have the Priority field set, or if it is set to 0, it is considered to have no explicit priority preference.
+Selection Logic:
+If one or more candidates have a Priority > 0:
+The candidate with the numerically highest Priority value will be selected as the leader.
+Tie-Breaking for Equal Highest Priority: If multiple candidates share the same highest non-zero Priority value, the selection among these equally prioritized candidates will be resolved using their existing v1.CoordinatedLeaseStrategy (e.g., OldestEmulatedVersion).
+If no candidates have a Priority > 0 (i.e., all are at the default value of 0 or the field is unset), the leader selection will proceed based purely on the existing v1.CoordinatedLeaseStrategy.
+
+#### Scenario Breakdown for priority based coordination leader election
+Here is a step-by-step breakdown of the scenarios for better understanding the priority-based leader election during upgrades.
+
+##### 1. Initial State
+At the beginning, all components (C1, C2, and C3) are running Binary Version 1 and are emulating Version 1
+
+| Component | Binary Version | Emulation Version | Leader |
+|-----------|----------------|-------------------|--------|
+| C1        | V1             | V1                | Y      |
+| C2        | V1             | V1                |        |
+| C3        | V1             | V1                |        |
+
+##### 2. During Upgrade
+During the upgrade, C1 and C2 are updated to Binary Version 2, but C3 remains on an earlier version. C2 is momentarily elected as the leader.
+
+| Component | Binary Version | Emulation Version | Leader |
+|-----------|----------------|-------------------|--------|
+| C1        | V2             | V2                |        |
+| C2        | V2             | V1                | Y      |
+| C3        | V2             | V1                |        |
+
+##### 3. Priority Setting
+The cluster administrator chooses C1 to be the leader by setting its priority to 100.
+
+| Component | Binary Version | Emulation Version | Priority | Leader |
+|-----------|----------------|-------------------|----------|--------|
+| C1        | V2             | V2                | 100      | Y      |
+| C2        | V2             | V1                |          |        |
+| C3        | V2             | V1                |          |        |
+
+##### 4.1. Upgrade Completion
+After the upgrade is finished, all components are running Binary Version 2 and are emulating Version 2. C1 remains the leader due to its set priority.
+
+| Component | Binary Version | Emulation Version | Priority | Leader |
+|-----------|----------------|-------------------|----------|--------|
+| C1        | V2             | V2                | 100      | Y      |
+| C2        | V2             | V2                |          |        |
+| C3        | V2             | V2                |          |        |
+
+##### 4.2 Update rollback
+Should an issue arise with C1 requiring a rollback, we can unset its priority. This will enable CLE to select C2, which contains the oldest emulated version.
+
+| Component | Binary Version | Emulation Version | Priority | Leader |
+|-----------|----------------|-------------------|----------|--------|
+| C1        | V2 -> V1       | V2 -> V1          |          |        |
+| C2        | V2             | V1                |          | Y      |
+| C3        | V2             | V1                |          |        |
+
+##### 5. Priority Persistence
+Unless the cluster administrator resets the priority, C1 will always remain the leader. When a component gets upgraded or downgraded, it may create a new release candidate, causing the priority to reset.
+
+#### Consideration for Stale Priorities
+A concern with the priority field is the potential for "stale priorities" – a priority set temporarily and not subsequently cleared. This could prevent the Coordinated Leader Election (CLE) system from selecting a more appropriate leader.
+We considered exposing a Time-To-Live (TTL) for priority in the LeaseCandidateSpec, where the CLE system would ignore a priority once its TTL expired. While this directly addresses the "temporary" nature of many priority assignments, we've decided not to include it in this initial phase due to several complexities:
+Implementation and Semantics: Defining the precise data type and behavior for a TTL (e.g., time.Duration vs. time.Time, resetting logic) adds significant complexity.
+User Rationalization: Adding a third field (ttl) to an already multi-faceted leader election logic (strategy + priority) greatly increases the cognitive load for users to understand and manage leader selection effectively.
+Therefore, in this initial iteration, managing priority lifecycles will be an operational responsibility, requiring manual clearance or updates. We may revisit TTL or similar automated mechanisms in future iterations after gaining more experience with the priority field.
 
 ### Enabling on a component
 


### PR DESCRIPTION
This commit updates the KEP for Coordinated Leader Election (KEP-4355) to include a new proposal section for priority-based leader selection.

The new section details:
- An overview of the need for more direct control over leader selection.
- Goals and non-goals for introducing a priority mechanism.
- A specific proposal to add a 'Priority' field to the LeaseCandidateSpec.
- The behavior of this priority field, including selection logic and tie-breaking.
- Scenario breakdowns illustrating how priority-based selection would work during upgrades and rollbacks.
- Considerations for stale priorities and the decision not to include TTL in the initial phase.

The Table of Contents has also been updated to reflect this new section.

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: updates the KEP for Coordinated Leader Election (KEP-4355) to include a new proposal section for priority-based leader selection.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4355

<!-- other comments or additional information -->
- Other comments: