### PR TITLE
KEP-5328: widen approvers

### DIFF
--- a/keps/sig-node/5328-node-declared-features/OWNERS
+++ b/keps/sig-node/5328-node-declared-features/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
+
+reviewers:
+  - SergeyKanzhelev # sig-node-assigned-reviewer
+  - haircommander # sig-node-assigned-reviewer
+
+approvers:
+  - tallclair # sig-node-assigned-approver

--- a/keps/sig-node/5328-node-declared-features/kep.yaml
+++ b/keps/sig-node/5328-node-declared-features/kep.yaml
@@ -9,15 +9,15 @@ participating-sigs:
 
 creation-date: "2025-05-27"
 reviewers: 
-  - '@tallclair'
+  - '@SergeyKanzhelev' # sig-node-assigned-reviewer
   - '@yujuhong'
   - '@wojtek-t'
   - '@dom4ha'
   - '@macsko'
-  - '@haircommander'
+  - '@haircommander' # sig-node-assigned-reviewer
 approvers:
-- '@dchen1107'
-- '@SergeyKanzhelev'
+- '@dchen1107' # sig-node-tl
+- '@tallclair' # sig-node-assigned-approver
 - '@dom4ha'
 - '@macsko'
 status: implementable


### PR DESCRIPTION
This is a proposal on how we can mark and in future automate OWNER files:

https://github.com/kubernetes/community/pull/8794/

We can mark approvers and reviewers with the special comment so they will appear explicitly in OWNERS file for this KEP.

chars: @haircommander @mrunalp for discussion