### PR TITLE
KEP-5073: Graduate DeclarativeValidation feature gate to GA in v1.36

### DIFF
--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
@@ -23,12 +23,13 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.33"
   beta: "v1.33"
+  ga: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
Update KEP-5073 to reflect the graduation of the DeclarativeValidation feature gate to GA in v1.36. This graduation is supported by three release cycles (v1.33-v1.35) of proven stability with no mismatch or panic metrics reported in production.

Changes:
- Update kep.yaml with latest-milestone v1.36 and ga: v1.36 milestone.
- Update README.md Summary and Motivation to reflect GA focus.
- Update README.md Graduation Criteria for DeclarativeValidation.
- Update README.md Implementation History with v1.36 GA entry.
