### PR TITLE
KEP-5311: Update beta target version

### DIFF
--- a/keps/sig-network/5311-relaxed-validation-for-service-names/README.md
+++ b/keps/sig-network/5311-relaxed-validation-for-service-names/README.md
@@ -382,11 +382,18 @@ N/A
     - https://github.com/kubernetes/enhancements/pull/5315
   - [x] Code (`k/k`) update PR(s):
     - https://github.com/kubernetes/kubernetes/pull/132339
-  - [ ] Docs (`k/website`) update PR(s):
+  - [x] Docs (`k/website`) update PR(s):
+    - https://github.com/kubernetes/website/pull/52447
 - [x] Beta
-  - [ ] KEP (`k/enhancements`) update PR(s):
-    - ...
+  - [x] KEP (`k/enhancements`) update PR(s):
+    - https://github.com/kubernetes/enhancements/pull/5561
   - [ ] Code (`k/k`) update PR(s):
+	- (this PR was rolled back by the PR below) https://github.com/kubernetes/kubernetes/pull/134493
+	- https://github.com/kubernetes/kubernetes/pull/135426
+    - ...
+  - [ ] Docs (`k/website`) update(s):
+	- (this PR was rolled back by the PR below)  https://github.com/kubernetes/website/pull/52920
+	- https://github.com/kubernetes/website/pull/53471
     - ...
 
 ## Drawbacks

--- a/keps/sig-network/5311-relaxed-validation-for-service-names/kep.yaml
+++ b/keps/sig-network/5311-relaxed-validation-for-service-names/kep.yaml
@@ -25,13 +25,13 @@ stage: beta #|stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.34"
-  beta: "v1.35"
-  stable: "v1.36"
+  beta: "v1.36"
+  stable: "v1.37"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- One-line PR description: Update KEP to reflect that it is targeting beta for 1.36

- Issue link:

- Other comments: