### PR TITLE
[KEP-4817] Graduate to stable

### DIFF
--- a/keps/prod-readiness/sig-node/4817.yaml
+++ b/keps/prod-readiness/sig-node/4817.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/4817-resource-claim-device-status/README.md
+++ b/keps/sig-node/4817-resource-claim-device-status/README.md
@@ -614,6 +614,8 @@ N/A
 - Initial proposal: 2024-08-30
 - Implementation merged ([kubernetes/kubernetes#128240](https://github.com/kubernetes/kubernetes/pull/128240)): 2024-11-08
 - Released as an alpha feature behind a feature-gate: 2024-12-11 (Kubernetes v1.32)
+- Released as a beta feature with the feature-gate enabled by default: 2025-05-15 (Kubernetes v1.33)
+- Released as a stable feature: 2025-12-17 (Kubernetes v1.35)
 
 ## Drawbacks
 

--- a/keps/sig-node/4817-resource-claim-device-status/kep.yaml
+++ b/keps/sig-node/4817-resource-claim-device-status/kep.yaml
@@ -27,14 +27,15 @@ see-also:
   - "https://github.com/k8snetworkplumbingwg/network-attachment-definition-client"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
-latest-milestone: "v1.33"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
   beta: "v1.33"
+  stable: "v1.35"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Graduate the ResourceClaim Device Status (KEP-4817) to stable/ga.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4817#issuecomment-3368898737

<!-- other comments or additional information -->
- Other comments: