### PR TITLE
KEP-5073: Declarative Validation: Explain and update document with cross-field field reference validation information

### DIFF
--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md
@@ -755,6 +755,28 @@ The below rules are currently implemented or are very similar to an existing val
     N/A
    </td>
   </tr>
+  <tr>
+   <td style="background-color: null">
+    group membership (virtual field)
+   </td>
+   <td style="background-color: null">
+    `+k8s:memberOf(group: &lt;groupname>)`
+   </td>
+   <td style="background-color: null">
+    N/A
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: null">
+    list map item reference (virtual field)
+   </td>
+   <td style="background-color: null">
+    `+k8s:listMapItem(pairs: [[key,value],...])`
+   </td>
+   <td style="background-color: null">
+    N/A
+   </td>
+  </tr>
 </table>
 
 The below rules are not currently implemented in the [validation-gen prototype](https://github.com/jpbetz/kubernetes/tree/validation-gen) so the exact syntax is still WIP


### PR DESCRIPTION
One-line PR description: This addresses how we intend to handle referencing fields for cross-field validations with Declarative Validation.

Issue link: https://github.com/kubernetes/enhancements/issues/5073