### PR TITLE
fix metadata to mark KEP-5307 implementable

### DIFF
--- a/keps/prod-readiness/sig-node/5307.yaml
+++ b/keps/prod-readiness/sig-node/5307.yaml
@@ -1,3 +1,3 @@
 kep-number: 5307
 alpha:
-  approver: " wojtek-t"
+  approver: "wojtek-t"

--- a/keps/sig-node/5307-container-restart-policy/kep.yaml
+++ b/keps/sig-node/5307-container-restart-policy/kep.yaml
@@ -5,7 +5,7 @@ authors:
   - "@SergeyKanzhelev"
 owning-sig: sig-node
 participating-sigs:
-status: provisional
+status: implementable
 creation-date: 2025-05-16
 reviewers:
   - "@SergeyKanzhelev"


### PR DESCRIPTION
/sig node

