### PR TITLE
Update kubelet tracing to target stable in v1.34

### DIFF
--- a/keps/sig-instrumentation/2831-kubelet-tracing/README.md
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/README.md
@@ -473,6 +473,7 @@ details). For now, we leave it here.
 - 2022-06-09: KEP targeted at Alpha in 1.25
 - 2023-01-09: KEP targeted at Beta in 1.27
 - 2025-02-07: KEP targeted at Stable in 1.33
+- 2025-06-10: KEP targeted at Stable in 1.34
 
 ## Drawbacks
 

--- a/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
@@ -24,11 +24,11 @@ see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/647-apiserver-tracing"
 replaces:
 stage: stable
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 milestone:
   alpha: "v1.25"
   beta: "v1.27"
-  stable: "v1.33"
+  stable: "v1.34"
 feature-gates:
   - name: KubeletTracing
     components:


### PR DESCRIPTION
- One-line PR description: updating stable target for 1.34

- Issue link: https://github.com/kubernetes/enhancements/issues/2831

It was already approved for stable in 1.33, but I was out on leave and wasn't able to put up PRs.  I looked at the current template, and don't see any differences.

cc @kubernetes/sig-instrumentation-leads 