### PR TITLE
scale approvers for Env Vars since it passed an alpha stage

### DIFF
--- a/keps/sig-node/3721-support-for-env-files/OWNERS
+++ b/keps/sig-node/3721-support-for-env-files/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- SergeyKanzhelev # scaling the approvers for individual KEPs


### PR DESCRIPTION
/sig node

Once KEP passed alpha, we can scale owners. I am marked as an approver for this KEP and I plan to see it thru Beta and GA