### PR TITLE
Update KEP-4876 Mutable CSINode Allocatable for Stable

### DIFF
--- a/keps/prod-readiness/sig-storage/4876.yaml
+++ b/keps/prod-readiness/sig-storage/4876.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-storage/4876-mutable-csinode-allocatable/README.md
+++ b/keps/sig-storage/4876-mutable-csinode-allocatable/README.md
@@ -475,8 +475,8 @@ All unit tests/integration/e2e tests completed and enabled:
 
 #### GA
 
-- No bug reports / feedback / improvements to address in k/k.
-- No bug reports in Cluster Autoscalar as a result of this enhancement (*this KEP does not affect CA, but we have added this requirement out of an abundance of caution, as requested by CA.*)
+- [✅] No bug reports / feedback / improvements to address in k/k.
+- [✅] No bug reports in Cluster Autoscalar as a result of this enhancement (*this KEP does not affect CA, but we have added this requirement out of an abundance of caution, as requested by CA.*)
 
 ### Upgrade / Downgrade Strategy
 
@@ -952,6 +952,8 @@ Major milestones might include:
 - 2024-08-08 - Enhancement proposed in sig-storage.
 - 2024-09-25 - Enhancement officially submitted to Kubernetes.
 - 2025-04-23 - Kubernetes v1.33: Enhancement implemented and released in Alpha.
+- 2025-08-27 - Kubernetes v1.34: Enhancement graduated to Beta.
+- 2025-12-17 - Kubernetes v1.35: Feature gate enabled by default in Beta.
 
 ## Drawbacks
 

--- a/keps/sig-storage/4876-mutable-csinode-allocatable/kep.yaml
+++ b/keps/sig-storage/4876-mutable-csinode-allocatable/kep.yaml
@@ -22,12 +22,12 @@ approvers:
   - "@msau42"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Updating milestone to Stable for sig-storage `KEP-4876` Mutable CSINode Allocatable.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4876