### PR TITLE
KEP-4006: Updated KEP for 1.35

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/4006.yaml
+++ b/keps/prod-readiness/sig-api-machinery/4006.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@jpbetz"
+stable:
+  approver: "@jpbetz"

--- a/keps/sig-api-machinery/4006-transition-spdy-to-websockets/kep.yaml
+++ b/keps/sig-api-machinery/4006-transition-spdy-to-websockets/kep.yaml
@@ -22,13 +22,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.31"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.29"
   beta: "v1.31"
-  stable: "v1.32"
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -43,6 +43,9 @@ feature-gates:
     components:
       - kube-apiserver
   - name: PortForwardWebsockets
+    components:
+      - kube-apiserver
+  - name: AuthorizePodWebsocketUpgradeCreatePermission
     components:
       - kube-apiserver
 disable-supported: true


### PR DESCRIPTION
* Adds requirement for new synthetic RBAC CREATE permission check for WebSocket upgrade request.
  * Feature Gate for this functionality: `AuthorizePodWebsocketUpgradeCreatePermission`; enabled by default
  * Beta in v1.35
* Refactor GA/stable requirement for transitioning to streaming WebSockets from client to Kubelet (but **NOT** from Kubelet to container runtime).
* Updates KEP to reflect graduating WebSockets functionality to GA in v1.36

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4006