### PR TITLE
KEP-5073: Graduate DeclarativeValidation feature gate to GA in v1.36

### DIFF
--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
@@ -23,7 +23,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: 
Update KEP-5073 to reflect the graduation of the `DeclarativeValidation` feature gate to GA in v1.36.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5073

- Other comments: 
  - This graduation is supported by three release cycles (v1.33-v1.35) of proven stability with no mismatch or panic metrics reported in production.   
  - **NOTE:** the `DeclarativeValidationTakeover` feature gate is still off by default.