### PR TITLE
KEP-4222: Add streaming list encode requirement to CBOR KEP.

### DIFF
--- a/keps/sig-api-machinery/4222-cbor-serializer/README.md
+++ b/keps/sig-api-machinery/4222-cbor-serializer/README.md
@@ -1084,6 +1084,8 @@ in back-to-back releases.
   custom CBOR behaviors.
 - All Kubernetes components have opted out of automatic transcoding to JSON for FieldsV1 and
   RawExtension.
+- List object encoding supports "true" streaming (i.e. buffer size is not proportional to output
+  size).
 
 #### GA
 

--- a/keps/sig-api-machinery/4222-cbor-serializer/kep.yaml
+++ b/keps/sig-api-machinery/4222-cbor-serializer/kep.yaml
@@ -22,7 +22,7 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.32"
+latest-milestone: "v1.34"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Adds streaming list encoding as a CBOR beta requirement.

<!-- link to the k/enhancements issue -->
- Issue link: https://kep.k8s.io/4222

<!-- other comments or additional information -->
- Other comments: https://kep.k8s.io/5116 excludes CBOR, but the problem and requirement are effectively the same. We can solve this either with a special case (as has been done for JSON) or by the introduction of generalized streamed encoding to the upstream library.