### PR TITLE
4639: bump to 1.34 and document noexec drop

### DIFF
--- a/keps/sig-node/4639-oci-volume-source/README.md
+++ b/keps/sig-node/4639-oci-volume-source/README.md
@@ -1374,6 +1374,7 @@ Major milestones might include:
 - 21-06-2024 KEP merged, targeted at alpha
 - 02-10-2024 KEP updated
 - 06-02-2025 KEP targeting beta in v1.33
+- 06-17-2025 KEP retargeting beta in v1.34, dropped noexec requirement
 
 ## Drawbacks
 

--- a/keps/sig-node/4639-oci-volume-source/kep.yaml
+++ b/keps/sig-node/4639-oci-volume-source/kep.yaml
@@ -46,12 +46,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.31"
-  beta: "v1.33"
+  beta: "v1.34"
   stable: "TBD"
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:

<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/4639
<!-- other comments or additional information -->
- Other comments: