### PR TITLE
kep-4317: add an in-cluster serving signer

### DIFF
--- a/keps/sig-auth/4317-pod-certificates/README.md
+++ b/keps/sig-auth/4317-pod-certificates/README.md
@@ -15,6 +15,8 @@
     - [Issuance Flow](#issuance-flow)
     - [API Object Diff](#api-object-diff)
     - [Example certificate bundle written to the pod filesystem](#example-certificate-bundle-written-to-the-pod-filesystem)
+  - [Kube-native serving certificates signer for Pods and Services](#kube-native-serving-certificates-signer-for-pods-and-services)
+    - [Referencing Services for the kubernetes.io/service-ca signer](#referencing-services-for-the-kubernetesioservice-ca-signer)
   - [Risks and Mitigations](#risks-and-mitigations)
   - [User Stories](#user-stories)
     - [Story 1](#story-1)
@@ -112,6 +114,9 @@ implementations are set up to issue certificates directly to arbitrary public
 keys.  However, there is a significant base of deployed systems (Vault, for
 example), that need a PKCS#10 certificate signing request in order to issue
 certificates.
+
+**Provide an easy way to to provision serving certificates** for an in-cluster
+trust domain to pods and services across the cluster.
 
 ### Non-Goals
 
@@ -740,6 +745,71 @@ k68gmm9HQCdRI3stW7TC3lB0Cd1XSSMUISIP0g==
 -----END CERTIFICATE-----
 ```
 
+### Kube-native serving certificates signer for Pods and Services
+
+This feature is controlled by the `KubeServingCertificatesSigner` feature gate that
+is off-by-default during alpha and beta, but becomes on-by-default when the feature
+reaches GA.
+
+A new certificate signer is introduced to handle PodCertificateRequests for
+serving certificates for Pods and Services - `kubernetes.io/service-ca`. The signer
+is represented by a controller in the Kubernetes Controller Manager that publishes
+a ClusterTrustBundle with the signer's trust anchor, and another controller to issue
+certificates for incoming PodCertificateRequests that target this signer.
+
+To be able to mint certificates on the service layer, the Kube Controller Manager
+receives new options:
+
+- `--service-ca-key` and `--service-ca-cert` that point to the signer's key and
+  certificate, respectively. These must be two different files.
+- `--cluster-service-domain` that will be appended for Pod/Service hostnames, e.g.
+my-pod.my-namespace<strong>.svc.cluster.local</strong> for service domain **cluster.local**
+
+The signer expects at least one of the following parameters in PodCertificateRequest
+`unverifiedUserAnnotations`:
+- `kubernetes.io/add-pod-ips`
+    - adds the `pod.status.podIPs` (or `pod.status.podIP` if `podIPs` is unspecified)
+	  to the SAN IP extension of the resulting certificate
+    - valid values: "true"
+- `kubernetes.io/add-pod-ip`
+    - adds one of the pod IPs to the SAN IP extension of the resulting certificate
+    - valid values: a pod IP from `pod.status.podIPs` and `pod.status.podIP`
+- `kubernetes.io/add-pod-fqdn`
+    - adds the Pod FQDN to the SAN DNS extension of the resulting certificate
+    - the pod must set its `spec.hostname` and a headless Service whose name
+      matches the Pod's `spec.subdomain` must exist in the namespace and the
+      Service's selector must match the Pod
+    <!-- these rules are based on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field -->
+    - valid values: "true"
+- `kubernetes.io/service-names`
+    - adds parameters from Kubernetes Service to the certificate
+    - valid values: comma-separated list of Service names in the Pod's namespace
+	  that match the Pod labels in the Service's label selector
+
+The attributes of the Pod requesting the certificate are mapped into the certificate
+subject like this:
+- `CN` is the Pod name
+- `O` is the Pod namespace
+- `uid` is the Pod UID (this uses the [standardized](https://www.rfc-editor.org/rfc/rfc4519.html#section-2.39)
+`uid` OID 0.9.2342.19200300.100.1.1, not the Kubernetes-specific UID for client certificates)
+
+#### Referencing Services for the kubernetes.io/service-ca signer
+
+The `kubernetes.io/service-names` Service references require the following to be
+considered valid:
+- the referenced Service must exist in the Pod's namespace
+- the `spec.selector` of the Service must match the Pod's labels
+
+If the above conditions are fulfilled, parameters of the Service are added into
+the resulting certificate.
+
+For **headless services** the certificate gets SAN DNS names in the form of
+`<svc-name>.<svc-namespace>.svc.<cluster-domain>` and `<svc-name>.<svc-namespace>.svc`.
+
+For **cluster IP services** the certificate gets SAN DNS names same as for
+headless services, but the Service's IP is also added to the certificate as SAN
+IP address.
+
 ### Risks and Mitigations
 
 **Scalability**: In the current design and draft implementation, kubelet holds
@@ -892,6 +962,17 @@ We expect no non-infra related flakes in the last month as a GA graduation crite
   establish an mTLS connection. An additional test case will confirm that
   rotation works properly by continuing to establish connections for 20 minutes,
   while using a signer that issues 10-minute valid certificates.
+* test/e2e/auth/serving_signer.go:
+  - Requests a pod certificate from the `kubernetes.io/service-ca` signer for one
+    pod. Another pod requests a ClusterTrustBundle to be mounted into its volume and
+    attempts to connect read HTTPS content served by the first pod, which uses the
+    certificates it received from the PodCertificatesVolume.
+  - Tests the scenario with:
+      - normal service
+      - headless service with and without pod IP and FQDN
+      - pod IP alone
+      - invalid service name
+      - pod FQDN without any service
 
 ### Graduation Criteria
 
@@ -910,6 +991,7 @@ For Beta:
   - issuing client certificates
   - SPIFFE certificates (?)
   [mesh-examples](https://github.com/ahmedtd/mesh-example).
+* Implement an in-tree signer for internal serving certificates domain
 * Migrate kubelet implementation to use the beta API.
 * Deprecate and remove the alpha API.
 
@@ -1083,6 +1165,7 @@ At beta, enabling this feature in a live cluster will require the following step
 1. Enable the certificates/v1beta1 API.
 2. Enable the PodCertificateRequest feature gate on all kube-apiserver replicas.
 3. Enable the PodCertificateRequest feature gate on all kubelet instances.
+4. Enable the KubeServingCertificatesSigner feature gate on all kube-controller-manager instances.
 
 At this point, you can begin to create pods that use the features.
 
@@ -1096,7 +1179,8 @@ Yes, the feature can be disabled safely by following this procedure.
 
 1. Remove any workloads that are currently using PodCertificate projected volumes.
 2. Disable the PodCertificateRequest feature gate on all kubelet instances
-3. Disable the PodCertificateRequest feature gate on all kube-apiserver replicas
+3. Disable the KubeServingCertificatesSigner feature gate on all kube-controller-manager instances
+4. Disable the PodCertificateRequest feature gate on all kube-apiserver replicas
 5. Disable the certificates/v1beta1 API.
 
 ###### What happens if we reenable the feature if it was previously rolled back?

--- a/keps/sig-auth/4317-pod-certificates/kep.yaml
+++ b/keps/sig-auth/4317-pod-certificates/kep.yaml
@@ -33,6 +33,8 @@ milestone:
 feature-gates:
   - name: PodCertificateRequest
     components: ['kube-apiserver']
+  - name: KubeServingCertificatesSigner
+    components: ['kube-controller-manager']
 disable-supported: true
 
 # The following PRR answers are required at beta release

--- a/keps/sig-auth/4317-pod-certificates/kep.yaml
+++ b/keps/sig-auth/4317-pod-certificates/kep.yaml
@@ -32,7 +32,7 @@ milestone:
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: PodCertificateRequest
-    components: ['kube-apiserver']
+    components: ['kube-apiserver', 'kubelet']
   - name: KubeServingCertificatesSigner
     components: ['kube-controller-manager']
 disable-supported: true


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: proposes an in-tree serving certificates signer to the PodCertificates KEP

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4317

<!-- other comments or additional information -->
- Other comments: The proposed feature is to be gated by a feature gate that has its own maturity that is independent of the other feature gates mentioned in the KEP.