### PR TITLE
3962: Update latest milestone and promote API versions for Mutating Admission Policies

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/3962.yaml
+++ b/keps/prod-readiness/sig-api-machinery/3962.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-api-machinery/3962-mutating-admission-policies/README.md
+++ b/keps/sig-api-machinery/3962-mutating-admission-policies/README.md
@@ -206,7 +206,7 @@ Each mutation field contains a CEL expression which evaluates to a partially pop
 Here is an example of injecting an initContainer.
 
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "sidecar-policy.example.com"
@@ -254,7 +254,7 @@ The "JSONPatch" strategy will use JSON Patch like what is done in Mutating Webho
 Example JSON Patch:
 
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "sidecar-policy.example.com"
@@ -311,7 +311,7 @@ and `Sidecar` parameter resource:
 
 ```yaml
 # Policy Binding
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: "sidecar-binding-test.example.com"
@@ -482,7 +482,7 @@ These validation checks will be declared using a `mutationValidationPolicy` fiel
 For example:
 
 ```yaml
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: "sidecar-policy.example.com"
@@ -1459,6 +1459,10 @@ Major milestones might include:
 - the version of Kubernetes where the KEP graduated to general availability
 - when the KEP was retired or superseded
 -->
+
+- v1.32: Alpha
+- v1.34: Beta
+- v1.36: Stable
 
 ## Drawbacks
 

--- a/keps/sig-api-machinery/3962-mutating-admission-policies/kep.yaml
+++ b/keps/sig-api-machinery/3962-mutating-admission-policies/kep.yaml
@@ -4,6 +4,7 @@ authors:
   - "@jpbetz"
   - "@cici37"
   - "@jiahuif"
+  - "@lalitc375"
 owning-sig: sig-api-machinery
 participating-sigs:
   - sig-auth
@@ -23,17 +24,18 @@ see-also:
   - "/keps/sig-bbb/2345-everyone-gets-a-kep"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
   beta: "v1.34"
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description:
Update milestones and promote example API versions to v1 for Mutating Admission Policies (KEP-3962).

- Issue link:
https://github.com/kubernetes/enhancements/issues/3962

- Other comments:
This PR updates the KEP documentation to align with the current graduation path and API status:
* Adds explicit milestones: Alpha (v1.32), Beta (v1.34), and Stable (v1.36).
* Promotes `apiVersion` in multiple example blocks from `v1alpha1` to `v1`.
* Updates the KEP metadata in `kep.yaml` and `README.md` to reflect these changes.
