### PR TITLE
KEP-4412: update kep latest milestone to v1.35

### DIFF
--- a/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/kep.yaml
+++ b/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/kep.yaml
@@ -17,7 +17,7 @@ see-also:
 creation-date: "2024-09-09"
 status: implementable
 stage: beta
-latest-milestone: "v1.34"
+latest-milestone: "v1.35"
 milestone:
   alpha: "v1.33"
   beta: "v1.34"


### PR DESCRIPTION
- Update KEP latest milestone to `v1.35`.
  - The feature has graduated to beta in v1.34, we plan to make some code changes in v1.35 release for e2e tests.
- Issue link: https://github.com/kubernetes/enhancements/issues/4412

/sig auth
/assign enj