### PR TITLE
Job Pod Replacement Policy; promote to GA - deprecation date update

### DIFF
--- a/keps/sig-apps/3939-allow-replacement-when-fully-terminated/README.md
+++ b/keps/sig-apps/3939-allow-replacement-when-fully-terminated/README.md
@@ -621,7 +621,7 @@ We expect no non-infra related flakes in the last month as a GA graduation crite
 
 #### Deprecation
 
-- Remove `JobPodReplacementPolicy` feature-gate in GA+2.
+- Remove `JobPodReplacementPolicy` feature-gate in GA+3.
 
 ### Upgrade / Downgrade Strategy
 


### PR DESCRIPTION
One-line PR description: Promote Job Pod Replacement Policy to GA
Issue link: https://github.com/kubernetes/enhancements/issues/3939
Other comments: Deprecation is now GA+3 instead of GA+2 (per latest lifecycle rules)

/cc @mimowo @kannon92 @soltysh 