### PR TITLE
KEP-859: promote command headers to stable

### DIFF
--- a/keps/prod-readiness/sig-cli/859.yaml
+++ b/keps/prod-readiness/sig-cli/859.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@johnbelamaric"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-cli/859-kubectl-headers/README.md
+++ b/keps/sig-cli/859-kubectl-headers/README.md
@@ -1,7 +1,4 @@
-# kubectl commands in headers
-
-
-## Table of Contents
+# KEP-859: kubectl commands in headers
 
 <!-- toc -->
 - [Release Signoff Checklist](#release-signoff-checklist)
@@ -12,17 +9,18 @@
   - [Anti-Goals](#anti-goals)
 - [Proposal](#proposal)
   - [Kubectl-Command Header](#kubectl-command-header)
-  - [Kubectl-Flags Header](#kubectl-flags-header)
-    - [Enumerated Flag Values](#enumerated-flag-values)
   - [Kubectl-Session Header](#kubectl-session-header)
-  - [Kubectl-Deprecated Header](#kubectl-deprecated-header)
-  - [Kubectl-Build Header](#kubectl-build-header)
   - [Example](#example)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Test Plan](#test-plan)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
-    - [Alpha -&gt; Beta Graduation](#alpha---beta-graduation)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
@@ -31,23 +29,29 @@
   - [Monitoring Requirements](#monitoring-requirements)
   - [Dependencies](#dependencies)
   - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
 - [Implementation History](#implementation-history)
+- [Alternatives](#alternatives)
 <!-- /toc -->
 
 ## Release Signoff Checklist
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [X] (R) KEP approvers have approved the KEP status as `implementable`
-- [X] (R) Design details are appropriately documented
-- [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input
-- [X] (R) Graduation criteria is in place
-- [X] (R) Production readiness review completed
-- [X] (R) Production readiness review approved
-- [X] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [x] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) Design details are appropriately documented
+- [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [x] e2e Tests for all Beta API Operations (endpoints)
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [x] (R) Graduation criteria is in place
+  - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
+- [x] (R) Production readiness review completed
+- [x] (R) Production readiness review approved
+- [x] "Implementation History" section is up-to-date for milestone
+- [x] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 
 [kubernetes.io]: https://kubernetes.io/
@@ -57,12 +61,11 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 ## Summary
 
-Requests sent to the apiserver from kubectl already include a User Agent header with
+Requests sent to the kube-apiserver from kubectl already include a User-Agent header with
 information about the kubectl build.  This KEP proposes sending http request headers
 with additional context about the kubectl command that created the request.
 This information may be used by operators of clusters for debugging or
 to gather telemetry about how users are interacting with the cluster.
-
 
 ## Motivation
 
@@ -75,7 +78,7 @@ are interacting with the cluster, which could be used for various purposes.
 
 - Allow cluster administrators to identify how requests in the logs were generated from
   kubectl commands.
-  
+
 Possible applications of this information may include but are not limited to:
 
 - Organizations could learn how users are interacting will their clusters to inform what internal
@@ -84,7 +87,7 @@ Possible applications of this information may include but are not limited to:
   when the version of kubectl is upgraded.  They could do this before upgrading kubectl.
   - SIG-CLI could build tools that cluster admins run and perform this analysis
     to them to help with understanding whether they will be impacted by command deprecation
-- Organizations could identify if users are running kubectl commands that are inconsistent with 
+- Organizations could identify if users are running kubectl commands that are inconsistent with
   the organization's internal best practices and recommendations.
 - Organizations could voluntarily choose to bring back high-level learnings to SIG-CLI regarding
   which and how commands are used.  This could be used by the SIG to inform where to invest resources
@@ -101,7 +104,7 @@ Possible applications of this information may include but are not limited to:
 *The following are not goals of this KEP, but could be considered in the future.*
 
 - Supply Headers for requests made by kubectl plugins.  Enforcing this would not be trivial.
-- Send Headers to the apiserver for kubectl command invocations that don't make requests - 
+- Send Headers to the apiserver for kubectl command invocations that don't make requests -
   e.g. `--dry-run`
 
 ### Anti-Goals
@@ -138,28 +141,6 @@ Examples:
 - `Kubectl-Command: kubectl delete`
 - `Kubectl-Command: kubectl get`
 
-### Kubectl-Flags Header
-
-The `Kubectl-Flags` Header contains a list of the kubectl flags that were provided to the sub
-command.  It does *not* contain the raw flag values, but may contain enumerations for
-whitelisted flag values.  (e.g. for `-f` it may contain whether a local file, stdin, or remote file
-was provided).  It does not normalize into short or long form.  If a flag is
-provided multiple times it will appear multiple times in the list.  Flags are sorted
-alpha-numerically and separated by a ',' to simplify human readability.
-
-Examples:
-
-- `Kubectl-Flags: --filename=local,--recursive,--context`
-- `Kubectl-Flags: -f=local,-f=local,-f=remote,-R`
-- `Kubectl-Flags: -f=stdin`
-- `Kubectl-Flags: --dry-run,-o=custom-columns`
-
-#### Enumerated Flag Values
-
-- `-f`, `--filename`: `local`, `remote`, `stdin`
-- `-o`, `--output`: `json`,`yaml`,`wide`,`name`,`custom-columns`,`custom-columns-file`,`go-template`,`go-template-file`,`jsonpath`,`jsonpath-file`
-- `--type` (for patch subcommand): `json`, `merge`, `strategic`
-
 ### Kubectl-Session Header
 
 The `Kubectl-Session` Header contains a Session ID that can be used to identify that multiple
@@ -168,30 +149,6 @@ once and used for all requests for each kubectl process.
 
 - `Kubectl-Session: 67b540bf-d219-4868-abd8-b08c77fefeca`
 
-### Kubectl-Deprecated Header
-
-The `Kubectl-Deprecated` Header is set to inform cluster admins that the command being run
-has been deprecated.  This may be used by organizations to determine if they are likely
-to be impacted by command deprecation and removal before they upgrade.
-
-The `Kubectl-Deprecated` Header is set if the command that was run is marked as deprecated.
-
-- The Header may have a value of `true` if the command has been deprecated, but has no removal date.
-- The Header may have a value of a specific Kubernetes release.  If it does, this is the release
-  that the command will be removed in.
-
-- `Kubectl-Deprecated: true`
-- `Kubectl-Deprecated: v1.16`
-
-
-### Kubectl-Build Header
-
-The `Kubectl-Build` Header may be set by building with a specific `-ldflags` value.  By default the Header
-is unset, but may be set if kubectl is built from source, forked, or vendored into another command.
-Organizations that distribute one or more versions of kubectl which they maintain internally may
-set a flag at build time and this header will be populated with the value.
-
-- `Kubectl-Build: some-value`
 
 ### Example
 
@@ -201,10 +158,8 @@ $ kubectl apply -f - -o yaml
 
 ```
 Kubectl-Command: apply
-Kubectl-Flags: -f=stdin,-o=yaml
 Kubectl-Session: 67b540bf-d219-4868-abd8-b08c77fefeca
 ```
-
 
 ```sh
 $ kubectl apply -f ./local/file -o=custom-columns=NAME:.metadata.name
@@ -212,7 +167,6 @@ $ kubectl apply -f ./local/file -o=custom-columns=NAME:.metadata.name
 
 ```
 Kubectl-Command: apply
-Kubectl-Flags: -f=local,-o=custom-columns
 Kubectl-Session: 0087f200-3079-458e-ae9a-b35305fb7432
 ```
 
@@ -223,10 +177,8 @@ image"}]'
 
 ```
 Kubectl-Command: patch
-Kubectl-Flags: --type=json,-p
 Kubectl-Session: 0087f200-3079-458e-ae9a-b35305fb7432
 ```
-
 
 ```sh
 kubectl run nginx --image nginx
@@ -234,9 +186,7 @@ kubectl run nginx --image nginx
 
 ```
 Kubectl-Command: run
-Kubectl-Flags: --image
 Kubectl-Session: 0087f200-3079-458e-ae9a-b35305fb7432
-Kubectl-Deprecated: true
 ```
 
 ### Risks and Mitigations
@@ -249,30 +199,44 @@ included.
 
 ### Test Plan
 
-- Verify the Command Header is sent for commands and has the correct value
-- Verify the Flags Header is sent for flags and has the correct value
-- Verify the Session Header is sent for the Session and has a legitimate value
-- Verify the Deprecation Header is sent for the deprecated commands and has the correct value
-- Verify the Build Header is sent when the binary is built with the correct ldflags value
-  specified and has the correct value
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Unit tests
+
+- `k8s.io/cli-runtime/pkg/genericclioptions`: `2025-10-08` - `22.9%`
+- `k8s.io/kubectl/pkg/cmd/`: `2025-10-08` - `61.8%`
+
+##### Integration tests
+
+None are necessary, the entire functionality can be tested with unit tests.
+
+##### e2e tests
+
+None are necessary, the entire functionality can be tested with unit tests.
 
 ### Graduation Criteria
 
-#### Alpha -> Beta Graduation
+#### Alpha
 
-- [ ] Change feature gate from default **off** to default **on**
-- [ ] Documentation in kubectl section of [kubernetes.io] describes the
-extra headers sent and how to disable these headers if necessary.
-- [ ] kubectl headers remove the `X-` prefix to align with
-[IETF guidance](https://datatracker.ietf.org/doc/html/rfc6648).
-Example: `X-Kubectl-Command` header is changed to `Kubectl-Command`.
-- [ ] All other issues raised during alpha use of feature are resolved.
-- [ ] Completion of the test plan
+- Initial implementation behind `KUBECTL_COMMAND_HEADERS` environment variable.
+
+#### Beta
+
+- Change feature gate from default **off** to default **on**
+- Documentation in kubectl section of [kubernetes.io] describes the extra headers sent and how to disable these headers if necessary.
+- kubectl headers remove the `X-` prefix to align with [IETF guidance](https://datatracker.ietf.org/doc/html/rfc6648). Example: `X-Kubectl-Command` header is changed to `Kubectl-Command`.
+- All other issues raised during alpha use of feature are resolved.
+- Completion of the test plan
+
+#### GA
+
+- Address feedback.
 
 ### Upgrade / Downgrade Strategy
 
 Not applicable. There are no cluster components affected by this feature.
-
 
 ### Version Skew Strategy
 
@@ -283,168 +247,159 @@ can be no version skew.
 
 ### Feature Enablement and Rollback
 
-* **How can this feature be enabled / disabled in a live cluster?**
+###### How can this feature be enabled / disabled in a live cluster?
 
-  This feature is enabled by default in kubectl, and it can be turned
-  off by setting the KUBECTL_COMMAND_HEADERS environment variable
-  to false.
+- [ ] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name:
+  - Components depending on the feature gate:
 
-  - [X] Feature gate (also fill in values in `kep.yaml`)
-    - Feature gate name: KUBECTL_COMMAND_HEADERS
-    - Components depending on the feature gate: kubectl
+- [X] Other
+  - Describe the mechanism:  The environment variable `KUBECTL_COMMAND_HEADERS=true`.
+  - Will enabling / disabling the feature require downtime of the control
+    plane?
+  - Will enabling / disabling the feature require downtime of the control
+    plane? No.
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node? No.
 
-  - [X] Other
-    - Describe the mechanism: To disable the default addition of the kubectl
-    extra headers, set the environment variable KUBECTL_COMMAND_HEADERS to false.
-    - Will enabling / disabling the feature require downtime of the control
-      plane?
-    No. This environment variable only affects the kubectl client.
-    - Will enabling / disabling the feature require downtime or reprovisioning
-      of a node? (Do not assume `Dynamic Kubelet Config` feature is enabled).
-    No. This environment variable only affects the kubectl client.
+###### Does enabling the feature change any default behavior?
 
-* **Does enabling the feature change any default behavior?**
+No. This feature is not user facing, so it does not change behavior.
 
-  No. This feature is not user facing, so it does not change behavior.
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-* **Can the feature be disabled once it has been enabled (i.e. can we roll back
-  the enablement)?**
+Yes. This feature can be disabled by simply setting the `KUBECTL_COMMAND_HEADERS`
+environment variable to false on the command line.
 
-  Yes. This feature can be disabled by simply setting the KUBECTL_COMMAND_HEADERS
-  environment variable to false on the command line.
+###### What happens if we reenable the feature if it was previously rolled back?
 
-* **What happens if we reenable the feature if it was previously rolled back?**
+Re-enabling this feature is simply accomplished by removing the feature
+environment variable on the client command line. There is no state, and there
+is no consequence for re-enabling the feature.
 
-  Re-enabling this feature is simply accomplished by removing the feature
-  environment variable on the client command line. There is no state, and there
-  is no consequence for re-enabling the feature.
+###### Are there any tests for feature enablement/disablement?
 
-* **Are there any tests for feature enablement/disablement?**
-
-  There will be unit tests and integration tests which test this
-  feature enablement and disablement by setting the environment
-  variable.
+Yes, there is a [unit test](https://github.com/kubernetes/kubernetes/blob/2e2c63ef731ff1526321b4f81508734d68df2872/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go#L364-L405),
+exercising the `KUBECTL_COMMAND_HEADERS` environment variable.
 
 ### Rollout, Upgrade and Rollback Planning
 
-* **How can a rollout fail? Can it impact already running workloads?**
+###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-  A danger in the rollout of this feature is adding too much data (too many
-  headers) to each of the API Server calls. We intend to mitigate this risk
-  by defining a MAX_HEADERS concept to ensure the headers to not grow above a
-  certain size. MAX_HEADERS will provide a mechanism to ensure the headers data
-  does not grow without bound. As far as cluster workloads, this feature only
-  affects kubectl; not any cluster components. So it would not be possible to
-  impact running workloads.
+A danger in the rollout of this feature is adding too much data (too many
+headers) to each of the API Server calls. We intend to mitigate this risk
+by defining a MAX_HEADERS concept to ensure the headers to not grow above a
+certain size. MAX_HEADERS will provide a mechanism to ensure the headers data
+does not grow without bound. As far as cluster workloads, this feature only
+affects kubectl; not any cluster components. So it would not be possible to
+impact running workloads.
 
-* **What specific metrics should inform a rollback?**
+###### What specific metrics should inform a rollback?
 
-  We will measure the **headers-added-round-trip-time** and compare it to the round-trip
-  time for the same API Server call without headers. This ratio will give us the
-  performance penalty for adding these headers. If this performance penalty exceedes
-  a specific threshold, users can opt-out by removing the client-side command line
-  feature environment variable to disable the headers.
+We will measure the **headers-added-round-trip-time** and compare it to the round-trip
+time for the same API Server call without headers. This ratio will give us the
+performance penalty for adding these headers. If this performance penalty exceeds
+a specific threshold, users can opt-out by removing the client-side command line
+feature environment variable to disable the headers.
 
-* **Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?**
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
-  Enabling and disabling the client-side command line environment variable will
-  be tested.
+This feature is completely within the client. The upgrades and rollback of cluster will not be affected by this change.
 
-* **Is the rollout accompanied by any deprecations and/or removals of features, APIs,
-fields of API types, flags, etc.?**
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
-  No
+No.
 
 ### Monitoring Requirements
 
-* **How can an operator determine if the feature is in use by workloads?**
-  Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
-  checking if there are objects with field X set) may be a last resort. Avoid
-  logs or events for this purpose.
+###### How can an operator determine if the feature is in use by workloads?
 
-  N/A.
+Not applicable.
 
-* **What are the SLIs (Service Level Indicators) an operator can use to determine
-the health of the service?**
+###### How can someone using this feature know that it is working for their instance?
 
-  The risk of network performance degradation because of increased REST call
-  size is minimal, since the additional header size is modest, and it is
-  capped at MAX_HEADERS size. Determination of this network performance degradation
-  would be increased network latency, while testing using a control of kubectl
-  version 1.21 or previous to compare against.
+- [ ] Events
+  - Event Reason:
+- [ ] API .status
+  - Condition name:
+  - Other field:
+- [x] Other (treat as last resort)
+  - Details: One can verify headers being sent to the cluster on the wire.
 
-  - [ ] Metrics
-    - Metric name:
-    - [Optional] Aggregation method:
-    - Components exposing the metric:
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
-  - [ ] Other (treat as last resort)
-    - Details:
+Not applicable.
 
-* **What are the reasonable SLOs (Service Level Objectives) for the above SLIs?**
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
-  TBD. In order to mitigate risk of inordinately increasing the size of the REST
-  call, we use MAX_HEADERS to limit the size of the additional headers. The maximum
-  size of the current two headers (largest kubectl command) is approximately 72
-  bytes (including the header keys). This modest addition to the size of the REST
-  calls should translate to a minor performance degradation risk.
+Not applicable.
 
-* **Are there any missing metrics that would be useful to have to improve observability
-of this feature?**
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-  We believe all the other specified **Kubectl** headers will be useful, but we are starting
-  out simply with two headers in beta to prove the value and feasibility of the feature. We
-  will add others as we approach GA.
+Not applicable.
 
 ### Dependencies
 
-* **Does this feature depend on any specific services running in the cluster?**
-  Think about both cluster-level services (e.g. metrics-server) as well
-  as node-level agents (e.g. specific version of CRI). Focus on external or
-  optional services that are needed. For example, if this feature depends on
-  a cloud provider API, or upon an external software-defined storage or network
-  control plane.
+###### Does this feature depend on any specific services running in the cluster?
 
-  No
+No.
 
 ### Scalability
 
-* **Will enabling / using this feature result in any new API calls?**
+###### Will enabling / using this feature result in any new API calls?
 
-  No
+No.
 
-* **Will enabling / using this feature result in introducing new API types?**
+###### Will enabling / using this feature result in introducing new API types?
 
-  No
+No.
 
-* **Will enabling / using this feature result in any new calls to the cloud
-provider?**
+###### Will enabling / using this feature result in any new calls to the cloud provider?
 
-  No
+No.
 
-* **Will enabling / using this feature result in increasing size or count of
-the existing API objects?**
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
 
-  No
+Negligible. This feature increases the size of the REST call from kubectl
+to the API Server by adding more headers to the calls. Constraining the
+size of the added headers through MAX_HEADERS will reduce the risk of
+any performance degradation. We will monitor this request size increase
+to ensure there is no deleterious effect.
 
-* **Will enabling / using this feature result in increasing time taken by any
-operations covered by [existing SLIs/SLOs]?**
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
 
-  Possibly. This feature increases the size of the REST call from kubectl
-  to the API Server by adding more headers to the calls. Constraining the
-  size of the added headers through MAX_HEADERS will reduce the risk of
-  any performance degradation. We will monitor this request size increase
-  to ensure there is no deleterious effect.
+Negligible. This feature increases the size of the REST call from kubectl
+to the API Server by adding more headers to the calls. Constraining the
+size of the added headers through MAX_HEADERS will reduce the risk of
+any performance degradation. We will monitor this request size increase
+to ensure there is no deleterious effect.
 
-* **Will enabling / using this feature result in non-negligible increase of
-resource usage (CPU, RAM, disk, IO, ...) in any components?**
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
 
-  Possibly. This feature increases the size of the REST call from kubectl
-  to the API Server by adding more headers to the calls. Constraining the
-  size of the added headers through MAX_HEADERS will reduce the risk of
-  any performance degradation. We will monitor this request size increase
-  to ensure there is no deleterious effect.
+No.
+
+### Troubleshooting
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+`kubectl` is not resilient to API server unavailability.
+
+###### What are other known failure modes?
+
+Not applicable.
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+Not applicable.
 
 ## Implementation History
 
-[(Alpha) Kubectl command headers in requests: KEP 859](https://github.com/kubernetes/kubernetes/pull/98952)
+2019-02-22: Initial version of this document.
+2021-02-10: [(Alpha) Kubectl command headers in requests: KEP 859](https://github.com/kubernetes/kubernetes/pull/98952).
+2021-05-13: Beta promotion of this KEP.
+2021-06-27: [kubectl command headers as default in beta](https://github.com/kubernetes/kubernetes/pull/103238).
+2025-10-08: Stable promotion.
+
+## Alternatives
+
+Alternatives would be to use a wrapper around `kubectl` to inject additional headers.

--- a/keps/sig-cli/859-kubectl-headers/kep.yaml
+++ b/keps/sig-cli/859-kubectl-headers/kep.yaml
@@ -3,33 +3,44 @@ kep-number: 859
 authors:
   - "@pwittrock"
   - "@seans3"
+  - "@soltysh"
 owning-sig: sig-cli
 participating-sigs:
   - sig-api-machinery
+status: implementable
+creation-date: 2019-02-22
 reviewers:
   - "@deads2k"
   - "@kow3ns"
   - "@lavalamp"
 approvers:
   - "@soltysh"
-editor: TBD
-creation-date: 2019-02-22
-last-updated: 2019-05-11
-status: implementable
-see-also:
-replaces:
-superseded-by:
-stage: beta
-latest-milestone: "v1.22"
+  - "@ardaguclu"
+
+see-also: []
+replaces: []
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: stable
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.35"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha:  "v1.21"
   beta:   "v1.22"
-  stable: "v1.24"
-# kubectl-commands-in-headers is on by default, but it can be
-# disabled by setting the feature gate (environment variable)
-# to false.
+  stable: "v1.35"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: kubectl-commands-in-headers
+  - name: KUBECTL_COMMAND_HEADERS
     components:
       - kubectl
 disable-supported: true
+
+# The following PRR answers are required at beta release
+metrics: []


### PR DESCRIPTION
- One-line PR description: promote command headers to stable

- Issue link: https://github.com/kubernetes/enhancements/issues/859

/assign @ardaguclu
for sig-cli review

/assign @deads2k 
for PRR review

/hold
so it doesn't merge accidentally before I get both of the above reviews in