### PR TITLE
KEP 1645: promote to beta and add more GA graduation criteria

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -359,13 +359,11 @@ Go in to as much detail as necessary here.
 This might be a good place to talk about core concepts and how they relate.
 -->
 
-This proposal intends to rely on the K8s [Service Topology API] for topology
-aware routing, but that API is currently in flux. As a result this proposal is
-only suited to same-region multi-cluster services until the topology API
-progresses.
-
-[Service Topology API]:
-    https://kubernetes.io/docs/concepts/services-networking/service-topology/
+While standard Services traffic policies and traffic distribution have been
+integrated and work across clusters (for instance PreferSameZone across clusters
+sharing the same zone), we do not yet have multi-cluster specific traffic
+distribution control. This is planned to be addressed in its own KEP that will
+complement this specification.
 
 ### Risks and Mitigations
 
@@ -1126,6 +1124,8 @@ when drafting this test plan.
 - Scalability/performance testing, understanding impact on cluster-local service
   scalability.
 - [Cluster ID KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid) is GA, with at least one other multi-cluster use case.
+- A conformance report program for MCS-API has been created to document the
+  conformance level of the various implementations.
 
 <!--
 **Note:** *Not required until targeted at a release.*

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/kep.yaml
@@ -18,4 +18,4 @@ approvers:
   - "@thockin"
 
 latest-milestone: "0.0"
-stage: "alpha"
+stage: "beta"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP 1645: promote to beta and add more GA graduation criteria

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1645

<!-- other comments or additional information -->
- Other comments:
Proposing to promote MCS-API to beta :tada:
Also add a GA criteria about  having a conformance report program