### PR TITLE
KEP-647: update apiserver tracing to target stable in v1.34

### DIFF
--- a/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
+++ b/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
@@ -20,12 +20,12 @@ approvers:
 see-also:
 replaces:
 stage: stable
-last-updated: 2023-11-10
-latest-milestone: "v1.33"
+last-updated: 2025-06-10
+latest-milestone: "v1.34"
 milestone:
   alpha: "v1.22"
   beta: "v1.27"
-  stable: "v1.33"
+  stable: "v1.34"
 feature-gates:
   - name: APIServerTracing
 disable-supported: true


### PR DESCRIPTION
- One-line PR description: updating stable target for 1.34

- Issue link: https://github.com/kubernetes/enhancements/issues/647

It was already approved for stable in 1.33, but I was out on leave and wasn't able to put up PRs.  I looked at the current template, and don't see any differences.

cc @kubernetes/sig-instrumentation-leads 