### PR TITLE
KEP-5710: Update KEP to use decoupled PodGroup API.

### DIFF
--- a/keps/sig-scheduling/5710-workload-aware-preemption/kep.yaml
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/kep.yaml
@@ -14,6 +14,7 @@ approvers:
 
 see-also:
   - "/keps/sig-scheduling/4671-gang-scheduling"
+  - "/keps/sig-scheduling/5832-decouple-podgroup-from-workload-api"
 
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature


### PR DESCRIPTION
- One-line PR description:
Adjust workload aware preemption KEP to use decoupled PodGroup API.

- Issue link: https://github.com/kubernetes/enhancements/issues/5710

- Other comments:
This main change is the move of priority from the Workload level to a PodGroup.  With the changes to PodGroup API we expect that the scheduler will no longer watch workload objects, so having this information in PodGroup object is necessary . An open question is whether we want to have this as a field on Workload level and copy to PodGroup on object creation, or on a PodGroupTemplate object. I decided to go with the latter as it seemed like a more natural fit also supporting non uniform priorities across pod groups out of the box.