### PR TITLE
KEP-5067: promote Pod Generation to beta

### DIFF
--- a/keps/prod-readiness/sig-node/5067.yaml
+++ b/keps/prod-readiness/sig-node/5067.yaml
@@ -2,4 +2,4 @@ kep-number: 5067
 alpha:
   approver: "johnbelamaric"
 beta:
-  approver: "johnbelamaric"
+  approver: "soltysh"

--- a/keps/prod-readiness/sig-node/5067.yaml
+++ b/keps/prod-readiness/sig-node/5067.yaml
@@ -1,3 +1,5 @@
 kep-number: 5067
 alpha:
   approver: "johnbelamaric"
+beta:
+  approver: "johnbelamaric"

--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -1149,7 +1149,13 @@ admission webhook is covered in these docs: https://kubernetes.io/docs/concepts/
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
-Investigate apiserver and/or kubelet logs.
+One could disable the feature gate and restart the API server. Additionally,
+one could investigate the apiserver and/or kubelet logs errors.
+
+Detection and mitigation of the infinite status-update loop by a badly-behaving
+admission webhook is covered in [these docs](https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/#why-good-webhook-design-matters). Specifically,
+the section about [detecting loops caused by competing controllers](https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/#prevent-loops-competing-controllers)
+can be helpful.
 
 ## Implementation History
 

--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -646,6 +646,7 @@ in back-to-back releases.
 
 * No major bugs reported for three months. 
 * User feedback is green.
+* Promote the [primary e2e tests](https://github.com/kubernetes/kubernetes/blob/08ee8bde594a42bc1a222c9fd25726352a1e6049/test/e2e/node/pods.go#L422-L719) to Conformance.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -458,10 +458,12 @@ regressions back to decreasing values.
 #### Mirror pods
 
 For this KEP, we will not treat mirror pods in any special way. Due to the way they are currently implemented in the
-kubelet and apiserver, this means two things:
+kubelet and apiserver, this means:
 
-1. If a mirror pod's spec is modified manually, its `metadata.generation` will be bumped accordingly.
-2. The kubelet does not currently propagate the mirror pod's `metadata.generation` to the place where
+1. If a mirror pod's spec is modified manually by a client via the apiserver, its `metadata.generation` will be bumped accordingly.
+1. If a static pod's manifest is updated, the kubelet treats this as a pod deletion followed by a pod creation,
+which will reset the `metadata.generation` of the corresponding mirror pod to 1.
+1. The kubelet does not currently propagate the mirror pod's `metadata.generation` to the place where
 the pod status is updated today, so the `observedGeneration` fields of mirror pods will remain
 unpopulated.
 

--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -554,6 +554,8 @@ E2E tests will be implemented to cover the following cases:
 * Verify that deletion of a pod causes the `metadata.generation` to be incremented by 1.
 * Issue ~500 pod updates (1 every 100ms) and verify that `metadata.generation` and `status.observedGeneration` converge to the final expected value.
 * Verify that various conditions each have `observedGeneration` populated. 
+* Verify that static pods have `metadata.generation` and `observedGeneration` fields set to 1, and that
+they never change.
 
 Added tests:
 - https://github.com/kubernetes/kubernetes/blob/08ee8bde594a42bc1a222c9fd25726352a1e6049/test/e2e/node/pods.go#L422-L719
@@ -633,11 +635,11 @@ in back-to-back releases.
 * `metadata.generation` functionality implemented
 * `status.observedGeneration` functionality implemented behind feature flag
 * `status.conditions[i].observedGeneration` field added to the API
+* `status.conditions[i].observedGeneration` functionality implemented behind feature flag
 
 #### Beta
 
 * `metadata.generation`,  `status.observedGeneration`,  `status.conditions[i].observedGeneration` functionality have been implemented and running as alpha for at least one release
-* `status.conditions[i].observedGeneration` functionality implemented behind feature flag
 
 #### GA
 
@@ -903,7 +905,8 @@ checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
 
-They can check if `metadata.generation` is set on the pod. 
+They can check if `metadata.generation` is set on the pod and that `observedGeneration`
+is being updated.
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -1136,6 +1139,9 @@ For each of them, fill in the following information by copying the below templat
 -->
 
 Other failure modes are described under Risks and Mitigations.
+
+Detection and mitigation of the infinite status-update loop by a badly-behaving
+admission webhook is covered in these docs: https://kubernetes.io/docs/concepts/cluster-administration/admission-webhooks-good-practices/#why-good-webhook-design-matters.
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 

--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -457,12 +457,13 @@ regressions back to decreasing values.
 
 #### Mirror pods
 
-The kubelet currently computes the internal pod UID of a mirror pod using a hash of the podspec, 
-meaning that any update to the podspec results in the kubelet seeing it as a pod deletion followed 
-by creation of a new pod. To fully support generation for mirror pods more changes to the kubelet's logic 
-will be expected. For now, we will not treat mirror pods in any special way. This means that due
-to the way that mirror pods are implemented, the generation (and observedGeneration) of a mirror pod 
-will always be 1.
+For this KEP, we will not treat mirror pods in any special way. Due to the way they are currently implemented in the
+kubelet and apiserver, this means two things:
+
+1. If a mirror pod's spec is modified manually, its `metadata.generation` will be bumped accordingly.
+2. The kubelet does not currently propagate the mirror pod's `metadata.generation` to the place where
+the pod status is updated today, so the `observedGeneration` fields of mirror pods will remain
+unpopulated.
 
 #### Future enhancements
 

--- a/keps/sig-node/5067-pod-generation/kep.yaml
+++ b/keps/sig-node/5067-pod-generation/kep.yaml
@@ -43,4 +43,4 @@ feature-gates:
 disable-supported: true
 
 # The following PRR answers are required at beta release
-metrics:
+metrics: []

--- a/keps/sig-node/5067-pod-generation/kep.yaml
+++ b/keps/sig-node/5067-pod-generation/kep.yaml
@@ -43,4 +43,7 @@ feature-gates:
 disable-supported: true
 
 # The following PRR answers are required at beta release
-metrics: []
+metrics:
+- kubelet_pod_start_total_duration_seconds
+- kubelet_pod_status_sync_duration_seconds
+- kubelet_pod_worker_duration_seconds

--- a/keps/sig-node/5067-pod-generation/kep.yaml
+++ b/keps/sig-node/5067-pod-generation/kep.yaml
@@ -19,12 +19,12 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
Promoting Pod Generation to beta. All the requirements were implemented in 1.33, so this update is just filling out the PRR questionnaire for beta.

Issue link: https://github.com/kubernetes/enhancements/issues/5067