### PR TITLE
Update KEP release checklist conformance requirements

### DIFF
--- a/keps/NNNN-kep-template/README.md
+++ b/keps/NNNN-kep-template/README.md
@@ -136,7 +136,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
   - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [ ] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
 - [ ] "Implementation History" section is up-to-date for milestone


### PR DESCRIPTION
- One-line PR description:
Updates the Release Checklist to specify that GA endpoints must be hit with conformance tests within 1 minor version of going GA, in line with actual practice.

- Other comments:
Conformance testing and the enforcement of this release checklist item are fundamentally broken, causing significant friction for both the Release Team and KEP owners. This change more closely reflects the reality of conformance testing in its current state, and gives the Release Team something enforceable without creating additional friction for KEP owners.

cc: @kubernetes/sig-release-leads @pohly @Vyom-Yadav @liggitt @dims 