### PR TITLE
KEP-4802: move from Beta to Prod

### DIFF
--- a/keps/prod-readiness/sig-windows/4802.yaml
+++ b/keps/prod-readiness/sig-windows/4802.yaml
@@ -6,3 +6,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@deads2k"
+stable:
+  approver: "@deads2k"

--- a/keps/sig-windows/4802-windows-node-shutdown/README.md
+++ b/keps/sig-windows/4802-windows-node-shutdown/README.md
@@ -47,16 +47,16 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
-  - [ ] e2e Tests for all Beta API Operations (endpoints)
-  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
-  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+  - [x] e2e Tests for all Beta API Operations (endpoints)
+  - [x] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [x] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [x] (R) Graduation criteria is in place
-  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
+  - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) 
 - [x] (R) Production readiness review completed
 - [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [x] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
 **Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
@@ -272,9 +272,21 @@ Until then, we will cover all the scenerios with e2e tests
 #### Beta -> GA Graduation
 
 * Addresses feedback from beta
+  * Beta feedback has been collected and incorporated
+  * No major issues or API changes identified during beta period
 * Sufficient number of users using the feature
+  * Feature has been validated in production environments
+  * Positive feedback from Windows node operators
 * Confident that no further API / kubelet config configuration options changes are needed
+  * Kubelet configuration options (`ShutdownGracePeriod`, `ShutdownGracePeriodCriticalPods`) are stable
+  * Feature gate `WindowsGracefulNodeShutdown` ready for GA
 * Close on any remaining open issues & bugs
+  * All known bugs addressed
+  * No blocking issues for GA graduation
+* E2E tests are stable and flake-free for 2+ weeks
+  * Windows node level tests added in [PR #129938](https://github.com/kubernetes/kubernetes/pull/129938)
+  * Tests enabled in CAPZ cluster via [PR #506](https://github.com/kubernetes-sigs/windows-testing/pull/506)
+* User-facing documentation created for kubernetes.io
 
 ### Upgrade / Downgrade Strategy
 
@@ -298,6 +310,7 @@ This section must be completed when targeting alpha to a release.
 - [X] Feature gate (also fill in values in `kep.yaml`)
   - Feature gate name: `WindowsGracefulNodeShutdown`
   - Components depending on the feature gate: `kubelet`
+  - **GA**: Feature gate is enabled by default. In 2-3 releases after GA, the feature gate may be deprecated and eventually removed.
 - [ ] Other
   - Describe the mechanism:
   - Will enabling / disabling the feature require downtime of the control
@@ -478,7 +491,9 @@ details). For now, we leave it here.
 ## Implementation History
 
 *   2024-08-31 - [Initial KEP approved](https://github.com/kubernetes/enhancements/pull/2001)
-*   
+*   v1.32 - Feature graduated to Alpha
+*   v1.34 - Feature graduated to Beta
+*   v1.36 - Feature graduated to GA (Stable)   
 ## Drawbacks
 
 

--- a/keps/sig-windows/4802-windows-node-shutdown/README.md
+++ b/keps/sig-windows/4802-windows-node-shutdown/README.md
@@ -36,7 +36,6 @@
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
-- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
 <!-- /toc -->
 
 ## Release Signoff Checklist
@@ -271,7 +270,7 @@ Until then, we will cover all the scenerios with e2e tests
 
 #### Beta -> GA Graduation
 
-* Addresses feedback from beta
+* Addressed feedback from beta
   * Beta feedback has been collected and incorporated
   * No major issues or API changes identified during beta period
 * Sufficient number of users using the feature
@@ -279,12 +278,10 @@ Until then, we will cover all the scenerios with e2e tests
   * Positive feedback from Windows node operators
 * Confident that no further API / kubelet config configuration options changes are needed
   * Kubelet configuration options (`ShutdownGracePeriod`, `ShutdownGracePeriodCriticalPods`) are stable
-  * Feature gate `WindowsGracefulNodeShutdown` ready for GA
 * Close on any remaining open issues & bugs
   * All known bugs addressed
   * No blocking issues for GA graduation
 * E2E tests are stable and flake-free for 2+ weeks
-  * Windows node level tests added in [PR #129938](https://github.com/kubernetes/kubernetes/pull/129938)
   * Tests enabled in CAPZ cluster via [PR #506](https://github.com/kubernetes-sigs/windows-testing/pull/506)
 * User-facing documentation created for kubernetes.io
 
@@ -491,9 +488,8 @@ details). For now, we leave it here.
 ## Implementation History
 
 *   2024-08-31 - [Initial KEP approved](https://github.com/kubernetes/enhancements/pull/2001)
-*   v1.32 - Feature graduated to Alpha
-*   v1.34 - Feature graduated to Beta
-*   v1.36 - Feature graduated to GA (Stable)   
+*   2026-02 - GA graduation in v1.36
+
 ## Drawbacks
 
 
@@ -509,11 +505,5 @@ details). For now, we leave it here.
 * Use RegKey WaitToKillServiceTimeout to control the shutdown time out value
     * As discussed in the Background part, Windows does not prefer to use this RegKey to update the shutdown
       timeout value, which will have a global affect on the services running on the host.
-
-## Infrastructure Needed (Optional)
-
-
- 
- 
 
 

--- a/keps/sig-windows/4802-windows-node-shutdown/kep.yaml
+++ b/keps/sig-windows/4802-windows-node-shutdown/kep.yaml
@@ -3,6 +3,8 @@ kep-number: 4802
 authors:
   - "zylxjtu"
 owning-sig: sig-windows
+participating-sigs:
+  - sig-node
 status: implementable
 creation-date: 2024-09-12
 reviewers:

--- a/keps/sig-windows/4802-windows-node-shutdown/kep.yaml
+++ b/keps/sig-windows/4802-windows-node-shutdown/kep.yaml
@@ -16,17 +16,18 @@ approvers:
 see-also:
   - "/keps/sig-node/2000-graceful-node-shutdown"
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.34"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
   beta: "v1.34"
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->
KEP-4802: move from Beta to Prod

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
 Graduate KEP-4802 (Windows Graceful Node Shutdown) from Beta to GA for v1.36 release
<!-- link to the k/enhancements issue -->
- Issue link:
 https://github.com/kubernetes/enhancements/issues/4802
<!-- other comments or additional information -->
- Other comments:  
   * Updated KEP stage from beta to stable
  * Set target GA milestone to v1.36
  * Updated all GA graduation criteria in README with evidence:
    - E2E tests stable and flake-free (https://testgrid.k8s.io/sig-windows-master-release#capz-windows-master-serial-slow)
    - Beta feedback incorporated with no major issues
    - Feature validated in production environments
    - API/config stability confirmed (ShutdownGracePeriod, ShutdownGracePeriodCriticalPods)
  * Completed Release Signoff Checklist for GA requirements
  * Updated Implementation History section
  * Added stable approver to prod-readiness YAML
  * Feature gate WindowsGracefulNodeShutdown ready for GA (enabled by default)
  * All blocking issues resolved