### PR TITLE
KEP-3104: Add kubectl kuberc command section

### DIFF
--- a/keps/sig-cli/3104-introduce-kuberc/README.md
+++ b/keps/sig-cli/3104-introduce-kuberc/README.md
@@ -94,18 +94,16 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Design Details](#design-details)
   - [Kubectl Kuberc Management Command (kubectl kuberc)](#kubectl-kuberc-management-command-kubectl-kuberc)
   - [kubectl kuberc view](#kubectl-kuberc-view)
-  - [kubectl kuberc default](#kubectl-kuberc-default)
+  - [kubectl kuberc set --section defaults](#kubectl-kuberc-set---section-defaults)
     - [command](#command)
     - [option](#option)
     - [overwrite](#overwrite)
-    - [recommended](#recommended)
-  - [kubectl kuberc alias](#kubectl-kuberc-alias)
+  - [kubectl kuberc set --section aliases](#kubectl-kuberc-set---section-aliases)
     - [name](#name)
     - [command](#command-1)
     - [option](#option-1)
-    - [prependargs](#prependargs)
-    - [appendargs](#appendargs)
-    - [overwrite](#overwrite-1)
+    - [prependarg](#prependarg)
+    - [appendarg](#appendarg)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
@@ -380,7 +378,7 @@ Therefore, this section proposes new kubectl command, namely `kubectl kuberc`.
 
 `kubectl kuberc` is the main command serving as an entry point to the subcommands similar to how `kubectl create` is designed.
 Invocation of `kubectl kuberc` prints the subcommands. 
-Currently, there are three subcommands (but this can be extended in the future, when more functionality is added to kuberc).
+Currently, there are two subcommands (but this can be extended in the future, when more functionality is added to kuberc).
 All the subcommands accept `kuberc` flag to explicitly specify the kuberc file to be updated. File priority order is the same with
 kuberc execution:
 
@@ -394,23 +392,23 @@ This command and subcommands are marked as alpha initially. They can be executed
 
 `kubectl kuberc view` subcommand prints the defined kuberc file content in the given format via `--output` flag (default is yaml).
 
-### kubectl kuberc default
+### kubectl kuberc set --section defaults
 
-`kubectl kuberc default` subcommand creates/updates the default values of commands. It has these flags;
+`kubectl kuberc set --section defaults` subcommand creates/updates the default values of commands. It has the following flags;
 
 #### command
 
-`kubectl kuberc default` command validates the presence of the command given via flag `--command`.
+`kubectl kuberc set --section defaults` command validates the presence of the command given via flag `--command`.
 This flag can contain subcommands as well. Examples might be `--command=apply`, `--command="create role"`.
 
 #### option
 
 `--option` flag accepts list of options. We may or may not validate the presence of the flag name in the given command. 
 But it is up to user to set the correct default value in correct type. Therefore, default field of the options is arbitrary.
-Examples might be `--option="--server-side=true"`, `--option="--namespace=test"`.
+Examples might be `--option="server-side=true"`, `--option="namespace=test"`.
 
 Although kuberc supports short versions of flags (e.g. `-n test`), 
-this flag forces users to enter options in standardized format `--option=--$flag_name=$flag_value`. 
+this flag forces users to enter options in standardized format `--option=$flag_name=$flag_value`. 
 This gives us the opportunity to standardize kuberc files. 
 
 #### overwrite
@@ -418,25 +416,9 @@ This gives us the opportunity to standardize kuberc files.
 By default, this command errors out, if it finds a section of same command and same flag that is executed. `--overwrite` flag
 is used to update this section.
 
-#### recommended
+### kubectl kuberc set --section aliases
 
-This boolean flag adds the recommended flag options by SIG CLI such as interactive delete, server side apply, so on. 
-
-```yaml
-defaults:
-  - command: apply
-    options:
-      - name: server-side
-        default: "true"
-      - name: namespace
-        default: "test"
-```
-
-As a result, in order to create the above defaults, user needs to simply run `kubectl kuberc default --command=apply --option="--server-side=true" --option="--namespace=test"`
-
-### kubectl kuberc alias
-
-`kubectl kuberc alias` defines alias definitions of a command and a set of flag options. It has these flags;
+`kubectl kuberc set --section aliases` defines alias definitions of a command and a set of flag options. It has these flags;
 
 #### name
 
@@ -444,48 +426,26 @@ This required field is to define the name of the alias. This is inherently arbit
 
 #### command
 
-`kubectl kuberc alias` command validates the presence of the command given via flag `--command`.
+`kubectl kuberc set --section aliases` command validates the presence of the command given via flag `--command`.
 This flag can contain subcommands as well. Examples might be `--command=apply`, `--command="create role"`.
 
 #### option
 
 `--option` flag accepts list of options. We may or may not validate the presence of the flag name in the given command.
 But it is up to user setting the correct default value in correct type. Therefore, default field of the options is arbitrary.
-Examples might be `--option="--server-side=true"`, `--option="--namespace=test"`.
+Examples might be `--option="server-side=true"`, `--option="namespace=test"`.
 
 Although kuberc supports short versions of flags (e.g. `-n test`),
-this flag forces users to enter options in opinionated format `--option=--$flag_name=$flag_value`.
+this flag forces users to enter options in opinionated format `--option=$flag_name=$flag_value`.
 This gives us the opportunity to standardize kuberc files.
 
-#### prependargs
+#### prependarg
 
-`--prependargs` is an arbitrary list of strings that accepts anything in a string array format. 
+`--prependarg` is an arbitrary list of strings that accepts anything in a string array format. 
 
-#### appendargs
+#### appendarg
 
-`--appendargs` is an arbitrary list of strings that accepts anything in string array format.
-
-#### overwrite
-
-By default, this command errors out, if it finds a section of same alias name. `--overwrite` flag
-is used to update this section.
-
-
-```yaml
-aliases:
-  - name: getdbprod
-    command: get
-    prependArgs:
-    - pods
-    options:
-    - name: labels
-      default: what=database
-    - name: namespace
-      default: us-2-production
-```
-
-As a result, in order to create the above alias, user needs to simply run:
-`kubectl kuberc alias getdbprod --command=get --option="--labels=what=database" --option="--namespace=us-2-production" --prependargs="pods"`
+`--appendarg` is an arbitrary list of strings that accepts anything in string array format.
 
 ### Test Plan
 

--- a/keps/sig-cli/3104-introduce-kuberc/kep.yaml
+++ b/keps/sig-cli/3104-introduce-kuberc/kep.yaml
@@ -26,7 +26,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Add `kubectl kuberc` command to generate kuberc files.

- Issue link:
     * [Discussion link](https://www.youtube.com/watch?v=7CxnjCu4Pms&list=PL69nYSiGNLP28HaTzSlFe6RJVxpFmbUvF&index=2)
     * https://github.com/kubernetes/enhancements/issues/3104

<!-- other comments or additional information -->
- Other comments: