### PR TITLE
KEP 5067: Mark Pod Generation as implemented

### DIFF
--- a/keps/sig-node/5067-pod-generation/README.md
+++ b/keps/sig-node/5067-pod-generation/README.md
@@ -1197,6 +1197,7 @@ Major milestones might include:
 2025-02-12: PR feedback addressed, KEP moved to "implementable" and merged
 2025-06-05: proposed promotion to beta
 2025-09-23: proposed promotion to stable
+2026-01-20: mark as implemented after GA release
 
 ## Drawbacks
 

--- a/keps/sig-node/5067-pod-generation/kep.yaml
+++ b/keps/sig-node/5067-pod-generation/kep.yaml
@@ -5,7 +5,7 @@ authors:
   - "@tallclair"
 owning-sig: sig-node
 participating-sigs:
-status: implementable
+status: implemented
 creation-date: 2025-01-21
 reviewers:
   - "@yujuhong"
@@ -40,7 +40,7 @@ feature-gates:
       - kubelet
       - kube-controller-manager
       - kube-scheduler
-disable-supported: true
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:


### PR DESCRIPTION
Closes https://github.com/kubernetes/enhancements/issues/5067

Mark Pod Generation KEP as implemented as it has graduated to stable as of v1.35. 

/assign @tallclair @dchen1107 
/cc @haircommander @SergeyKanzhelev 