### PR TITLE
KEP-5778: Introduce explicit node ownership

### DIFF
--- a/keps/sig-cloud-provider/5778-hybrid-cloud/README.md
+++ b/keps/sig-cloud-provider/5778-hybrid-cloud/README.md
@@ -1,0 +1,913 @@
+<!--
+**Note:** When your KEP is complete, all of these comment blocks should be removed.
+
+Follow the guidelines of the [documentation style guide].
+In particular, wrap lines to a reasonable length, to make it
+easier for reviewers to cite specific portions, and to minimize diff churn on
+updates.
+
+[documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
+
+To get started with this template:
+
+- [ ] **Pick a hosting SIG.**
+  Make sure that the problem space is something the SIG is interested in taking
+  up. KEPs should not be checked in without a sponsoring SIG.
+- [ ] **Create an issue in kubernetes/enhancements**
+  When filing an enhancement tracking issue, please make sure to complete all
+  fields in that template. One of the fields asks for a link to the KEP. You
+  can leave that blank until this KEP is filed, and then go back to the
+  enhancement and add the link.
+- [x] **Make a copy of this template directory.**
+  Copy this template into the owning SIG's directory and name it
+  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
+  leading-zero padding) assigned to your enhancement above.
+- [ ] **Fill out as much of the kep.yaml file as you can.**
+  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
+  "Status", and date-related fields.
+- [ ] **Fill out this file as best you can.**
+  At minimum, you should fill in the "Summary" and "Motivation" sections.
+  These should be easy if you've preflighted the idea of the KEP with the
+  appropriate SIG(s).
+- [ ] **Create a PR for this KEP.**
+  Assign it to people in the SIG who are sponsoring this process.
+- [ ] **Merge early and iterate.**
+  Avoid getting hung up on specific details and instead aim to get the goals of
+  the KEP clarified and merged quickly. The best way to do this is to just
+  start with the high-level sections and fill out details incrementally in
+  subsequent PRs.
+
+Just because a KEP is merged does not mean it is complete or approved. Any KEP
+marked as `provisional` is a working document and subject to change. You can
+denote sections that are under active debate as follows:
+
+```
+<<[UNRESOLVED optional short context or usernames ]>>
+Stuff that is being argued.
+<<[/UNRESOLVED]>>
+```
+
+When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
+focused. If you disagree with what is already in a document, open a new PR
+with suggested changes.
+
+One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
+You do not need a new KEP to move from beta to GA, for example. If
+new details emerge that belong in the KEP, edit the KEP. Once a feature has become
+"implemented", major changes should get new KEPs.
+
+The canonical place for the latest set of instructions (and the likely source
+of this file) is [here](/keps/NNNN-kep-template/README.md).
+
+**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
+it is marked `implementable`, must be approved by each of the KEP approvers.
+If none of those approvers are still appropriate, then changes to that list
+should be approved by the remaining approvers and/or the owning SIG (or
+SIG Architecture for cross-cutting KEPs).
+-->
+# KEP-5778: Introduce explicit node ownership to allow multiple CCMs in a single Kubernetes cluster
+
+To have different nodes from different environments in one cluster (hybrid cloud installation) we need to support node ownership in the Cloud Controller Manager (CCM) framework.
+
+<!--
+This is the title of your KEP. Keep it short, simple, and descriptive. A good
+title can help communicate what the KEP is and should be considered as part of
+any review.
+-->
+
+<!--
+A table of contents is helpful for quickly jumping to sections of a KEP and for
+highlighting any additional information provided beyond the standard KEP
+template.
+
+Ensure the TOC is wrapped with
+  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
+tags, and then generate with `hack/update-toc.sh`.
+-->
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories)
+    - [Story 1 (Optional)](#story-1)
+    - [Story 2 (Optional)](#story-2)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge code into a release, there must be an
+issue in [kubernetes/enhancements] referencing this KEP and targeting a release
+milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
+of the targeted release**.
+
+For enhancements that make changes to code or processes/procedures in core
+Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
+Signoff checklist to be completed.
+
+Check these off as they are completed for the Release Team to track. These
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+This KEP proposes a standardized mechanism that allows Kubernetes clusters to safely run nodes from multiple cloud providers and/or on-premises environments in a single cluster by enabling multiple Cloud Controller Managers (CCMs) to coexist and by making node ownership explicit and enforceable.
+
+Each CCM will manage only the nodes that belong to its own cloud, preventing destructive cross-cloud actions and enabling true hybrid-cloud Kubernetes clusters.
+
+## Motivation
+
+Today, Kubernetes Cloud Controller Manager (CCM) assumes that all nodes in a cluster belong to a single cloud provider.
+In practice, many users run hybrid clusters that include nodes from multiple clouds and/or on-premises (self-managed) environments.
+
+Common production patterns include:
+* A managed control plane in a public cloud with worker nodes on bare-metal
+* Adding GPU or FPGA nodes from a different provider
+* Combining cheap on-prem or colo capacity with elastic public cloud compute
+
+### Goals
+
+* Allow nodes from multiple clouds and/or on-premises environments to join the same Kubernetes cluster.
+* Allow multiple CCMs to coexist in one cluster.
+* Ensure that each CCM only manages the nodes that belong to its own cloud.
+* Prevent a CCM from performing destructive lifecycle operations (deleting node resources or updating routes) on nodes that belong to a different cloud or are self-managed (unmanaged nodes).
+
+### Non-Goals
+
+* CCM is not responsible for configuring networking between different clouds or between cloud and on-premises environments. Cluster bootstrap tooling must ensure networking is configured correctly.
+* Supporting Service and Route controllers in hybrid environments is not a goal of this KEP. Depending on the cloud setup, CCM may be unable to manage load balancers and routes across clouds, or doing so may add significant complexity. Service and Route controllers may need to be disabled. Support for these components can be added in the future.
+* Defining how and where CCMs are deployed (in one cloud or in separate clouds) is not a goal of this KEP, though we may provide deployment recommendations in documentation.
+
+## Proposal
+
+Today, some Kubernetes distributions already provide implementations that support hybrid cloud clusters. They do this by running their own CCM with logic to identify which nodes belong to which cloud. Some CCM implementations also use additional annotations or labels to mark nodes as unmanaged.
+
+* Azure [IsNodeUnmanagedByProviderID](https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d14fab905102983621c8a30f5a675ad05ae37cf6/pkg/provider/azure_wrap.go#L71) handles ProviderID to identify unmanaged nodes.
+* [TalosCCM](https://github.com/siderolabs/talos-cloud-controller-manager) supports hybrid installations
+* [HetznerCCM](https://github.com/hetznercloud/hcloud-cloud-controller-manager) has different ProviderID prefixes to identify nodes (cloud and bare-metal).
+
+To make node management standard and predictable, we need to move node ownership and responsibility into the Cloud Provider framework so that it becomes explicit and consistent.
+Each Cloud Controller Manager must be able to clearly determine which nodes it is responsible for managing.
+
+### User Stories
+
+#### Story 1
+
+Cloud control plane + on-prem / third-party nodes:
+
+I want to:
+* use a managed control plane from cloud provider X
+* add nodes from my home lab or a third-party bare-metal provider
+* run specialized hardware (GPU, FPGA, TPU, etc.)
+
+And I expect:
+* CCM must not delete my self-managed nodes
+* CCM must not try to manage load balancers or routes for self-managed nodes
+* Workloads running on self-managed nodes (without CCM management) that become unreachable or are removed should be handled by other components. A CCM from another cloud provider must not add labels or taints to those nodes.
+
+#### Story 2
+
+Two cloud providers in one cluster:
+
+I want to:
+
+* use a managed control plane from cloud provider X
+* add worker nodes from cloud provider Y
+* run two CCMs: one for X and one for Y
+
+And I expect:
+* CCM X manages only nodes from cloud X
+* CCM Y manages only nodes from cloud Y
+* CCM X must ignore nodes from Y
+* CCMs must:
+  * label nodes with cloud-specific metadata
+  * delete node resources when a node is removed from the specific cloud
+
+I understand that:
+* cross-cloud traffic may be expensive
+* cross-cloud networking is my responsibility and may require additional configuration or Kubernetes add-ons
+* cross-cloud load balancing may not serve traffic to nodes in other clouds, and should be used carefully.
+
+Kubernetes administrators should use `Service.spec.trafficDistribution` or similar mechanisms to ensure traffic stays within the same cloud where required.
+
+## Design Details
+
+Changes required to implement the proposal:
+* add a new method to the Cloud Provider interface to return supported platform identifiers (e.g., "aws", "gcp", "azure", "on-prem").
+* add a new command-line flag to the CCM to override the supported platform identifiers, allowing administrators to define which platforms are supported in a specific CCM deployment (even when the cloud provider does not officially support hybrid installation).
+* add a new command-line flag to the CCM to set a timeout while waiting for node initialization by the Node controller before the NodeLifecycle controller starts, to avoid deleting nodes that are not yet initialized by another CCM and do not have ownership information.
+* define the node label used to identify the platform on the Node object. This helps users target workloads to specific platforms: `topology.kubernetes.io/platform`, as proposed in https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/837-cloud-provider-labels/README.md.
+
+Introduce a new interface method in the Cloud Provider framework:
+
+```go
+type Interface interface {
+  // ProviderPlatforms returns a list of platform identifiers
+  // that the cloud provider supports.
+  // A platform identifier is a string that uniquely identifies
+  // a cloud provider or on-premises environment.
+  // This identifier is the prefix of the ProviderID field in NodeSpec.
+  // Examples: "aws", "gcp", "azure", "on-prem"
+  ProviderPlatforms() []string
+}
+```
+
+The Cloud Controller will use this method to determine which nodes it is responsible for managing.
+This method can return an empty list for cloud providers that assume single-cloud clusters.
+In this case, the logic will fall back to the default behavior of managing all nodes in the cluster, which is the same as the current behavior.
+
+To override the platform list, introduce a new command-line flag to the CCM:
+
+```shell
+--cloud-provider-platforms=<platform1,platform2,...>
+```
+
+The administrator can use this flag to define or disable support for specific platforms in the Cloud Controller Manager without modifying the cloud provider code.
+It also allows the new CCM logic to be applied even when a cloud provider does not support or officially provide hybrid cloud installations.
+
+Controller logic:
+
+__Node controller__:
+* When processing a node, check if the node's ProviderID prefix matches any of the supported platforms.
+* If it matches, proceed with normal processing (initialization, labeling, tainting, etc.)
+* If it does not match, skip processing for that node.
+* If ProviderID is not set, use a default behavior:
+  * find the node in the cloud provider API
+  * if found, treat it as managed and proceed with normal processing
+  * if not found, return an error and do not change the node resource
+
+__NodeLifecycle controller__:
+* When processing a node, check if the node's ProviderID prefix matches any of the supported platforms.
+* If it matches, proceed with normal processing (InstanceExists/InstanceShutdown)
+* If it does not match, skip processing for that node.
+* If ProviderID is not set, check the node label `topology.kubernetes.io/platform`:
+  * if the label is set, use it as the platform identifier
+  * if the label is not set, use the default behavior
+
+Currently, the NodeLifecycle controller starts working even when the node has not yet been initialized by the Node controller.
+If a node does not have ProviderID, both NodeLifecycle and Node controllers execute similar logic to find the node in the cloud provider API.
+To avoid duplicate calls to the cloud provider API, we can add timeout logic so NodeLifecycle waits for Node controller initialization, and/or use the node label to identify the platform.
+
+__Route controller__:
+* Controller can manage routes only for nodes that belong to its own cloud.
+* When processing a node, check if the node's ProviderID prefix matches any of the supported platforms.
+* Subnets may have default routes for nodes that do not belong to this cloud. This is outside CCM control, and administrators must ensure routing is configured correctly in hybrid environments.
+* If the native routing is not required, the route controller can be disabled. Modern CNI plugins can manage routing without the need for the CCM route controller.
+
+__Service controller__:
+* Because the CCM load balancer only works when service.spec.loadBalancerClass is empty, only one CCM implementation can manage LoadBalancer Services in a cluster.
+
+* If a cloud provider supports multiple platforms or can route traffic to nodes in other clouds, the CCM can manage LoadBalancer Services for all supported platforms. Otherwise, the CCM should manage LoadBalancer Services only for nodes that belong to its own cloud.
+* Similar to Node and NodeLifecycle controllers, the Service controller should use `ProviderPlatforms()` to determine supported platforms.
+* We should explicitly state that CCM can run in a hybrid environment and that each cloud-provider implementation must add checks to prevent cross-cloud load balancer management.
+* If this cannot be guaranteed, users should disable the Service controller.
+
+Because hybrid environments are complex and may vary significantly, we should document that Service and Route controllers may need to be disabled. Cloud providers should also add hybrid-environment recommendations to their Service controller documentation.
+
+### Other components
+
+__Kubelet__:
+* Kubelet may use a cloud provider metadata service to obtain credentials for pulling images from the provider’s container registry.
+* Virtual machine images can be prepared per cloud provider and include built-in logic to access that provider’s metadata service.
+* In other environments, separate VM images should be used, each configured to access its own container registry.
+* After the node is registered in the cluster, Kubelet should rely on `ImagePullSecrets` to pull images for workloads, rather than directly using the metadata service.
+
+__CSI plugins__:
+* CSI plugins should use a `nodeSelector` to deploy the node plugin DaemonSet only on nodes that belong to their own cloud.
+
+__Node autoscaler__:
+* The node autoscaler should be updated to work only with its own ProviderID prefix. Currently, many implementations parse the ProviderID directly, which may fail when applying regular expressions to unexpected ProviderID formats.
+
+__Karpenter__:
+* Karpenter uses ownerReferences for `Node` and `NodeClaim` resources. In hybrid-environment setups, users should define separate `NodePool` classes for each environment.
+
+### Test Plan
+
+<!--
+**Note:** *Not required until targeted at a release.*
+The goal is to ensure that we don't accept enhancements with inadequate testing.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
+when drafting this test plan.
+
+[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+
+[x] I/we understand that owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+<!--
+Based on reviewers feedback describe what additional tests need to be added prior
+implementing this enhancement to ensure the enhancements have also solid foundations.
+-->
+
+##### Unit tests
+
+<!--
+In principle every added code should have complete unit test coverage, so providing
+the exact set of tests will not bring additional value.
+However, if complete unit test coverage is not possible, explain the reason of it
+together with explanation why this is acceptable.
+-->
+
+<!--
+Additionally, for Alpha try to enumerate the core package you will be touching
+to implement this enhancement and provide the current unit coverage for those
+in the form of:
+- <package>: <date> - <current test coverage>
+The data can be easily read from:
+https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
+
+This can inform certain test coverage improvements that we want to do before
+extending the production code to implement this enhancement.
+-->
+
+- `<package>`: `<date>` - `<test coverage>`
+
+##### Integration tests
+
+<!--
+Integration tests are contained in https://git.k8s.io/kubernetes/test/integration.
+Integration tests allow control of the configuration parameters used to start the binaries under test.
+This is different from e2e tests which do not allow configuration of parameters.
+Doing this allows testing non-default options and multiple different and potentially conflicting command line options.
+For more details, see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing-strategy.md
+
+If integration tests are not necessary or useful, explain why.
+-->
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, document that tests have been written,
+have been executed regularly, and have been stable.
+This can be done with:
+- permalinks to the GitHub source code
+- links to the periodic job (typically https://testgrid.k8s.io/sig-release-master-blocking#integration-master), filtered by the test name
+- a search in the Kubernetes bug triage tool (https://storage.googleapis.com/k8s-triage/index.html)
+-->
+
+- [test name](https://github.com/kubernetes/kubernetes/blob/2334b8469e1983c525c0c6382125710093a25883/test/integration/...): [integration master](https://testgrid.k8s.io/sig-release-master-blocking#integration-master?include-filter-by-regex=MyCoolFeature), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=MyCoolFeature)
+
+##### e2e tests
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, document that tests have been written,
+have been executed regularly, and have been stable.
+This can be done with:
+- permalinks to the GitHub source code
+- links to the periodic job (typically a job owned by the SIG responsible for the feature), filtered by the test name
+- a search in the Kubernetes bug triage tool (https://storage.googleapis.com/k8s-triage/index.html)
+
+We expect no non-infra related flakes in the last month as a GA graduation criteria.
+If e2e tests are not necessary or useful, explain why.
+-->
+
+- unmanaged node with providerID test:
+  * Create a cluster with nodes in one cloud
+  * Verify that CCM manages them correctly
+  * Add node with a different ProviderID prefix (different cloud or on-premises)
+  * Verify that CCM ignores the new node and does not perform any actions on it
+  * Reboot the node to trigger the node lifecycle controller
+  * Verify that CCM ignores the new node and does not perform any actions on it
+  * Remove the new node
+  * Verify that CCM does not delete the node resource
+
+- unmanaged node without providerID test:
+  * Create a cluster with nodes in one cloud
+  * Verify that CCM manages them correctly
+  * Add a node with an empty ProviderID (fully uninitialized node)
+  * Verify that CCM ignores the new node if it is not found in the cloud provider API and does not perform any actions on it
+  * Patch the node with a random ProviderID
+  * Verify that CCM ignores the node and does not perform any actions on it
+  * Reboot the node to trigger the node lifecycle controller
+  * Verify that CCM ignores the new node and does not perform any actions on it
+  * Remove the new node
+  * Verify that CCM does not delete the node resource
+
+- [test name](https://github.com/kubernetes/kubernetes/blob/2334b8469e1983c525c0c6382125710093a25883/test/e2e/...): [SIG ...](https://testgrid.k8s.io/sig-...?include-filter-by-regex=MyCoolFeature), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=MyCoolFeature)
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+
+#### Alpha
+
+- Feature implemented behind a feature flag
+- Initial e2e tests completed and enabled
+
+#### Beta
+
+- Gather feedback from developers and surveys
+- Complete features A, B, C
+- Additional tests are in Testgrid and linked in KEP
+- More rigorous forms of testing—e.g., downgrade tests and scalability tests
+- All functionality completed
+- All security enforcement completed
+- All monitoring requirements completed
+- All testing requirements completed
+- All known pre-release issues and gaps resolved
+
+**Note:** Beta criteria must include all functional, security, monitoring, and testing requirements along with resolving all issues and gaps identified
+
+#### GA
+
+- N examples of real-world usage
+- N installs
+- Allowing time for feedback
+- All issues and gaps identified as feedback during beta are resolved
+
+**Note:** GA criteria must not include any functional, security, monitoring, or testing requirements.  Those must be beta requirements.
+
+**Note:** Generally we also wait at least two releases between beta and
+GA/stable, because there's no opportunity for user feedback, or even bug reports,
+in back-to-back releases.
+
+**For non-optional features moving to GA, the graduation criteria must include
+[conformance tests].**
+
+[conformance tests]: https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md
+
+#### Deprecation
+
+<!--
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+
+### Upgrade / Downgrade Strategy
+
+Since all logic is based on the immutable ProviderID prefix,
+no special upgrade or downgrade strategy is required within a single environment.
+
+Keep in mind that during downgrade you need to choose only one CCM (the preferred cloud provider), remove other CCMs, and delete nodes from other clouds. The active CCM will then remove Node resources for those nodes.
+
+### Version Skew Strategy
+
+Not required, because this proposal does not change any API.
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+<!--
+This section must be completed when targeting alpha to a release.
+-->
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+<!--
+Pick one of these and delete the rest.
+
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
+
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
+
+- [ ] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name:
+  - Components depending on the feature gate:
+- [ ] Other
+  - Describe the mechanism:
+  - Will enabling / disabling the feature require downtime of the control
+    plane?
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node?
+
+###### Does enabling the feature change any default behavior?
+
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+
+### Rollout, Upgrade and Rollback Planning
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
+
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
+
+###### What specific metrics should inform a rollback?
+
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+### Monitoring Requirements
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### How can an operator determine if the feature is in use by workloads?
+
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
+
+###### How can someone using this feature know that it is working for their instance?
+
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [ ] Events
+  - Event Reason:
+- [ ] API .status
+  - Condition name:
+  - Other field:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+- [ ] Metrics
+  - Metric name:
+  - [Optional] Aggregation method:
+  - Components exposing the metric:
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+### Dependencies
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+### Scalability
+
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
+
+For beta, this section is required: reviewers must answer these questions.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### Will enabling / using this feature result in any new API calls?
+
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
+
+###### Will enabling / using this feature result in introducing new API types?
+
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+### Troubleshooting
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+###### What are other known failure modes?
+
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of a KEP should be tracked in this section.
+Major milestones might include:
+- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
+- the `Proposal` section being merged, signaling agreement on a proposed design
+- the date implementation started
+- the first Kubernetes release where an initial version of the KEP was available
+- the version of Kubernetes where the KEP graduated to general availability
+- when the KEP was retired or superseded
+-->
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+## Alternatives
+
+<!--
+What other approaches did you consider, and why did you rule them out? These do
+not need to be as detailed as the proposal, but should include enough
+information to express the idea and why it was not acceptable.
+-->
+
+## Infrastructure Needed (Optional)
+
+<!--
+Use this section if you need things from the project/SIG. Examples include a
+new subproject, repos requested, or GitHub details. Listing these here allows a
+SIG to get the process for these resources started right away.
+-->

--- a/keps/sig-cloud-provider/5778-hybrid-cloud/kep.yaml
+++ b/keps/sig-cloud-provider/5778-hybrid-cloud/kep.yaml
@@ -1,0 +1,15 @@
+title: Introduce explicit node ownership to allow multiple CCMs in a single Kubernetes cluster
+kep-number: 5778
+authors:
+  - "@sergelogvinov"
+owning-sig: sig-cloud-provider
+participating-sigs: []
+status: implementable
+creation-date: 2025-01-11
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+stage: alpha
+latest-milestone: "0.0"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Introduce explicit node ownership to allow multiple CCMs in a single Kubernetes cluster.

<!-- link to the k/enhancements issue -->
- Issue link: #5778 https://github.com/kubernetes/kubernetes/issues/124885

<!-- other comments or additional information -->
- Other comments:

This KEP proposes a standardized mechanism that allows Kubernetes clusters to safely run nodes from multiple cloud providers and/or on-premises environments in a single cluster by enabling multiple Cloud Controller Managers (CCMs) to coexist and by making node ownership explicit and enforceable.