### PR TITLE
KEP-4680 is targeting alpha for DRA in 1.34

### DIFF
--- a/keps/sig-node/4680-add-resource-health-to-pod-status/README.md
+++ b/keps/sig-node/4680-add-resource-health-to-pod-status/README.md
@@ -543,7 +543,7 @@ Not applicable.
 
 ## Implementation History
 
-- `v1.31`: KEP is in alpha
+- `v1.31`: KEP is in alpha and imlpemented for Device Plugin
 
 ## Drawbacks
 

--- a/keps/sig-node/4680-add-resource-health-to-pod-status/kep.yaml
+++ b/keps/sig-node/4680-add-resource-health-to-pod-status/kep.yaml
@@ -2,6 +2,7 @@ title: Add Resource Health Status to the Pod Status for Device Plugin and DRA
 kep-number: 4680
 authors:
   - "@SergeyKanzhelev"
+  - "@Jpsassine"
 owning-sig: sig-node
 participating-sigs:
   - sig-node
@@ -28,13 +29,13 @@ stage: alpha #|beta|stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.31" # 1.32 will contain an alpha2 with more features 
-  beta: "v1.34"
-  stable: "v1.36"
+  beta: "v1.35"
+  stable: "v1.37"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
/sig node

/cc @Jpsassine

/assign @mrunalp 

It was approved and PRR reviewed already for 1.33. Moved to 1.34 as implementation slipped the release