### PR TITLE
KEP-5554: update KEP alpha milestone to v1.37 and update with reviews during v1.36

### DIFF
--- a/keps/sig-node/5554-in-place-update-pod-resources-alongside-static-cpu-manager-policy/kep.yaml
+++ b/keps/sig-node/5554-in-place-update-pod-resources-alongside-static-cpu-manager-policy/kep.yaml
@@ -32,13 +32,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.36"
-  beta: "v1.37"
-  stable: "v1.38"
+  alpha: "v1.37"
+  beta: "v1.38"
+  stable: "v1.39"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
One-line PR description: KEP-5554: update KEP alpha milestone to v1.37

Issue link: https://github.com/kubernetes/enhancements/issues/5554

Other comments:
- Done for clarification as per https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4072096915 we have decided it is best to postpone this KEP, aiming for v1.37 after having solved the blocking issue with CPU Manager checkpoint in a generic way as per https://github.com/kubernetes/kubernetes/pull/129719#issuecomment-4076486789.