### PR TITLE
KEP 4960: Update for 1.36

### DIFF
--- a/keps/sig-node/4960-container-stop-signals/kep.yaml
+++ b/keps/sig-node/4960-container-stop-signals/kep.yaml
@@ -17,7 +17,7 @@ approvers:
 
 status: implementable
 stage: alpha
-latest-milestone: "v1.34"
+latest-milestone: "v1.36"
 milestone:
     alpha: "v1.33"
     beta: ""


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bump the latest-milestone in KEP 4960's kep.yaml file for v1.36

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4960

<!-- other comments or additional information -->
- Other comments: Updates related to metrics were added in 1.34, but the code PRs weren't merged. This PR just bumps the version to the latest release to attempt a second round of alpha in 1.36.