### PR TITLE
KEP-5073: PRR update for v1.34

### DIFF
--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
@@ -23,7 +23,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
One-line PR description: This PR explains the work being done in Declarative Validation in v1.34 as part of the PRR process.  Related comment here: https://github.com/kubernetes/enhancements/issues/5073#issuecomment-2958130141 

Issue link: #5073

### Summary of Declarative Validation Work In v1.33 and v1.34

"Beta - v1.33"
- `validation-gen` framework core pieces
- migration of subset of fields from `ReplicaSet`

"Beta - v1.34"
- ratcheting support (https://github.com/kubernetes/enhancements/pull/5292)
- cross-field validation support (https://github.com/kubernetes/enhancements/pull/5290, https://github.com/kubernetes/enhancements/pull/5363)
- immutability support (https://github.com/kubernetes/enhancements/pull/5373)
- migration of subset of fields of from `CertificateSigningRequest`

### Declarative Validation PRR Information

From the conversation https://github.com/kubernetes/enhancements/issues/5073#issuecomment-2947977400 with the v1.34 Enhancments team, the below was mentioned: 

This is a reminder of the upcoming PRR Freeze on Thursday 12th June 2025.

By this date, there must be a PR open in k/enhancements with:

- [x] The KEP's [PRR questionnaire](https://github.com/kubernetes/enhancements/tree/master/keps/NNNN-kep-template#production-readiness-review-questionnaire) filled out.
  - The PRR readiness review questionnaire was filled out as part of the KEP process in v1.33, nothing has changed w.r.t the PRR questionnaire that was filled out in v1.33: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md#production-readiness-review-questionnaire
- [x] **(this PR)** The [kep.yaml](https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/kep.yaml) updated with the stage, latest-milestone, and milestone struct filled out.
  - This PR updates latest-milestone to v1.34
- [x] A [PRR approval file](https://github.com/kubernetes/enhancements/blob/master/keps/prod-readiness/template/nnnn.yaml) with the PRR approver listed for the stage the KEP is targeting.
  - This was already done for KEP 5073 Beta stage in v1.33: https://github.com/kubernetes/enhancements/blob/master/keps/prod-readiness/sig-api-machinery/5073.yaml
