### PR TITLE
KEP-5526: Pod Level Resource Managers 1.36

### DIFF
--- a/keps/sig-node/5526-pod-level-resource-managers/kep.yaml
+++ b/keps/sig-node/5526-pod-level-resource-managers/kep.yaml
@@ -27,13 +27,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.35"
-  beta: "v1.36"
-  stable: "v1.38"
+  alpha: "v1.36"
+  beta: "v1.37"
+  stable: "v1.39"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
This KEP change does not modify the original proposed behavior, only adds some specifics that surfaced during the implementation of the feature.

The most significant additions are a new property to the CPU and Memory managers state to keep track of the pod level exclusive resource allocation (requires PRR review perspective) and the introduction of a new term `ResourceIsolationLevel` that describes if the container resources belong to the container, the pod or the node (currently only used by the CPU manager to handle CPU quota enablement/disablement).

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Pod Level Resource Managers update to mainly add implementation specifics

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5526

<!-- other comments or additional information -->
- Other comments:
   - https://github.com/kubernetes/kubernetes/pull/134768
   - https://github.com/kubernetes/enhancements/pull/5527