### PR TITLE
ComponentStatuz beta : address metrics requirements

### DIFF
--- a/keps/sig-instrumentation/4827-component-statusz/README.md
+++ b/keps/sig-instrumentation/4827-component-statusz/README.md
@@ -519,7 +519,7 @@ This enhancement proposes data that can be used to determine the health of the c
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-No. We are open to input.
+Requests to `/statusz` will be tracked in the existing `apiserver_request_total` and `apiserver_request_duration_seconds` metrics.
 
 ### Dependencies
 

--- a/keps/sig-instrumentation/4827-component-statusz/kep.yaml
+++ b/keps/sig-instrumentation/4827-component-statusz/kep.yaml
@@ -39,3 +39,7 @@ feature-gates:
       - kubelet
       - kube-proxy
 disable-supported: true
+# The following PRR answers are required at beta release
+metrics:
+  - apiserver_request_total
+  - apiserver_request_duration_seconds


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update beta criteria to include metrics for statusz. No new metrics are added but we will reuse existing `apiserver_request_total` and `apiserver_request_duration_seconds` metrics to instrument the statusz handler.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4827
