### PR TITLE
KEP-5538: update kep for GA in v1.36

### DIFF
--- a/keps/prod-readiness/sig-storage/5538.yaml
+++ b/keps/prod-readiness/sig-storage/5538.yaml
@@ -1,3 +1,5 @@
 kep-number: 5538
 beta:
   approver: "@jpbetz"
+stable:
+  approver: "@jpbetz"

--- a/keps/sig-storage/5538-csi-sa-tokens-secrets-field/README.md
+++ b/keps/sig-storage/5538-csi-sa-tokens-secrets-field/README.md
@@ -230,7 +230,11 @@ New tests will be added for:
 
 - Feature gate locked to true (always enabled)
 - At least one CSI driver updated to use the secrets field
+  - Secrets Store CSI Driver using secrets field for tokens: [PR](https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/1979)
+  - Fallback logic implemented in Azure File CSI Driver: [PR](https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/2945)
+  - Fallback logic implemented in Blob CSI Driver: [PR](https://github.com/kubernetes-sigs/blob-csi-driver/pull/2305)
 - Clear best practice documentation and migration guides
+  - This is already done in the [beta blog post](https://kubernetes.io/blog/2026/01/07/kubernetes-v1-35-csi-sa-tokens-secrets-field-beta/)
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-storage/5538-csi-sa-tokens-secrets-field/kep.yaml
+++ b/keps/sig-storage/5538-csi-sa-tokens-secrets-field/kep.yaml
@@ -21,18 +21,18 @@ see-also:
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: ""
   beta: "v1.35"
-  stable: ""
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
- Update [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/5538-csi-sa-tokens-secrets-field) for GA
- Issue link: https://github.com/kubernetes/enhancements/issues/5538

/sig auth storage
/triage accepted
/assign @liggitt @msau42 @xing-yang

