### PR TITLE
make a ffromani an approver for KEP 4800

### DIFF
--- a/keps/sig-node/4800-cpumanager-split-uncorecache/OWNERS
+++ b/keps/sig-node/4800-cpumanager-split-uncorecache/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ffromani # scaling the approvers for individual KEPs

--- a/keps/sig-node/4800-cpumanager-split-uncorecache/kep.yaml
+++ b/keps/sig-node/4800-cpumanager-split-uncorecache/kep.yaml
@@ -10,12 +10,11 @@ participating-sigs:
 status: implementable 
 creation-date: 2024-08-23
 reviewers:
-  - "@ffromani"
   - "@kannon92"
   - "@kad"
 approvers:
+  - "@ffromani"
   - "@klueska" 
-  - "@sig-node-leads"
 
 see-also: 
   - keps/sig-node/2625-cpumanager-policies-thread-placement"


### PR DESCRIPTION
- One-line PR description:

Scaling the SIG Node approvers. @ffromani was identified as an approver. Since the KEP passed the alpha stage, meaning it is an approved direction, it is fine to expand the approvership for the KEP on beta and GA stages

<!-- link to the k/enhancements issue -->
- Issue link: #4800 