### PR TITLE
KEP-3104 Add `kubectl kuberc` options for plugin policy/allowlist

### DIFF
--- a/keps/sig-cli/3104-introduce-kuberc/README.md
+++ b/keps/sig-cli/3104-introduce-kuberc/README.md
@@ -107,7 +107,7 @@ tags, and then generate with `hack/update-toc.sh`.
     - [appendarg](#appendarg)
   - [kubectl kuberc set --section credentialplugin](#kubectl-kuberc-set---section-credentialplugin)
     - [policy](#policy)
-    - [allowlistentry](#allowlistentry)
+    - [allowlist-entry](#allowlist-entry)
   - [Allowlist Design Details](#allowlist-design-details)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -472,20 +472,20 @@ This gives us the opportunity to standardize kuberc files.
 #### policy
 
 The required `--policy` flag sets the credential plugin policy. The value must be one of `AllowAll`, `DenyAll`, or
-`AllowList` (case-insensitive). If `--policy=Allowlist` is used, it must be accompanied by the `--allowlistentry` flag.
+`AllowList` (case-insensitive). If `--policy=Allowlist` is used, it must be accompanied by the `--allowlist-entry` flag.
 
-#### allowlistentry
+#### allowlist-entry
 
-`--allowlistentry` may be supplied one or multiple times if (and only if) the `--policy` flag is set to `Allowlist`. In order
-to build an allowlist with multiple entries, you must supply the flag multiple times. The argument to `--allowlistentry` is a
+`--allowlist-entry` may be supplied one or multiple times if (and only if) the `--policy` flag is set to `Allowlist`. In order
+to build an allowlist with multiple entries, you must supply the flag multiple times. The argument to `--allowlist-entry` is a
 list of `key=value` pairs separated by a comma. In the below example, we add two entries to the allowlist, one with `command`
 `cloudplatform-credential-helper`, and another with `command` `custom-credential-script`:
 
 ```bash
 kubectl kuberc set --section credentialplugin \
     --policy=Allowlist \
-    --allowlistentry="command=cloudplatform-credential-helper" \
-    --allowlistentry="command=custom-credential-script"
+    --allowlist-entry="command=cloudplatform-credential-helper" \
+    --allowlist-entry="command=custom-credential-script"
 ```
 
 ### Allowlist Design Details


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Add descriptions of flags to `kubectl kuberc set` which allow for setting plugin policy and allowlist values.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/kubernetes/issues/135558

- Additionally remarks on the `name` vs. `command` discrepancy between this KEP and the actual implementation.