### PR TITLE
KEP-5073: update kep.yaml lifecycle to GA/stable

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/5073.yaml
+++ b/keps/prod-readiness/sig-api-machinery/5073.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@jpbetz"
 beta:
   approver: "@jpbetz"
+stable:
+  approver: "@jpbetz"

--- a/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
+++ b/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/kep.yaml
@@ -4,8 +4,9 @@ authors:
   - "@aprindle"
   - "@yongruilin"
   - "@jpbetz"
+  - "@lalitc375"
 owning-sig: sig-api-machinery
-status: implementable
+status: implemented
 creation-date: 2024-01-21
 reviewers:
   - deads2k
@@ -18,7 +19,7 @@ see-also:
   - "/keps/sig-api-machinery/4153-declarative-validation"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
@@ -29,6 +30,7 @@ latest-milestone: "v1.36"
 milestone:
   alpha: "v1.33"
   beta: "v1.33"
+  stable: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bumps KEP 5073 kep.yaml from beta -> GA following the GA of the DeclarativeValidation feature gate

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5073

<!-- other comments or additional information -->
- Other comments: