### PR TITLE
KEP-3331: update kep latest milestone to v1.35

### DIFF
--- a/keps/sig-auth/3331-structured-authentication-configuration/kep.yaml
+++ b/keps/sig-auth/3331-structured-authentication-configuration/kep.yaml
@@ -12,7 +12,7 @@ approvers:
 creation-date: "2022-06-02"
 status: implementable
 stage: stable
-latest-milestone: "v1.34"
+latest-milestone: "v1.35"
 milestone:
   alpha: "v1.29"
   beta: "v1.30"


### PR DESCRIPTION
- Update KEP latest milestone to `v1.35`.
  - The feature has graduated to stable in v1.34, we plan to make some code changes in v1.35 release for metrics and distributed claims support (feature-gated).
  - refer to https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration#possible-future-work for more details.
- Issue link: https://github.com/kubernetes/enhancements/issues/3331

/sig auth
/assign enj