### PR TITLE
KEP-740: Update for GA promotion

### DIFF
--- a/keps/prod-readiness/sig-auth/740.yaml
+++ b/keps/prod-readiness/sig-auth/740.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@soltysh"
 beta:
   approver: "@soltysh"
+stable:
+  approver: "@soltysh"

--- a/keps/sig-auth/740-service-account-external-signing/README.md
+++ b/keps/sig-auth/740-service-account-external-signing/README.md
@@ -370,7 +370,7 @@ experience would be the same as when enabling.
 
 ###### Are there any tests for feature enablement/disablement?
 
-- Unit and E2E tests will be added.
+- Unit and integration tests will be added.
 - The tests would **not** focus on continuing to support the same key set when enabling/disabling but would rather focus on viability of enabling/disabling.
 
 ### Rollout, Upgrade and Rollback Planning
@@ -613,8 +613,15 @@ Initial PRs:
 - kubernetes/kubernetes#125177
 
 1.32: Alpha release
+- kubernetes/kubernetes#128190
+- kubernetes/kubernetes#128192
+- kubernetes/kubernetes#128953
 
 1.34: Beta release
+- kubernetes/kubernetes#131300
+
+1.36: Stable release
+- kubernetes/kubernetes#136118
 
 ## Drawbacks
 

--- a/keps/sig-auth/740-service-account-external-signing/kep.yaml
+++ b/keps/sig-auth/740-service-account-external-signing/kep.yaml
@@ -15,13 +15,14 @@ approvers:
   - "@liggitt"
   - "@enj"
 
-stage: beta
+stage: stable
 
-latest-milestone: "v1.34"
+latest-milestone: "v1.36"
 
 milestone:
   alpha: "v1.32"
   beta: "v1.34"
+  stable: "v1.36"
 
 feature-gates:
   - name: ExternalServiceAccountTokenSigner


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Promote KEP-740 to GA/stable

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/740

<!-- other comments or additional information -->
- Other comments:
  - externalization of legacy controller in staging repo was dropped in beta promotion; Going GA without it since none of the known consumers of this feature would use the externalized controller code.
  - In production use by more then one providers i.e. GKE and EKS

/sig auth
/cc @liggitt @micahhausler
cc @ahmedtd
