### PR TITLE
KEP-5278: Specify to keep NNN in case of error during binding cycle

### DIFF
--- a/keps/sig-scheduling/5278-nominated-node-name-for-expectation/README.md
+++ b/keps/sig-scheduling/5278-nominated-node-name-for-expectation/README.md
@@ -390,6 +390,7 @@ We'll ensure this scenario works correctly via tests.
 
 As of now the scheduler clears the `NominatedNodeName` field at the end of failed scheduling cycle, if it
 found the nominated node unschedulable for the pod. This logic remains unchanged.
+If an error occurs during the binding cycle, `NominatedNodeName` will not be cleared.
 
 NOTE: The previous version of this KEP, that allowed external components to set `NominatedNodeName`, deliberately left the `NominatedNodeName` field unchanged after scheduling failure. With the KEP update for v1.35 this logic is being reverted, and scheduler goes back to clearing the field after scheduling failure.
  


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Specifying behavior for NNN on binding cycle error

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5278

<!-- other comments or additional information -->
- Other comments:

Right now the implementation intends to clear NNN on binding error: https://github.com/kubernetes/kubernetes/blob/21f7c3ff68b388b565331724d5a46920854431a8/pkg/scheduler/schedule_one.go#L392.

There are two problems with this:
1. There's a bug that causes it to only clear on the 2nd binding failure in a row
2. In case PreBind succeeded, the pod may be "locked into" a node, and clearing NNN may let another pod take its place, e.g. due to dynamically provisioned PV ([#135771](https://github.com/kubernetes/kubernetes/issues/135771)). Side note: even with NNN, a higher priority pod may take its place, so it's not completely robust

The KEP is a bit unclear on the intended behavior in this case. It mentions

> scheduler clears the NominatedNodeName field at the end of failed scheduling cycle if it found the nominated node unschedulable for the pod

There's a comment in code that suggests that a pod that fails to bind isn't considered unschedulable: https://github.com/kubernetes/kubernetes/blob/21f7c3ff68b388b565331724d5a46920854431a8/pkg/scheduler/schedule_one.go#L318. I weren't able to find any docs that would mention it though.

I suggest to not clear NNN if there was an error during binding cycle and update the KEP wording to make it apparent. This is based on the assumption that binding cycle failure is either
* transient or
* consistent for all pods or
* a bug in the scheduler code or one of the plugins

Even without NNN the scheduler may keep picking the same node. The main change is that the pod will continue to take space from other lower priority pods, which shouldn't matter if the assumption above holds.