### PR TITLE
[KEP-4671]: fix api version issue and update api with implementation

### DIFF
--- a/keps/sig-scheduling/4671-gang-scheduling/README.md
+++ b/keps/sig-scheduling/4671-gang-scheduling/README.md
@@ -134,7 +134,7 @@ apiVersion: v1
 kind: Pod
 spec:
   ...
-  workload:
+  workloadRef:
     name: job-1
   ...
 ```
@@ -151,8 +151,9 @@ spec:
   completionMode: Indexed
   template:
     spec:
-      workload:
+      workloadRef:
         name: job-1
+        podGroup: pg1
       restartPolicy: OnFailure
       containers:
       - name: ml-worker
@@ -173,7 +174,7 @@ The `Workload` core resource will be introduced. A `Workload` does not create an
 
  It does not affect pod creation by Job or any other controller.  A sample resource looks like this:
 ```yaml
-apiVersion: scheduling/v1alpha1   
+apiVersion: scheduling.k8s.io/v1alpha1
 kind: Workload
 metadata:
   namespace: ns-1
@@ -222,7 +223,7 @@ usecases. You can read more about it in the [extended proposal] document.
 ### Naming
 
 * `Workload` is the resource Kind.
-* `scheduling` is the ApiGroup.
+* `scheduling.k8s.io` is the ApiGroup.
 * `spec.workload` is the name of the new field in pod.
 * Within a Workload there is a list of groups of pods. Each group represents a top-level division of pods within a Workload.  Each group can be independently gang scheduled (or not use gang scheduling). This group is named `PodGroup`.
 * In a future , we expect that this group can optionally specify further subdivision into sub groups.  Each sub-group can have an index.  The indexes go from 0 to N, without repeats or gaps. These subgroups are called `PodSubGroup`.
@@ -265,7 +266,7 @@ treat it as a blocker.
 The example below shows how this could look like for with the following `Workload` object:
 
 ```yaml
-apiVersion: scheduling/v1alpha1   
+apiVersion: scheduling.k8s.io/v1alpha1
 kind: Workload
 metadata:
   name: jobset
@@ -285,10 +286,10 @@ metadata:
   name: jobset-job-1-abc123
 spec:
   ...
-  workload:
+  workloadRef:
     name: jobset
     podGroup: job-1
-    podGroupReplicaIndex: 2
+    podGroupReplicaKey: key-2
   ...
 
 ```


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Fix typos in KEP and update with latest api

<!-- link to the k/enhancements issue -->
- Issue link: #4671 

<!-- other comments or additional information -->
- Other comments:

I was testing this feature for 1.35. I wanted to learn more about it.

I had to tweak the examples a bit to get this to work.

```yaml
apiVersion: scheduling.k8s.io/v1alpha1   
kind: Workload
metadata:
  namespace: default
  name: job-1
spec:
  podGroups:
    - name: "pg1"
      policy:
        gang:
          minCount: 50
```
An example job:
```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: sleep-job
spec:
  parallelism: 200
  completions: 200
  template:
    spec:
      workloadRef:
        name: job-1
        podGroup: pg1
      containers:
      - name: sleep-container
        image: busybox:latest
        command: ["sleep", "10000"]
        resources:
          requests:
            cpu: 100m
            memory: 100Mi
          limits:
            cpu: 100m
            memory: 100Mi
      restartPolicy: Never
  backoffLimit: 4
````