### PR TITLE
4205: Split the two phases into two KEPs and update Alpha and Beta requirements

### DIFF
--- a/keps/sig-node/4205-psi-metric/README.md
+++ b/keps/sig-node/4205-psi-metric/README.md
@@ -115,9 +115,11 @@ default threshold to be used for reporting the nodes under heavy resource pressu
 
 **Note:** These actions are tentative, and will depend on different the outcome from testing and discussions with sig-node members, users, and other folks. 
 
+**Note:** In the initial Alpha implementation, we are not introducing node pressure condition for CPU. This is because unlike memory and IO, CPU is a compressible resource. See https://github.com/kubernetes/enhancements/issues/5062 for more details.
+
 1. Introduce a new kubelet config parameter, pressure threshold, to let users specify the pressure percentage beyond which the kubelet would report the node condition to disallow workloads to be scheduled on it.
 
-2. Add new node conditions corresponding to high PSI (beyond threshold levels) on CPU, Memory and IO.
+2. Add new node conditions corresponding to high PSI (beyond threshold levels) on Memory and IO.
 
 ```go
 // These are valid conditions of the node. Currently, we don't have enough information to decide
@@ -125,12 +127,10 @@ default threshold to be used for reporting the nodes under heavy resource pressu
 const (
 …
 	// Conditions based on pressure at system level cgroup.
-	NodeSystemCPUContentionPressure    NodeConditionType = "SystemCPUContentionPressure"
 	NodeSystemMemoryContentionPressure NodeConditionType = "SystemMemoryContentionPressure"
 	NodeSystemDiskContentionPressure   NodeConditionType = "SystemDiskContentionPressure"
 
 	// Conditions based on pressure at kubepods level cgroup.
-	NodeKubepodsCPUContentionPressure    NodeConditionType = "KubepodsCPUContentionPressure"
 	NodeKubepodsMemoryContentionPressure NodeConditionType = "KubepodsMemoryContentionPressure"
 	NodeKubepodsDiskContentionPressure   NodeConditionType = "KubepodsDiskContentionPressure"
 )
@@ -247,6 +247,7 @@ Test plan:
 
 #### Alpha
 
+- Conduct experiments to decide the scope of the node condition (system v.s. kubepods v.s. node) as well as the default threshold
 - Enables kubelet to 
 report node conditions based off PSI values.
 - Initial e2e tests completed and enabled if CRI implementation supports
@@ -255,6 +256,7 @@ it.
 
 #### Beta
 
+- Decide whether CPU PSI will be used for node conditions.
 - Feature gate is enabled by default.
 - Extend e2e test coverage.
 - Allowing time for feedback.

--- a/keps/sig-node/4205-psi-metric/README.md
+++ b/keps/sig-node/4205-psi-metric/README.md
@@ -8,22 +8,15 @@
 - [Proposal](#proposal)
   - [User Stories (Optional)](#user-stories-optional)
     - [Story 1](#story-1)
-    - [Story 2](#story-2)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
-    - [Phase 1](#phase-1)
-      - [CPU](#cpu)
-      - [Memory](#memory)
-      - [IO](#io)
-    - [Phase 2 to add PSI based actions.](#phase-2-to-add-psi-based-actions)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
       - [Integration tests](#integration-tests)
       - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
-    - [Phase 1: Alpha](#phase-1-alpha)
-    - [Phase 2: Alpha](#phase-2-alpha)
+    - [Alpha](#alpha)
     - [Beta](#beta)
     - [GA](#ga)
     - [Deprecation](#deprecation)
@@ -85,7 +78,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 ## Summary
 
-This KEP proposes adding support in kubelet to read Pressure Stall Information (PSI) metric pertaining to CPU, Memory and IO resources exposed from cAdvisor and runc. This will enable kubelet to report node conditions which will be utilized to prevent scheduling of pods on nodes experiencing significant resource constraints.
+This KEP proposes enabling kubelet to report node conditions which will be utilized to prevent scheduling of pods on nodes experiencing significant resource constraints.
 
 ## Motivation
 
@@ -96,13 +89,7 @@ In short, PSI metric are like barometers that provide fair warning of impending 
 ### Goals
 
 This proposal aims to:
-1. Enable the kubelet to have the PSI metric of cgroupv2 exposed from cAdvisor and Runc.
-2. Enable the pod level PSI metric and expose it in the Summary API.
-3. Utilize the node level PSI metric to set node condition and node taints.
-
-It will have two phases:
-Phase 1: includes goal 1, 2 
-Phase 2: includes goal 3
+1. Utilize the node level PSI metric to set node condition and node taints.
 
 ### Non-Goals
 
@@ -115,86 +102,17 @@ userspace OOM kills, and so on, for future KEPs.
 
 #### Story 1
 
-Today, to identify disruptions caused by resource crunches, Kubernetes users need to
-install node exporter to read PSI metric. With the feature proposed in this enhancement, 
-PSI metric will be available for users in the Kubernetes metrics API.
-
-#### Story 2
-
 Kubernetes users want to prevent new pods to be scheduled on the nodes that have resource starvation. By using PSI metric, the kubelet will set Node Condition to avoid pods being scheduled on nodes under high resource pressure. The node controller could then set a [taint on the node based on these new Node Conditions](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-nodes-by-condition).
 
 ### Risks and Mitigations
 
-There are no significant risks associated with Phase 1 implementation that involves integrating
-the PSI metric in kubelet from either from cadvisor runc libcontainer library or kubelet's CRI runc libcontainer implementation which doesn't involve any shelled binary operations.
-
-Phase 2 involves utilizing the PSI metric to report node conditions. There is a potential
+There is a potential
 risk of early reporting for nodes under pressure. We intend to address this concern
 by conducting careful experimentation with PSI threshold values to identify the optimal
 default threshold to be used for reporting the nodes under heavy resource pressure.
 
 ## Design Details
 
-#### Phase 1
-1. Add new Data structures PSIData and PSIStats corresponding to the PSI metric output format as following:
-
-```
-some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-```
-
-```go
-type PSIData struct {
-	Avg10  *float64 `json:"avg10"`
-	Avg60  *float64 `json:"avg60"`
-	Avg300 *float64 `json:"avg300"`
-	Total  *float64 `json:"total"`
-}
-
-type PSIStats struct {
-	Some *PSIData `json:"some,omitempty"`
-	Full *PSIData `json:"full,omitempty"`
-}
-```
-
-2. Summary API includes stats for both system and kubepods level cgroups. Extend the Summary API to include PSI metric data for each resource obtained from cadvisor. 
-Note: if cadvisor-less is implemented prior to the implementation of this enhancement, the PSI
-metric data will be available through CRI instead.
-
-##### CPU
-```go
-type CPUStats struct { 
-	// PSI stats of the overall node
-	PSI cadvisorapi.PSIStats `json:"psi,omitempty"`
-}
-```
-
-##### Memory
-```go
-type MemoryStats struct {
-	// PSI stats of the overall node
-	PSI cadvisorapi.PSIStats `json:"psi,omitempty"`
-}
-```
-
-##### IO
-```go
-// IOStats contains data about IO usage.
-type IOStats struct {
-	// The time at which these stats were updated.
-	Time metav1.Time `json:"time"`
-
-	// PSI stats of the overall node
-	PSI cadvisorapi.PSIStats `json:"psi,omitempty"`
-}
-
-type NodeStats struct {
-	// Stats about the IO pressure of the node
-	IO *IOStats `json:"io,omitempty"`
-}
-```
-
-#### Phase 2 to add PSI based actions.
 **Note:** These actions are tentative, and will depend on different the outcome from testing and discussions with sig-node members, users, and other folks. 
 
 1. Introduce a new kubelet config parameter, pressure threshold, to let users specify the pressure percentage beyond which the kubelet would report the node condition to disallow workloads to be scheduled on it.
@@ -318,15 +236,9 @@ We expect no non-infra related flakes in the last month as a GA graduation crite
 
 ### Graduation Criteria
 
-#### Phase 1: Alpha
+#### Alpha
 
-- PSI integrated in kubelet behind a feature flag.
-- Unit tests to check the fields are populated in the 
-  Summary API response.
-
-#### Phase 2: Alpha
-
-- Implement Phase 2 of the enhancement which enables kubelet to 
+- Enables kubelet to 
 report node conditions based off PSI values.
 - Initial e2e tests completed and enabled if CRI implementation supports
 it.
@@ -407,7 +319,7 @@ well as the [existing list] of feature gates.
 
 - [X] Feature gate (also fill in values in `kep.yaml`)
   - Feature gate name: PSINodeCondition
-  - Components depending on the feature gate: kubelet
+  - Components depending on the feature gate: kubelet, kube-controller-manager, kube-scheduler
 - [ ] Other
   - Describe the mechanism:
   - Will enabling / disabling the feature require downtime of the control
@@ -421,7 +333,7 @@ well as the [existing list] of feature gates.
 Any change of default behavior may be surprising to users or break existing
 automations, so be extremely careful here.
 -->
-Not in Phase 1. Phase 2 is TBD in K8s 1.31.
+TBD
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
@@ -513,11 +425,6 @@ Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
 checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
-For Phase 1:
-Use `kubectl get --raw "/api/v1/nodes/{$nodeName}/proxy/stats/summary"` to call Summary API. If the PSIStats field is seen in the API response,
-the feature is available to be used by workloads.
-
-For Phase 2:
 TBD
 
 ###### How can someone using this feature know that it is working for their instance?
@@ -658,12 +565,10 @@ NA
 ## Implementation History
 
 - 2023/09/13: Initial proposal
+- 2025/06/11: Drop Phase 1 contents as they are split into a separate KEP. Keep Phase 2 contents.
 
 ## Drawbacks
 
-No drawbacks in Phase 1 identified. There's no reason the enhancement should not be
-implemented. This enhancement now makes it possible to read PSI metric without installing
-additional dependencies
 
 ## Infrastructure Needed (Optional)
 

--- a/keps/sig-node/4205-psi-metric/README.md
+++ b/keps/sig-node/4205-psi-metric/README.md
@@ -232,7 +232,16 @@ https://storage.googleapis.com/k8s-triage/index.html
 We expect no non-infra related flakes in the last month as a GA graduation criteria.
 -->
 
-- <test>: <link to test coverage>
+Test plan:
+- Enable the feature gate.
+- For each of memory and IO
+  - Schedule workloads to a node that overwhelms the resource.
+  - Ensure the node is marked with corresponding PSI pressure node condition and taint.
+  - Create more workloads and observe that the workloads cannot be scheduled onto this node.
+  - Delete existing workloads to free up the resource.
+  - Ensure the node condition and taint are removed.
+  - Create more workloads and observe the the workloads can be scheduled.
+  - Clean up.
 
 ### Graduation Criteria
 
@@ -566,6 +575,7 @@ NA
 
 - 2023/09/13: Initial proposal
 - 2025/06/11: Drop Phase 1 contents as they are split into a separate KEP. Keep Phase 2 contents.
+- 2025/06/11: Update Alpha requirements.
 
 ## Drawbacks
 

--- a/keps/sig-node/4205-psi-metric/kep.yaml
+++ b/keps/sig-node/4205-psi-metric/kep.yaml
@@ -3,6 +3,7 @@ kep-number: 4205
 authors:
   - "@ndixita"
   - "@dragoncell"
+  - "@roycaihw"
 owning-sig: sig-node
 participating-sigs:
   - sig-node
@@ -26,11 +27,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.33"
+  alpha: "v1.34"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Split the two phases into two KEPs to allow them moving at different paces. See https://github.com/kubernetes/enhancements/pull/5395 for more details. Also update Alpha and Beta requirements. Make CPU PSI a Beta requirement 

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4205

<!-- other comments or additional information -->
- Other comments: See https://github.com/kubernetes/enhancements/issues/5062. CPU PSI cannot be used the same way as memory / IO PSI due to CPU being a compressible resource.

/sig node
/cc @haircommander @ndixita @tiraboschi