### PR TITLE
KEP-24: AppArmor annotation deprecation v1.34 phase

### DIFF
--- a/keps/sig-node/24-apparmor/README.md
+++ b/keps/sig-node/24-apparmor/README.md
@@ -473,7 +473,7 @@ Phase 1 (v1.30): AppArmor field support merged
 
 Phase 2 (v1.34):
 - API server stops copying fields to annotations
-- Warn on ALL annotation use
+- Warn on annotation use if there is no corresponding _container_ field (including on workload resources)
 - **Risk:** policy controllers that don't consider field values
 
 Phase 3 (v1.36): End state

--- a/keps/sig-node/24-apparmor/kep.yaml
+++ b/keps/sig-node/24-apparmor/kep.yaml
@@ -28,7 +28,7 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Update AppArmor KEP-24 for the annotation deprecation phase in v1.34
- Issue link: https://github.com/kubernetes/enhancements/issues/24#issuecomment-2960351596
- Other comments: Syncs KEP to the proposed changes from https://github.com/kubernetes/kubernetes/pull/131989