### PR TITLE
Set the beta graduation of KEP-4951 to 1.35

### DIFF
--- a/keps/sig-autoscaling/4951-configurable-hpa-tolerance/kep.yaml
+++ b/keps/sig-autoscaling/4951-configurable-hpa-tolerance/kep.yaml
@@ -9,8 +9,10 @@ creation-date: 2024-11-05
 reviewers:
   - "@gjtempleton"
   - "@raywainman"
+  - "@adrianmoisey"
 approvers:
   - "@gjtempleton"
+  - "@soltysh"
 
 see-also:
   - "/keps/sig-autoscaling/853-configurable-hpa-scale-velocity"
@@ -22,12 +24,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.33"
-  beta: "v1.34"
+  beta: "v1.35"
   stable: TBD
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
- One-line PR description: Set the beta graduation of KEP-4951 to 1.35.
- Issue link: https://github.com/kubernetes/kubernetes/issues/116984