### PR TITLE
KEP-5589: Update gogo removal to 1.36

### DIFF
--- a/keps/sig-api-machinery/5589-gogo-dependency/README.md
+++ b/keps/sig-api-machinery/5589-gogo-dependency/README.md
@@ -592,6 +592,7 @@ There is no runtime behavior change associated with this KEP.
 * 2020: gogo / golang/protobuf incompatibilities stall dependency updates, panic etcd libraries, get resolved in a best-effort way
 * 2021-2022: gogo transitions to deprecated / unmaintained
 * v1.35: This KEP proposed
+* v1.35: code-generator updated to remove runtime dependencies from generated code ([#134256](https://github.com/kubernetes/kubernetes/pull/134256))
 
 ## Drawbacks
 

--- a/keps/sig-api-machinery/5589-gogo-dependency/kep.yaml
+++ b/keps/sig-api-machinery/5589-gogo-dependency/kep.yaml
@@ -23,7 +23,7 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.35"
+latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update for 1.36

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5589

/sig api-machinery
/assign @jpbetz 