### PR TITLE
KEP-2570: Mitigate MemoryQoS memory.high livelock concern in v1.36

### DIFF
--- a/keps/sig-node/2570-memory-qos/kep.yaml
+++ b/keps/sig-node/2570-memory-qos/kep.yaml
@@ -2,6 +2,8 @@ title: Memory QoS
 kep-number: 2570
 authors:
   - "@xiaoxubeii"
+  - "@QiWang19"
+  - "@sohankunkerkar"
 reviewers:
   - "@derekwaynecarr"
   - "@bobbypage"
@@ -11,12 +13,12 @@ reviewers:
 approvers:
   - "@derekwaynecarr"
 owning-sig: sig-node
-status: provisional
+status: implementable
 editor: "@ndixita"
 creation-date: 2021-03-14
-last-updated: 2023-06-14
+last-updated: 2026-02-04
 stage: alpha
-latest-milestone: "v1.27"
+latest-milestone: "v1.36"
 milestone:
   alpha: "v1.27"
 feature-gates:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: This PR updates the stalled KEP-2570 addressing the livelock concern for beta graduation.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/2570

