### PR TITLE
Retarget KEP-5365 (ImageVolume with image digest) alpha graduation to v1.35

### DIFF
--- a/keps/sig-node/5365-ImageVolume-with-image-digest/kep.yaml
+++ b/keps/sig-node/5365-ImageVolume-with-image-digest/kep.yaml
@@ -25,11 +25,11 @@ stage: alpha # alpha|beta|stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.34"
+  alpha: "v1.35"
   beta: "TBD"
   stable: "TBD"
 


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Retarget KEP-5365 (ImageVolume with image digest) alpha graduation to v1.35.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5365.

<!-- other comments or additional information -->
- Other comments:

/cc @SergeyKanzhelev @aibarbetta 