### PR TITLE
[KEP 3960]: Promote PodLifecycleSleepAction to stable

### DIFF
--- a/keps/sig-node/3960-pod-lifecycle-sleep-action/README.md
+++ b/keps/sig-node/3960-pod-lifecycle-sleep-action/README.md
@@ -455,7 +455,7 @@ Disable PodLifecycleSleepAction feature gate, and restart related components.
 
 - 2023-04-22: Initial draft KEP
 - 2023-12-20: Target to beta in v1.30 
-- 2024-09-21: Target to stable in v1.32
+- 2025-06-11: Target to stable in v1.34
   
 ## Drawbacks
 

--- a/keps/sig-node/3960-pod-lifecycle-sleep-action/kep.yaml
+++ b/keps/sig-node/3960-pod-lifecycle-sleep-action/kep.yaml
@@ -20,13 +20,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.32"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.29"
   beta: "v1.30"
-  stable: "v1.32"
+  stable: "v1.34"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
PodLifecycleSleepAction is planned to graduate to ga in 1.34
<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/3960
<!-- other comments or additional information -->
- Other comments:
We once brought this to ga in v1.32: https://github.com/kubernetes/enhancements/pull/4866
But reverted because of flaky tests.
So this pr only changes the version information, the rest part should be fine.