### PR TITLE
KEP-4671: Add performance tests to the beta graduation criteria

### DIFF
--- a/keps/sig-scheduling/4671-gang-scheduling/README.md
+++ b/keps/sig-scheduling/4671-gang-scheduling/README.md
@@ -1186,6 +1186,7 @@ In 1.36:
 - Implementing delayed preemption to avoid premature preemptions
 - Workload-aware preemption design to ensure we won't break backward compatibility with it.
 - Some real-workload controllers (e.g. Job) integrate with decoupled Workload API.
+- Performance tests are created and are being run in CI to protect against regressions.
 
 #### GA
 


### PR DESCRIPTION
#### One-line PR description
Add performance tests as a beta graduation criterion for the gang scheduling support in Kubernetes.

#### Issue link
https://github.com/kubernetes/enhancements/issues/4671

#### Other comments
Follow-up from a discussion in https://github.com/kubernetes/kubernetes/pull/136976#discussion_r2833884236.