### PR TITLE
KEP-4639: Mark as implemented with disable-supported false

### DIFF
--- a/keps/sig-node/4639-oci-volume-source/kep.yaml
+++ b/keps/sig-node/4639-oci-volume-source/kep.yaml
@@ -7,7 +7,7 @@ owning-sig: sig-node
 participating-sigs:
   - sig-node
   - sig-storage
-status: implementable
+status: implemented
 creation-date: 2024-05-17
 reviewers:
   - "@BigVan"
@@ -60,7 +60,7 @@ feature-gates:
     components:
       - kube-apiserver
       - kubelet
-disable-supported: true
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:


### PR DESCRIPTION
Mark KEP-4639 as implemented with disable-supported set to false

Refers to: https://github.com/kubernetes/enhancements/issues/4639

Reflects the stable graduation of OCI images as VolumeSource in v1.36.