### PR TITLE
KEP-5004: added rationale for deterministically picking a device class for an extended resource when there are multiple device classes matching

### DIFF
--- a/keps/sig-scheduling/5004-dra-extended-resource/README.md
+++ b/keps/sig-scheduling/5004-dra-extended-resource/README.md
@@ -311,8 +311,10 @@ same cluster can have the same named extended resource backed by Device Plugin.
 The extended resource name to DRA device mapping can be specified at
 `DeviceClassSpec`. The same extended resource name should be given to at most one 
 device class. If there are more than one device classes, the one created later is picked 
-at scheduling time, if two are created at the same time, the name
-lexicographically sorted first is picked.
+at scheduling time, if two are created at the same time, the name lexicographically
+sorted first is picked, this gives a non-disruptive non-error way to transition an
+extended resource from being backed by one device class to being backed by another
+(create new device class, update old device class to clear the extended resource field).
 
 Cluster administrator is soly responsible for creating device classes, and the
 mapping between the class of devices and the extended resource name.


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
added rationale for deterministically picking a device class for an extended resource when there are multiple device classes matching

<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/5004

<!-- other comments or additional information -->
- Other comments:
https://github.com/kubernetes/kubernetes/issues/133693#issuecomment-3250346939