### PR TITLE
KEP-5307: Correct typo in feature gate name

### DIFF
--- a/keps/sig-node/5307-container-restart-policy/README.md
+++ b/keps/sig-node/5307-container-restart-policy/README.md
@@ -309,7 +309,7 @@ type ContainerRestartPolicy string
 const (
   ContainerRestartPolicyAlways ContainerRestartPolicy = "Always"
   ContainerRestartPolicyNever ContainerRestartPolicy = "Never"
-  ContainerRestartPolicyOnFailure ContainerRestartPolicyOnFailure = "OnFailure"
+  ContainerRestartPolicyOnFailure ContainerRestartPolicy = "OnFailure"
 )
 
 type Container struct {
@@ -774,7 +774,7 @@ well as the [existing list] of feature gates.
 -->
 
 - [x] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: ContainerRestartPolicy
+  - Feature gate name: ContainerRestartRules
   - Components depending on the feature gate: kubelet, kube-apiserver
 
 ###### Does enabling the feature change any default behavior?

--- a/keps/sig-node/5307-container-restart-policy/kep.yaml
+++ b/keps/sig-node/5307-container-restart-policy/kep.yaml
@@ -35,7 +35,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: ContainerRestartPolicy
+  - name: ContainerRestartRules
     components:
       - kubelet
       - kube-apiserver


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Changes the typo in feature gate name from `ContainerRestartPolicy` to `ContainerRestartRules`.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5307

<!-- other comments or additional information -->
- Other comments: