### PR TITLE
KEP-3926: keep in alpha for v1.35

### DIFF
--- a/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
+++ b/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
@@ -4,7 +4,6 @@ authors:
   - "@stlaz"
 owning-sig: sig-auth
 participating-sigs:
-  - sig-auth
   - sig-api-machinery
 status: implementable
 creation-date: 2023-03-27
@@ -13,11 +12,6 @@ reviewers:
   - "@deads2k"
 approvers:
   - "@deads2k"
-
-see-also:
-  -
-replaces:
-  - 
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha
@@ -30,7 +24,7 @@ latest-milestone: "v1.35"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
-  beta: "v1.35"
+  beta: ""
   stable: ""
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
- One-line PR description: KEP-3926: keep in alpha for v1.35 (to allow us to iterate on the beta requirements)
- Issue link: #3926