### PR TITLE
KEP-5339: define extensions-based per-cluster plugin configuration

### DIFF
--- a/keps/sig-multicluster/5339-clusterprofile-plugin-credentials/README.md
+++ b/keps/sig-multicluster/5339-clusterprofile-plugin-credentials/README.md
@@ -296,10 +296,10 @@ In this structure, not all fields would apply, such as:
 
 Some credential providers require cluster-specific, non-secret parameters (for example, a `clusterName`) in order to obtain credentials. To standardize how this information is conveyed from a `ClusterProfile` to a plugin, the library follows the existing convention defined by the client authentication API:
 
-- Optional: when a plugin needs per-cluster, non-secret config, set an extension entry with `name: client.authentication.k8s.io/exec` under `Cluster.extensions`.
-- The library reads only the `extension` field of that entry and passes it through verbatim to `ExecCredential.Spec.Cluster.Config`.
-- The content must be non-secret and cluster-specific. Controller- or environment-specific data must not be placed here.
-- Plugins may read values (e.g. `clusterName`) from `ExecCredential.Spec.Cluster.Config`.
+> Optional: when a plugin needs per-cluster, non-secret config, set an extension entry with `name: client.authentication.k8s.io/exec` under `Cluster.extensions`.
+> The library reads only the `extension` field of that entry and passes it through verbatim to `ExecCredential.Spec.Cluster.Config`.
+> The content must be non-secret and cluster-specific. Controller- or environment-specific data must not be placed here.
+> Plugins may read values (e.g. `clusterName`) from `ExecCredential.Spec.Cluster.Config`.
 
 Reference: [client.authentication.k8s.io/v1 Cluster: `config` sourced from `extensions[client.authentication.k8s.io/exec]`](https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#client-authentication-k8s-io-v1beta1-Cluster)
 


### PR DESCRIPTION
- One-line PR description:
  Define extensions-based per-cluster plugin configuration and pass-through to ExecCredential.Spec.Cluster.Config

- Issue link:
  kubernetes/enhancements#5339

- Other comments:
  - Add a "Passing plugin configuration via extensions" section under Design Details
  - Clarify that the extensions entry is optional, non-secret, and per-cluster; controller- or environment-specific data must not be placed there
  - Specify library behavior to pass the `extension` object through to `ExecCredential.Spec.Cluster.Config` when present
  - Add a SecretReader ClusterProfile example that provides `clusterName` via extensions
  - Reference for the configuration source:
    - client authentication API (v1) Cluster: `config` sourced from `extensions[client.authentication.k8s.io/exec]`:
      https://kubernetes.io/docs/reference/config-api/client-authentication.v1/#client-authentication-k8s-io-v1-Cluster
  - Background: the core implementation landed first and this change formalizes the behavior in the KEP:
    https://github.com/kubernetes-sigs/cluster-inventory-api/pull/21/files#diff-9079632b67f704fe47373dc3fc1cf49db8b421592a06ffb89d74d436a65faf2c