### PR TITLE
KEP-4205: Fix prod readiness approver

### DIFF
--- a/keps/prod-readiness/sig-node/4205.yaml
+++ b/keps/prod-readiness/sig-node/4205.yaml
@@ -5,4 +5,4 @@ kep-number: 4205
 alpha:
   approver: "@johnbelamaric"
 beta:
-  approver: "@johnbelamaric"
+  approver: "@deads2k"


### PR DESCRIPTION
To correctly reflect https://github.com/kubernetes/enhancements/pull/5409#issuecomment-2985284532. Somehow this change was missed in the commit there.

/assign @deads2k 
/sig-node