### PR TITLE
[KEP-4639] Graduate image volume source to GA

### DIFF
--- a/keps/sig-node/4639-oci-volume-source/README.md
+++ b/keps/sig-node/4639-oci-volume-source/README.md
@@ -1386,7 +1386,8 @@ Major milestones might include:
 - 02-10-2024 KEP updated
 - 06-02-2025 KEP targeting beta in v1.33
 - 06-17-2025 KEP retargeting beta in v1.34, dropped noexec requirement
-- 09-03-2025 KEP retargeting GA in v1.35
+- 09-03-2025 KEP retargeting ~GA~ beta (enabled by default) in v1.35
+- 20-01-2026 KEP retargeting GA in v1.36 since we moved to beta (enabled by default in 1.35)
 
 ## Drawbacks
 

--- a/keps/sig-node/4639-oci-volume-source/kep.yaml
+++ b/keps/sig-node/4639-oci-volume-source/kep.yaml
@@ -46,13 +46,13 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.31"
   beta: "v1.34"
-  stable: "v1.35"
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
This KEP completed the GA review process for Kubernetes 1.35, including PRR approval, but was not merged in time for that release. This PR retargets the previously approved GA graduation for inclusion in a subsequent release.

  **Previous review context:**
  - PRR approval was obtained during the 1.35 release cycle
  - All GA graduation requirements were met
  - Only the timing prevented inclusion in 1.35


Issue link: #4639
