### PR TITLE
KEP-5295: Fix the typo from kayml to kyaml

### DIFF
--- a/keps/sig-cli/5295-kyaml/README.md
+++ b/keps/sig-cli/5295-kyaml/README.md
@@ -130,7 +130,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 This KEP proposes to add a new output format for kubectl,
 called "KYAML"
-(as in `kubectl get -o kayml ...`).
+(as in `kubectl get -o kyaml ...`).
 This format is a strict subset (aka "dialect") of standard YAML,
 and so should be parseable by the existing ecosystem.
 This dialect seeks to emphasize syntactical choices which avoid


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Fix the typo from `kayml` to `kyaml`

<!-- link to the k/enhancements issue -->
- Issue link: #5295 

<!-- other comments or additional information -->
- Other comments: