### PR TITLE
KEP-1645: Fix typo in Upgrade / Downgrade Strategy section

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -1183,8 +1183,9 @@ in back-to-back releases.
 
 ### Upgrade / Downgrade Strategy
 
-- DNS Provider: To take advantage of MCS DNS (`<svc>.<ns>.svc.clusterset.local`), the DNS provider (e.g. CoreDNS with the multicluster plugin) must be upgraded to a version that implements the MCS DNS specification.
-- mcs-controller: That implementor of MCS API must be deployed and configured to watch `ServiceExport` resources and create/manage derived `ServiceImport` objects and their associated `EndpointSlice` objects in each importing cluster.
+The MCS API is defined as a set of CRDs (`ServiceExport` and `ServiceImport`) that are installed and managed independently of core Kubernetes components. As such, the upgrade and downgrade strategy is the responsibility of each MCS implementation. The two key components of the implementations are:
+- mcs-controller component: responsible for watching `ServiceExport` resources and managing the lifecycle of `ServiceImport` objects and their associated `EndpointSlice` resources.
+- MCS DNS component: responsible for serving the `<svc>.<ns>.svc.clusterset.local` domain, conforming to the multicluster DNS specification as defined in this KEP's [specification.md](specification.md).
 <!--
 If applicable, how will the component be upgraded and downgraded? Make sure
 this is in the test plan.
@@ -1199,8 +1200,8 @@ enhancement:
 
 ### Version Skew Strategy
 
-- mcs-controller <-> MCS CRD versions: The mcs-controller must support the installed version of the `ServiceExport` and `ServiceImport` CRDs. Backwards compatibility will be maintained in accordance with the [deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).
-- DNS provider <-> MCS DNS spec: The DNS provider must support the version of the MCS DNS specification corresponding to the deployed MCS CRDs.
+- mcs-controller component <-> MCS CRD versions: The mcs-controller component must support the installed version of the `ServiceExport` and `ServiceImport` CRDs. Backwards compatibility will be maintained in accordance with the [deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).
+- MCS DNS component <-> MCS DNS spec: The MCS DNS component must conform to the multicluster DNS specification as defined in this KEP's [specification.md](specification.md).
 <!--
 If applicable, how will the component handle version skew with other
 components? What are the guarantees? Make sure this is in the test plan.

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -1183,12 +1183,8 @@ in back-to-back releases.
 
 ### Upgrade / Downgrade Strategy
 
-Kube-proxy and DNS must be updated to a supported version before MCS services may be
-used. To take advantage of MCS DNS, the DNS provider must be upgraded to a
-version that implements the MCS spec. Kube-proxy MCS support will be guarded by
-a `MultiClusterServices` feature gate. When enabled, kube-proxy will watch the
-`serviceimports.multicluster.k8s.io` CRD. MCS support will be dynamically
-enabled and disabled as the CRD is created and deleted.
+- DNS Provider: To take advantage of MCS DNS (`<svc>.<ns>.svc.clusterset.local`), the DNS provider (e.g. CoreDNS with the multicluster plugin) must be upgraded to a version that implements the MCS DNS specification.
+- mcs-controller: That implementor of MCS API must be deployed and configured to watch `ServiceExport` resources and create/manage derived `ServiceImport` objects and their associated `EndpointSlice` objects in each importing cluster.
 <!--
 If applicable, how will the component be upgraded and downgraded? Make sure
 this is in the test plan.
@@ -1203,9 +1199,8 @@ enhancement:
 
 ### Version Skew Strategy
 
-Kube-proxy and DNS must be upgraded before new MCS API versions may be used.
-Backwards compatibility will be maintained in accordance with the [deprecation
-policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).
+- mcs-controller <-> MCS CRD versions: The mcs-controller must support the installed version of the `ServiceExport` and `ServiceImport` CRDs. Backwards compatibility will be maintained in accordance with the [deprecation policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).
+- DNS provider <-> MCS DNS spec: The DNS provider must support the version of the MCS DNS specification corresponding to the deployed MCS CRDs.
 <!--
 If applicable, how will the component handle version skew with other
 components? What are the guarantees? Make sure this is in the test plan.

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -1183,7 +1183,7 @@ in back-to-back releases.
 
 ### Upgrade / Downgrade Strategy
 
-Kube-proxy and must be updated to a supported version before MCS services may be
+Kube-proxy and DNS must be updated to a supported version before MCS services may be
 used. To take advantage of MCS DNS, the DNS provider must be upgraded to a
 version that implements the MCS spec. Kube-proxy MCS support will be guarded by
 a `MultiClusterServices` feature gate. When enabled, kube-proxy will watch the


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
I think the missing word is "DNS" here as:                                                           
1. The Version Skew Strategy section in the same doc says: "Kube-proxy and DNS must be upgraded before new MCS API versions may be used."                                     
2. The context of the paragraph discusses about DNS: "To take advantage of MCS DNS, the DNS provider must be upgraded..." 



