### PR TITLE
promote kep-3673 to GA

### DIFF
--- a/keps/prod-readiness/sig-node/3673.yaml
+++ b/keps/prod-readiness/sig-node/3673.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@wojtek-t"
 beta:
   approver: "@wojtek-t"
+stable:
+  approver: "@wojtek-t"

--- a/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
+++ b/keps/sig-node/3673-kubelet-parallel-image-pull-limit/kep.yaml
@@ -6,22 +6,22 @@ authors:
 owning-sig: sig-node
 status: implementable
 creation-date: 2023-01-05
-last-updated: 2024-10-31
+last-updated: 2025-10-09
 reviewers:
   - "@SergeyKanzhelev"
 approvers:
   - "@mrunalp"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.32"
+latest-milestone: "v1.35"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.27"
   beta: "v1.32"
-  stable: "v1.34"
+  stable: "v1.35"


### PR DESCRIPTION
- One-line PR description: kep 3673 GA

- Issue link: https://github.com/kubernetes/enhancements/issues/3673

- Other comments: for GA, we  change default behavior to  `serializeImagePulls: false` and `maxParallelImagePulls: 2`.