### PR TITLE
KEP-5339: fix typo in ClusterProfile credentialProviders example

### DIFF
--- a/keps/sig-multicluster/5339-clusterprofile-plugin-credentials/README.md
+++ b/keps/sig-multicluster/5339-clusterprofile-plugin-credentials/README.md
@@ -312,7 +312,8 @@ status:
    - name: location
      value: us-central1
   credentialProviders:
-    google:
+  - name: google
+    cluster:
       cluster:
         server: https://connectgateway.googleapis.com/v1/projects/123456789/locations/us-central1/gkeMemberships/my-cluster-1
 ```


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
  Update the `ClusterProfile` example so `.status.credentialProviders` is a **list of providers** (`- name: <provider>, cluster: {...}`) rather than a map keyed by provider name, aligning the KEP example with the intended API.

<!-- link to the k/enhancements issue -->
- Issue link:
  N/A (minor example correction). Context/discussion: kubernetes-sigs/cluster-inventory-api#20

<!-- other comments or additional information -->
- Other comments:
  * Rationale: maintainers clarified that `credentialProviders` represents a list of supported credential providers for a `ClusterProfile`.
  * Scope: documentation-only change within the KEP README; no change to KEP status, graduation criteria, or API surface.
  * Before (excerpt):
    ```yaml
    status:
      credentialProviders:
        google:
          cluster:
            server: https://connectgateway.googleapis.com/...
    ```
  * After (excerpt):
    ```yaml
    status:
      credentialProviders:
      - name: google
        cluster:
          server: https://connectgateway.googleapis.com/...
    ```
