### PR TITLE
KEP-5055: DRA device taints: document state in 1.35 and plan beta in 1.36

### DIFF
--- a/keps/prod-readiness/sig-scheduling/5055.yaml
+++ b/keps/prod-readiness/sig-scheduling/5055.yaml
@@ -4,3 +4,5 @@
 kep-number: 5055
 alpha:
   approver: "@soltysh"
+beta:
+  approver: "@soltysh"

--- a/keps/sig-scheduling/5055-dra-device-taints-and-tolerations/kep.yaml
+++ b/keps/sig-scheduling/5055-dra-device-taints-and-tolerations/kep.yaml
@@ -21,11 +21,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.33"
+  beta: "v1.36"
+  stable: "v1.37"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -35,7 +37,15 @@ feature-gates:
       - kube-apiserver
       - kube-scheduler
       - kube-controller-manager
+  - name: DRADeviceTaintRules
+    components:
+      - kube-apiserver
+      - kube-scheduler
+      - kube-controller-manager
 disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
+  - device_taint_eviction_controller_pod_deletions_total
+  - device_taint_eviction_controller_pod_deletion_duration_seconds
+  - workqueue_* with name="device-taint-eviction-controller" in kube-controller-manager


### PR DESCRIPTION

- One-line PR description: DRA device taints: document state in 1.35 and plan beta in 1.36

- Issue link: #5055 

- Other comments:

The actual implementation in 1.35 was a bit different than planned. This gets reflected here, plus the changes for beta.