### PR TITLE
KEP 1645: add ServiceImport conditions

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -538,6 +538,11 @@ cluster, non-cluster-admin users should not be allowed to create or modify
 `ServiceImport` resources. The mcs-controller should be solely responsible for
 the lifecycle of a `ServiceImport`.
 
+Some errors may occur during the `ServiceImport`'s lifecycle, such as IP protocol
+incompatibilities (i.e.: importing an IPv6 only service in an IPv4 cluster). These
+errors and general status reporting of a `ServiceImport` should be reported
+via its status conditions field.
+
 For each exported service, one `ServiceExport` will exist in each cluster that
 exports the service. The mcs-controller will create and maintain a derived
 `ServiceImport` in each cluster within the clusterset so long as the service's
@@ -620,6 +625,12 @@ type ServiceImportStatus struct {
   // +listType=map
   // +listMapKey=cluster
   Clusters []ClusterStatus `json:"clusters"`
+  // +optional
+  // +patchStrategy=merge
+  // +patchMergeKey=type
+  // +listType=map
+  // +listMapKey=type
+  Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ClusterStatus contains service configuration mapped to a specific source cluster
@@ -644,6 +655,11 @@ spec:
     port: 80
   sessionAffinity: None
 status:
+  conditions:
+  - type: Ready
+    reason: Ready
+    status: "True"
+    lastTransitionTime: "2020-03-30T01:33:51Z"
   clusters:
   - cluster: us-west2-a-my-cluster
 ```


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Add conditions field to ServiceImport resource

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1645

<!-- other comments or additional information -->
- Other comments:

So far we had the conditions fields only on ServiceExport, trying to implement dual stack on Cilium and Submariner highlighted that there could be some "import time" errors as well. For instance, having an IPv6 only service and trying to import in IPv4 only clusters which in both Cilium and Submariner raise some issue that we would want to report to users via the ServiceImport conditions.

This is not specifically tied to IP protocol/families issues but supposed to be a general thing for implementations to report any errors and status occurring during import time.