### PR TITLE
KEP 647, 2831: Mark apiserver and kubelet tracing KEPs as implemented

### DIFF
--- a/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
+++ b/keps/sig-instrumentation/2831-kubelet-tracing/kep.yaml
@@ -8,7 +8,7 @@ owning-sig: sig-instrumentation
 participating-sigs:
   - sig-architecture
   - sig-node
-status: implementable
+status: implemented
 creation-date: 2021-07-21
 reviewers:
   - "@saschagrunert"

--- a/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
+++ b/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
@@ -9,7 +9,7 @@ participating-sigs:
   - sig-architecture
   - sig-api-machinery
   - sig-scalability
-status: implementable
+status: implemented
 creation-date: 2018-12-04
 reviewers:
   - "@logicalhan"


### PR DESCRIPTION
fixes https://github.com/kubernetes/enhancements/issues/647 https://github.com/kubernetes/enhancements/issues/2831

Both features graduated to stable in 1.34

@kubernetes/sig-instrumentation-leads 