### PR TITLE
KEP-3015: update PreferSame* TrafficDistribution to GA

### DIFF
--- a/keps/prod-readiness/sig-network/3015.yaml
+++ b/keps/prod-readiness/sig-network/3015.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-network/3015-prefer-same-node/README.md
+++ b/keps/sig-network/3015-prefer-same-node/README.md
@@ -1,7 +1,6 @@
 # KEP-3015 PreferSameZone and PreferSameNode Traffic Distribution
 
 <!-- toc -->
-- [Release Signoff Checklist](#release-signoff-checklist)
 - [Summary](#summary)
 - [Motivation](#motivation)
   - [Goals](#goals)
@@ -36,48 +35,6 @@
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
 <!-- /toc -->
-
-## Release Signoff Checklist
-
-<!--
-**ACTION REQUIRED:** In order to merge code into a release, there must be an
-issue in [kubernetes/enhancements] referencing this KEP and targeting a release
-milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
-of the targeted release**.
-
-For enhancements that make changes to code or processes/procedures in core
-Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
-Signoff checklist to be completed.
-
-Check these off as they are completed for the Release Team to track. These
-checklist items _must_ be updated for the enhancement to be released.
--->
-
-Items marked with (R) are required *prior to targeting to a milestone / release*.
-
-- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [X] (R) KEP approvers have approved the KEP status as `implementable`
-- [X] (R) Design details are appropriately documented
-- [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
-  - [X] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
-- [X] (R) Graduation criteria is in place
-  - [X] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-- [X] (R) Production readiness review completed
-- [X] (R) Production readiness review approved
-- [X] "Implementation History" section is up-to-date for milestone
-- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [X] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
-
-<!--
-**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
--->
-
-[kubernetes.io]: https://kubernetes.io/
-[kubernetes/enhancements]: https://git.k8s.io/enhancements
-[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
-[kubernetes/website]: https://git.k8s.io/website
 
 ## Summary
 

--- a/keps/sig-network/3015-prefer-same-node/kep.yaml
+++ b/keps/sig-network/3015-prefer-same-node/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@danwinship"
 owning-sig: sig-network
 participating-sigs:
-status: implementable
+status: implemented
 creation-date: 2025-01-23
 reviewers:
   - "@gauravkghildiyal"
@@ -17,12 +17,12 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
Update https://github.com/kubernetes/enhancements/issues/3015 to GA.

The GA graduation criteria are just "Time passes, no major objections". The biggest change will be the docs updates reflecting that `PreferClose` is now deprecated in favor of `PreferSameZone`.
