### PR TITLE
Update attach-limit enhancement for v1.36

### DIFF
--- a/keps/sig-autoscaling/5030-attach-limit-autoscaler/README.md
+++ b/keps/sig-autoscaling/5030-attach-limit-autoscaler/README.md
@@ -285,8 +285,9 @@ A node which is ready  but does not have CSI driver installed within certain tim
 
 ### When it is safe to Prevent pod placement?
 
-Generally speaking it is safe to prevent pod placement to nodes without CSI driver in scheduler, if cluster-admin or Kubernetes distro is aware that, it is running a version of autoscaler (CAS or Karpenter), which is aware of CSI attach limits coming from the node.  For CAS this generally means, `enable-csi-node-aware-scheduling` flag should be enabled and set to true in the version of CAS that is running in the cluster.
+Generally speaking it is safe to prevent pod placement to nodes without CSI driver in scheduler when running an autoscaler that has support for CSI attach limit awareness. Cluster Autoscaler currently supports this with the enable-csi-node-aware-scheduling feature flag (starting with version 1.35). Other autoscalers in the ecosystem may support this in the future.
 
+Obviously it is also safe to prevent pod placement if your cluster doesn't have any autoscalers.
 
 #### What happens if cluster-admin opts-in to prevent pod scheduling but autoscaler does not have CSI attach limit awareness?
 

--- a/keps/sig-autoscaling/5030-attach-limit-autoscaler/kep.yaml
+++ b/keps/sig-autoscaling/5030-attach-limit-autoscaler/kep.yaml
@@ -32,9 +32,9 @@ latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.36"
-  beta: "v1.36"
-  stable: "v1.37"
+  alpha: "v1.35"
+  beta: "v1.37"
+  stable: "v1.38"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
xref https://github.com/kubernetes/enhancements/issues/5030

This updates the enhancement to make scheduler changes (which prevent pod placement on nodes without CSI driver) an explicit opt-in via `CSIDriver` object. There are no proposed changes in behaviour of Cluster-Autoscaler in this PR. 


cc @jsafrane @deads2k 
