### PR TITLE
KEP-3926: update KEP latest milestone to v1.34 as implementable

### DIFF
--- a/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
+++ b/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
@@ -25,7 +25,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
One-line PR description: KEP-3926: update KEP latest milestone to v1.34 as implementable

Issue link: https://github.com/kubernetes/enhancements/issues/3926

Other comments: N/A