### PR TITLE
KEP-1441: Fix the version of changing default profile

### DIFF
--- a/keps/sig-cli/1441-kubectl-debug/README.md
+++ b/keps/sig-cli/1441-kubectl-debug/README.md
@@ -415,7 +415,7 @@ Probes and labels are be stripped from Pod copies.
 In order to maintain backwards compatibility the `legacy` profile will be the default profile until 1.35.
 When `--profile` is not specified `kubectl debug` will print a warning about the upcoming change in behavior.
 
-Including 1.35 and upwards, `general` will be the default profile. `legacy` profile will entirely be removed in 1.38.
+From 1.36, `general` will be the default profile. `legacy` profile will entirely be removed in 1.39.
 
 #### Future Improvements
 


### PR DESCRIPTION
- One-line PR description: The plan was delayed one release so fix this KEP.
- Issue link: https://github.com/kubernetes/enhancements/issues/1441
- Other comments: I've submitted https://github.com/kubernetes/kubernetes/pull/135874 as code PR. Currently our shortest path is as follow(discussed here https://github.com/kubernetes/kubectl/issues/1780#issuecomment-3258489337):
  - Make general profile default: v1.36
  - Remove legacy profile: v1.39