### PR TITLE
KEP-3104: Update latest milesone

### DIFF
--- a/keps/sig-cli/3104-introduce-kuberc/README.md
+++ b/keps/sig-cli/3104-introduce-kuberc/README.md
@@ -402,8 +402,6 @@ kuberc execution:
 * If `KUBERC` environment variable is specified, operate on this file
 * If none, operate on default kuberc (i.e. `$HOME/.kube/kuberc`).
 
-This command and subcommands are marked as alpha initially. They can be executed under `kubectl alpha`, until they are promoted to beta.
-
 ### kubectl kuberc view
 
 `kubectl kuberc view` subcommand prints the defined kuberc file content in the given format via `--output` flag (default is yaml).

--- a/keps/sig-cli/3104-introduce-kuberc/kep.yaml
+++ b/keps/sig-cli/3104-introduce-kuberc/kep.yaml
@@ -28,7 +28,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: This PR updates the latest milestone. Besides, since we plan to promote `kubectl kuberc` commands to beta. It removes the statement about alpha.

- Issue link: https://github.com/kubernetes/enhancements/issues/3104

<!-- other comments or additional information -->
- Other comments: