### PR TITLE
KEP-5883: Resolve remaining wording comments

### DIFF
--- a/keps/sig-scheduling/5832-decouple-podgroup-api/README.md
+++ b/keps/sig-scheduling/5832-decouple-podgroup-api/README.md
@@ -321,8 +321,6 @@ type PodGroupStatus struct {
    // - "Scheduled": All required pods have been successfully scheduled.
    // - "Unschedulable": The PodGroup cannot be scheduled due to resource constraints,
    //   affinity/anti-affinity rules, or insufficient capacity for the gang.
-   // - "SchedulingGated": One or more pods in the PodGroup have scheduling gates
-   //   that must be cleared before scheduling can proceed.
    // - "Preempted": The PodGroup was preempted to make room for higher-priority workloads.
    // - "Timeout": The PodGroup failed to schedule within the configured timeout.
    //


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Resolve remaining wording comments missed in https://github.com/kubernetes/enhancements/pull/5833

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5832

<!-- other comments or additional information -->
- Other comments: