### PR TITLE
KEP-3926: update KEP beta milestone to v1.35

### DIFF
--- a/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
+++ b/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
@@ -30,7 +30,7 @@ latest-milestone: "v1.34"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
-  beta: ""
+  beta: "v1.35"
   stable: ""
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
One-line PR description: KEP-3926: update KEP beta milestone to v1.35

Issue link: https://github.com/kubernetes/enhancements/issues/3926

Other comments:

- Done for clarification.