### PR TITLE
[KEP-3104] Update KEP with credential plugin allowlist

### DIFF
--- a/keps/sig-cli/3104-introduce-kuberc/kep.yaml
+++ b/keps/sig-cli/3104-introduce-kuberc/kep.yaml
@@ -5,7 +5,8 @@ authors:
   - "@soltysh"
 owning-sig: sig-cli
 participating-sigs:
-  - sig-cli
+  - sig-auth
+  - sig-api-machinery
 status: implementable
 creation-date: 2022-06-13
 reviewers:
@@ -13,6 +14,7 @@ reviewers:
   - "@eddiezane"
   - "@soltysh"
   - "@mpuckett159"
+  - "@enj"
 approvers:
   - "@ardaguclu"
 


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update kuberc KEP with credential plugin allowlist

<!-- link to the k/enhancements issue -->
- Issue link: #3104 

<!-- other comments or additional information -->
- Other comments:
- 
Currently, the kubeconfig may specify arbitrary binaries to run as
client-go credential plugins. Due to the fact that kubeconfig files are
often generated, and because they contain a lot of noise, there is
significant friction in manually inspecting the kubeconfig for
suspicious binaries after it is generated.

To encourage secure behavior, we want to introduce an allowlist to the
kuberc, which will describe the conditions under which a binary plugin
may be run. Currently the only condition is the name (absolute path or
basename of a binary found in `PATH`).
