### PR TITLE
KEP-5007: DRA Device Binding Conditions beta in 1.36

### DIFF
--- a/keps/prod-readiness/sig-scheduling/5007.yaml
+++ b/keps/prod-readiness/sig-scheduling/5007.yaml
@@ -4,3 +4,5 @@
 kep-number: 5007
 alpha:
   approver: "@johnbelamaric"
+beta:
+  approver: "@johnbelamaric"

--- a/keps/sig-scheduling/5007-device-attach-before-pod-scheduled/kep.yaml
+++ b/keps/sig-scheduling/5007-device-attach-before-pod-scheduled/kep.yaml
@@ -17,19 +17,20 @@ reviewers:
   - "@sanposhiho"
 approvers:
   - "@alculquicondor"
+  - "@dom4ha"
 
 see-also:
   - "/keps/sig-node/4381-dra-structured-parameters"
   - https://github.com/kubernetes/kubernetes/issues/124042#issuecomment-2548068135
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 #|beta|stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: updating KEP docs for promotion to beta

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5007

<!-- other comments or additional information -->
- Other comments:  
  This PR promotes the DRA Device Binding Conditions feature from alpha to beta for Kubernetes v1.36, with enhancements based on DRA driver developer's feedback and metrics.

  #### **1. Stage Promotion to Beta**
  - Updated `stage: alpha` → `stage: beta` in kep.yaml  
  - Updated `latest-milestone: "v1.35"` → `"v1.36"`

  #### **2. Enhanced DRA Driver Developer's Feedback**
  - **CoHDI**: Added comprehensive feedback from CoHDI (Composable Hardware Device Infrastructure) testing, including scenarios for device pool changes and external controller bug identification
  - **NVIDIA DRA Driver**: Added feedback from NVIDIA's k8s-dra-driver-gpu showcasing ComputeDomain support with Multi-Node NVLink and IMEX technology

  #### **3. Improved Monitoring & Observability**
  - **New Metrics**: Introduced two new metrics for better operational visibility:
    - `scheduler_dra_bindingconditions_allocations_total`:  
       tracks scheduling attempts with success/failure/timeout status
    - `scheduler_dra_bindingconditions_prebind_duration_seconds`:  
        measures PreBind phase duration with detailed labels
  - **Enhanced Detection**: Replaced event log-based monitoring with metric-based detection for better automation

  #### **4. Clarified Feature Scope**
  - Added explicit non-goal: device pool migration as happy-path flow (deferred to separate KEP)
  
  **NOTE:**  
  I addressed comments and suggestions from @johnbelamaric  during the v1.35 review cycle:  
  https://github.com/kubernetes/enhancements/pull/5487
  
/wg device-management
/sig scheduling
/cc @pohly @johnbelamaric @dom4ha

