### PR TITLE
KEP-4858: update StrictIPCIDRValidation to Beta

### DIFF
--- a/keps/prod-readiness/sig-network/4858.yaml
+++ b/keps/prod-readiness/sig-network/4858.yaml
@@ -4,3 +4,5 @@
 kep-number: 4858
 alpha:
   approver: "@soltysh"
+beta:
+  approver: "@soltysh"

--- a/keps/sig-network/4858-ip-cidr-validation/kep.yaml
+++ b/keps/sig-network/4858-ip-cidr-validation/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-network
 participating-sigs:
   - sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2024-09-18
 reviewers:
   - "@thockin"
@@ -16,12 +16,12 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.33"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -38,4 +38,4 @@ feature-gates:
 disable-supported: true
 
 # The following PRR answers are required at beta release
-metrics:
+metrics: []


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/issues/4858

Updates UNRESOLVED sections to reflect what was actually implemented.

One notable change is that we originally had a Goal of adding some sort of logging/events when the apiserver saw bad IPs/CIDRs in existing objects, but we never added that... Do we care?
