### PR TITLE
KEP-5729: Update ResourceClaim Support for Workloads for beta in 1.37

### DIFF
--- a/keps/prod-readiness/sig-scheduling/5729.yaml
+++ b/keps/prod-readiness/sig-scheduling/5729.yaml
@@ -1,3 +1,5 @@
 kep-number: 5729
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/README.md
+++ b/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/README.md
@@ -1202,6 +1202,19 @@ PodGroup. It will do this even if there is already a PodGroup reference in the
 `status.reservedFor` list. This leads to the challenge described in the previous
 section.
 
+If the API server is on a version that supports the feature, but
+kube-controller-manager is not, then the ResourceClaim controller may observe
+PodGroups that define `spec.resourceClaims`. When Pods contain matching claims,
+the intent is that those claims are generated for the PodGroup instead of each
+Pod. Even when this feature is disabled, the ResourceClaim controller will check
+a Pod's claims against its PodGroup. If the controller _would have_ created a
+ResourceClaim for the PodGroup _if_ the feature _was_ enabled, then it will
+return an error. Users are expected to restart kube-controller-manager with the
+feature enabled to generate a ResourceClaim for the PodGroup. If the user
+intended to generate a ResourceClaim for that Pod, then the user has to recreate
+the PodGroup without the resource claim and all of its member Pods with the
+resource claim.
+
 ## Production Readiness Review Questionnaire
 
 <!--

--- a/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/README.md
+++ b/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/README.md
@@ -137,7 +137,6 @@ tags, and then generate with `hack/update-toc.sh`.
 - [Alternatives](#alternatives)
   - [Increase the size limit on the <code>status.reservedFor</code> field](#increase-the-size-limit-on-the-statusreservedfor-field)
   - [Allow ResourceClaims to be reserved for any object](#allow-resourceclaims-to-be-reserved-for-any-object)
-- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
 <!-- /toc -->
 
 ## Release Signoff Checklist
@@ -419,8 +418,8 @@ The following API changes will be made:
 
 - The Workload and PodGroup APIs will be updated to include references to
   ResourceClaims and ResourceClaimTemplates, like Pods.
-- The Pod API will be updated to include references to claims listed in its
-  PodGroup.
+- The Pod API will include new semantics for the existing API fields to refer to
+  claims made by its PodGroup.
 
 #### Workload
 
@@ -432,21 +431,27 @@ type PodGroupTemplate struct {
 	...
 
 	// ResourceClaims defines which ResourceClaims may be shared among Pods in
-	// the group. Pods must reference these claims in order to consume the
-	// allocated devices.
+	// the group. Pods consume the devices allocated to a PodGroup's claim by
+	// defining a claim in its own Spec.ResourceClaims that matches the
+	// PodGroup's claim exactly. The claim must have the same name and refer to
+	// the same ResourceClaim or ResourceClaimTemplate.
 	//
 	// This is an alpha-level field and requires that the
-	// WorkloadPodGroupResourceClaimTemplate feature gate is enabled.
+	// DRAWorkloadResourceClaims feature gate is enabled.
 	//
 	// This field is immutable.
 	//
+	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
 	// +listType=map
 	// +listMapKey=name
-	// +featureGate=WorkloadPodGroupResourceClaimTemplate
-	// +optional
-	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty"`
+	// +k8s:optional
+	// +k8s:listType=map
+	// +k8s:listMapKey=name
+	// +k8s:maxItems=4
+	// +featureGate=DRAWorkloadResourceClaims
+	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 }
 
 // PodGroupResourceClaim references exactly one ResourceClaim, either directly
@@ -454,11 +459,17 @@ type PodGroupTemplate struct {
 // for the PodGroup.
 //
 // It adds a name to it that uniquely identifies the ResourceClaim inside the PodGroup.
-// Pods that need access to the ResourceClaim reference it with this name.
+// Pods that need access to the ResourceClaim define a matching reference in its
+// own Spec.ResourceClaims. The Pod's claim must match all fields of the
+// PodGroup's claim exactly.
 type PodGroupResourceClaim struct {
 	// Name uniquely identifies this resource claim inside the PodGroup.
 	// This must be a DNS_LABEL.
-	Name string `json:"name"`
+	//
+	// +required
+	// +k8s:required
+	// +k8s:format=k8s-short-name
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// ResourceClaimName is the name of a ResourceClaim object in the same
 	// namespace as this PodGroup. The ResourceClaim will be reserved for the
@@ -466,6 +477,11 @@ type PodGroupResourceClaim struct {
 	//
 	// Exactly one of ResourceClaimName and ResourceClaimTemplateName must
 	// be set.
+	//
+	// +optional
+	// +k8s:optional
+	// +k8s:unionMember
+	// +k8s:format=k8s-long-name
 	ResourceClaimName *string `json:"resourceClaimName,omitempty"`
 
 	// ResourceClaimTemplateName is the name of a ResourceClaimTemplate
@@ -475,7 +491,7 @@ type PodGroupResourceClaim struct {
 	// be bound to this PodGroup. When this PodGroup is deleted, the ResourceClaim
 	// will also be deleted. The PodGroup name and resource name, along with a
 	// generated component, will be used to form a unique name for the
-	// ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+	// ResourceClaim, which will be recorded in podgroup.status.resourceClaimStatuses.
 	//
 	// This field is immutable and no changes will be made to the
 	// corresponding ResourceClaim by the control plane after creating the
@@ -483,6 +499,11 @@ type PodGroupResourceClaim struct {
 	//
 	// Exactly one of ResourceClaimName and ResourceClaimTemplateName must
 	// be set.
+	//
+	// +optional
+	// +k8s:optional
+	// +k8s:unionMember
+	// +k8s:format=k8s-long-name
 	ResourceClaimTemplateName *string `json:"resourceClaimTemplateName,omitempty"`
 }
 ```
@@ -497,48 +518,130 @@ type PodGroupSpec struct {
 	...
 
 	// ResourceClaims defines which ResourceClaims may be shared among Pods in
-	// the group. Pods must reference these claims in order to consume the
-	// allocated devices.
+	// the group. Pods consume the devices allocated to a PodGroup's claim by
+	// defining a claim in its own Spec.ResourceClaims that matches the
+	// PodGroup's claim exactly. The claim must have the same name and refer to
+	// the same ResourceClaim or ResourceClaimTemplate.
 	//
 	// This is an alpha-level field and requires that the
-	// WorkloadPodGroupResourceClaimTemplate feature gate is enabled.
+	// DRAWorkloadResourceClaims feature gate is enabled.
 	//
 	// This field is immutable.
 	//
+	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
 	// +listType=map
 	// +listMapKey=name
-	// +featureGate=WorkloadPodGroupResourceClaimTemplate
+	// +k8s:optional
+	// +k8s:listType=map
+	// +k8s:listMapKey=name
+	// +k8s:maxItems=4
+	// +k8s:immutable
+	// +featureGate=DRAWorkloadResourceClaims
+	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+```
+
+Similar to Pods, PodGroups will include a new `status.resourceClaimStatuses`
+field to resolve ResourceClaimTemplate references in `spec.resourceClaims` to
+the exact ResourceClaim generated for the PodGroup:
+
+```go
+// PodGroupStatus represents information about the status of a pod group.
+type PodGroupStatus struct {
+	...
+
+	// Status of resource claims.
 	// +optional
-	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge,retainKeys
+	// +listType=map
+	// +listMapKey=name
+	// +k8s:optional
+	// +k8s:listType=map
+	// +k8s:listMapKey=name
+	// +k8s:maxItems=4
+	// +featureGate=DRAWorkloadResourceClaims
+	ResourceClaimStatuses []PodGroupResourceClaimStatus `json:"resourceClaimStatuses,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
+}
+
+// PodGroupResourceClaimStatus is stored in the PodGroupStatus for each
+// PodGroupResourceClaim which references a ResourceClaimTemplate. It stores the
+// generated name for the corresponding ResourceClaim.
+type PodGroupResourceClaimStatus struct {
+	// Name uniquely identifies this resource claim inside the PodGroup. This
+	// must match the name of an entry in podgroup.spec.resourceClaims, which
+	// implies that the string must be a DNS_LABEL.
+	//
+	// +required
+	Name string `json:"name" protobuf:"bytes,1,name=name"`
+
+	// ResourceClaimName is the name of the ResourceClaim that was generated for
+	// the PodGroup in the namespace of the PodGroup. If this is unset, then
+	// generating a ResourceClaim was not necessary. The
+	// podgroup.spec.resourceClaims entry can be ignored in this case.
+	//
+	// +optional
+	// +k8s:optional
+	// +k8s:format=k8s-long-name
+	ResourceClaimName *string `json:"resourceClaimName,omitempty"`
 }
 ```
 
 #### Pod
 
-When a PodGroup includes claims, the `name` of a claim in the
-PodGroup can be used on Pods in the group to associate the PodGroup's dedicated
-ResourceClaim. This complements existing references to ResourceClaims and
-ResourceClaimTemplates.
+The existing DRA API fields for Pods remain unchanged. To request a
+ResourceClaim reserved for its PodGroup, a Pod specifies a claim in
+`spec.resourceClaims` that exactly matches a claim made in its PodGroup's
+`spec.resourceClaims`. The `name`, `resourceClaimName`, and
+`resourceClaimTemplateName` fields must match between the Pod's and the
+PodGroup's claim. If a claim made by a Pod does not exactly match one made by
+its PodGroup, then the ResourceClaim is reserved (and for
+ResourceClaimTemplates, generated) for the Pod.
 
-```go
-// PodResourceClaim references exactly one ResourceClaim, either directly,
-// by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
-// for the pod, or by naming a claim made for a PodGroup.
-//
-// It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
-// Containers that need access to the ResourceClaim reference it with this name.
-type PodResourceClaim struct {
-	...
+The `status.resourceClaimStatuses` field continues to include the names of
+ResourceClaims generated from ResourceClaimTemplates referenced in
+`spec.resourceClaimNames` whether they are generated
+for the Pod or the PodGroup. Status for ResourceClaims generated for the
+PodGroup is also recorded in the PodGroup's `status.resourceClaimStatuses`.
 
-	// PodGroupResourceClaim refers to the name of a claim associated
-	// with this pod's PodGroup.
-	//
-	// Exactly one of ResourceClaimName, ResourceClaimTemplateName,
-	// or PodGroupResourceClaim must be set.
-	PodGroupResourceClaim *string `json:"podGroupResourceClaim,omitempty"`
-}
+The following example demonstrates the matching semantics:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha2
+kind: PodGroup
+metadata:
+  name: podgroup
+spec:
+  resourceClaims:
+  - name: pg-claim
+    resourceClaimName: my-claim
+  - name: pg-claim-template
+    resourceClaimTemplateName: my-claim-template
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+spec:
+  resourceClaims:
+  # Matches the PodGroup's claim, reserved for the PodGroup:
+  - name: pg-claim
+    resourceClaimName: my-claim
+
+  # Matches the PodGroup's claim, reserved for the PodGroup, ResourceClaim is
+  # generated for the PodGroup and shared by its Pods:
+  - name: pg-claim-template
+    resourceClaimTemplateName: my-claim-template
+
+  # Does not match any PodGroup claim, reserved for the Pod:
+  - name: pod-claim
+    resourceClaimName: my-claim
+
+  # Does not match any PodGroup claim, generated and reserved for the Pod:
+  - name: pg-claim-template
+    resourceClaimTemplateName: my-other-claim-template
 ```
 
 #### Example
@@ -581,8 +684,8 @@ spec:
 The true workload API defines how ResourceClaims and ResourceClaimTemplates
 relate to groups of Pods. If the user is responsible for defining the Pods'
 `spec.resourceClaims` in a Pod template, then the PodGroups'
-`spec.resourceClaims[].name`s must be deterministic for the user to be able to
-reference them in the Pod spec.
+`spec.resourceClaims` must be deterministic for the user to be able to
+define matching claims in the Pod spec.
 
 The true workload controller then creates the following Workload API resources
 based on the true workload's definition:
@@ -595,13 +698,7 @@ metadata:
   namespace: default
 spec:
   podGroupTemplates:
-  - name: group-1
-    schedulingPolicy:
-      basic: {}
-    resourceClaims:
-    - name: pg-claim
-      resourceClaimTemplateName: pg-claim-template
-  - name: group-2
+  - name: group
     schedulingPolicy:
       basic: {}
     resourceClaims:
@@ -615,8 +712,11 @@ metadata:
   namespace: default
 spec:
   podGroupTemplateRef:
-    workloadName: my-workload
-    podGroupTemplateName: group-1
+    workload:
+      workloadName: my-workload
+      podGroupTemplateName: group
+  schedulingPolicy:
+    basic: {}
   resourceClaims:
   - name: pg-claim
     resourceClaimTemplateName: pg-claim-template
@@ -628,8 +728,11 @@ metadata:
   namespace: default
 spec:
   podGroupTemplateRef:
-    workloadName: my-workload
-    podGroupTemplateName: group-2
+    workload:
+      workloadName: my-workload
+      podGroupTemplateName: group
+  schedulingPolicy:
+    basic: {}
   resourceClaims:
   - name: pg-claim
     resourceClaimTemplateName: pg-claim-template
@@ -654,10 +757,10 @@ spec:
         image: "registry.k8s.io/pause:3.6"
         resources:
           claims:
-          - name: resource
+          - name: pg-claim
       resourceClaims:
-      - name: resource
-        podGroupResourceClaim: pg-claim
+      - name: pg-claim
+        resourceClaimTemplateName: pg-claim-template
       schedulingGroup:
         podGroupName: my-podgroup-1
 ---
@@ -681,10 +784,10 @@ spec:
         image: "registry.k8s.io/pause:3.6"
         resources:
           claims:
-          - name: resource
+          - name: pg-claim
       resourceClaims:
-      - name: resource
-        podGroupResourceClaim: pg-claim
+      - name: pg-claim
+        resourceClaimTemplateName: pg-claim-template
       schedulingGroup:
         podGroupName: my-podgroup-2
 ```
@@ -694,9 +797,9 @@ different PodGroups.
 Each group refers to the same ResourceClaimTemplate,
 `pg-claim-template`. This single ResourceClaimTemplate forms the basis of two
 different ResourceClaims which will be created by the ResourceClaim controller:
-one for each PodGroup. The Pod templates in the Deployments include a reference
-to the claim listed for the PodGroup, which ultimately resolves to its
-PodGroup's ResourceClaim. The result is that with a single
+one for each PodGroup. The Pod templates in the Deployments include a claim
+matching their PodGroup's claim, which ultimately resolves to the ResourceClaim
+generated for the PodGroup. The result is that with a single
 ResourceClaimTemplate, Pods in the same group all share the exact same allocated
 device, while Pods in the other group use an equivalent, but separately
 allocated, device.
@@ -716,16 +819,13 @@ When a PodGroup is created which references a ResourceClaimTemplate, the
 ResourceClaim controller will create a ResourceClaim from that template if one
 does not already exist for that PodGroup. Generated ResourceClaims will be owned (through
 `metadata.ownerReferences`) by the PodGroup and annotated with
-`resource.kubernetes.io/podgroup-claim-name` where the value is the name of the
+`resource.kubernetes.io/pod-claim-name` where the value is the name of the
 claim from the PodGroup's `spec.resourceClaims[].name` to facilitate mapping a
 single PodGroup claim to the ResourceClaim generated for its PodGroup. When a
 Pod is created which requests a claim from its PodGroup, the name of the
 ResourceClaim generated for the PodGroup's claim
 will be recorded in the Pod's `status.resourceClaimStatuses` like
-ResourceClaims generated for Pods. Like the
-`resource.kubernetes.io/podgroup-claim-name` annotation,
-`resource.kubernetes.io/podgroup-claim-name` is only to be used by the
-controller and will not be documented as part of the public API.
+ResourceClaims generated for Pods.
 
 #### Delete
 
@@ -742,27 +842,36 @@ deleting the ResourceClaim once its owning PodGroup is deleted.
 Generated and standalone ResourceClaims referenced by a PodGroup remain
 unallocated until kube-scheduler allocates the ResourceClaim by setting
 `status.allocation` for the first Pod in the PodGroup that references the
-PodGroup's claim. When a Pod's claim is requested through
-`podGroupResourceClaim`, the ResourceClaim's `status.reservedFor` list will
+PodGroup's claim. When a Pod's claim matches a claim made by its PodGroup,
+the ResourceClaim's `status.reservedFor` list will
 reference the PodGroup instead of each individual Pod.
 
-The name of a ResourceClaim referenced by a PodGroup via `resourceClaimName`
-will be recorded in the `status.resourceClaimStatuses` of each Pod that
-requests that PodGroup's claim. Along with names of ResourceClaims generated
-from templates (for the Pod or its PodGroup), this keeps all information about
-exactly which ResourceClaims are requested by the Pod in the Pod itself so the
-kubelet does not need to look up a Pod's PodGroup.
+The names of all ResourceClaims associated with a Pod continue to be represented
+in the Pod, no matter if those ResourceClaims are reserved for the Pod or its
+PodGroup. The names of ResourceClaims referenced via `resourceClaim` continue to
+match that value, and the names of ResourceClaims generated from
+ResourceClaimTemplates continue to be recorded in the Pod's
+`status.resourceClaimStatuses`. The kubelet does not need to look up a Pod's
+PodGroup to find all of the Pod's ResourceClaims.
 
 #### Deallocate
 
 The ResourceClaim controller will continue to deallocate claims when there are
 no entries in the ResourceClaim's `status.reservedFor`. References to PodGroups
 in `status.reservedFor` are removed after the PodGroup is deleted. PodGroup
-deletion should be gated by a finalizer managed by the creator of the PodGroup
+deletion is gated by a finalizer managed by kube-controller-manager
 to prevent the PodGroup from being removed from `status.reservedFor` before all
 of its Pods are done using the ResourceClaim. When no more Pods in the group are
-expected to run, the creator of the PodGroup is responsible for removing the
-finalizer and deleting the PodGroup.
+expected to run, the creator of the PodGroup is responsible for deleting it to
+free up the devices allocated by its ResourceClaims.
+
+Claims reserved for a PodGroup can also be deallocated by the scheduler in the
+DynamicResource plugin's `PostFilter` phase. In `PostFilter`, the
+DynamicResources plugin uses the scheduler's internal view of PodGroups to
+determine if any of the group's Pods are scheduled. When no Pods in the group
+are scheduled, the scheduler removes the PodGroup from the claim's
+`status.reservedFor`. A future invocation of `PostFilter` will deallocate the
+ResourceClaim if its `status.reservedFor` list is still empty.
 
 ### Determining Allowed Pods for a ResourceClaim
 
@@ -773,7 +882,7 @@ only the name in the reference must match a Pod's
 being deleted before any of its Pods, a reference to the name of a PodGroup in a
 Pod will always refer to the exact same PodGroup, i.e. the PodGroup cannot be
 deleted and recreated with the same name without all of its Pods also being
-deleted in the meantime or if its finalizer is manually removed.
+deleted or terminating in the meantime or if its finalizer is manually removed.
 
 ### Finding Pods Using a ResourceClaim
 
@@ -792,18 +901,6 @@ are scheduled to use the ResourceClaim. It is possible to have Pods that
 reference a PodGroup that has been allocated a claim, but haven't
 yet been scheduled. This distinction is important for some of the usages of the
 `status.reservedFor` list described above:
-
-<!-- TBD if status.allocation.reservedForAnyPod will be used
-1. If the kubelet sees that the `status.allocation.ReservedForAnyPod` is set, it
-   will skip the check that the Pod is listed in the `ReservedFor` list and just
-   run the pod.
--->
-
-1. If the DRA scheduler plugin is trying to find candidates for deallocation in
-   the `PostFilter` function and sees a ResourceClaim with a non-Pod reference,
-   it will not attempt to deallocate. The plugin has no way to know how many
-   Pods are actually consuming the ResourceClaim without the explicit list in
-   `status.reservedFor` list and therefore it will not be safe to deallocate.
 
 1. The device_taint_eviction controller will use the list of Pods referencing
    the PodGroup to determine the list of pods that needs to be
@@ -895,7 +992,7 @@ This can be done with:
 
 New integration tests will verify:
 - New API fields in Pod and PodGroup are persisted or rejected correctly
-  depending on the value of the `WorkloadPodGroupResourceClaimTemplate` feature
+  depending on the value of the `DRAWorkloadResourceClaims` feature
   gate.
 - ResourceClaimTemplates specified for PodGroups result in the correct
   ResourceClaims being allocated for the correct Pods.
@@ -908,6 +1005,11 @@ New integration tests will verify:
 
 Additionally, scheduler_perf tests will be added, aiming for the same thresholds
 as existing DRA tests.
+
+Integration tests added for alpha:
+
+- [TestDRA/all/WorkloadResourceClaims](https://github.com/kubernetes/kubernetes/blob/b5a943f629904bda73a8f6784ad3cd8325ead57c/test/integration/dra/workload_resource_claims.go#L38): [integration master](https://testgrid.k8s.io/sig-release-master-blocking#integration-master&include-filter-by-regex=dra&include-filter-by-regex=%2Fdra%2F&include-filter-by-regex=%2Fintegration%2Fdra%2F), [triage search](https://storage.googleapis.com/k8s-triage/index.html?pr=1&text=TestDRA%2F%5Cw%2B%2FWorkloadResourceClaims&job=kubernetes-integration)
+
 
 ##### e2e tests
 
@@ -942,6 +1044,13 @@ PodGroup.
 - When the PodGroup has been deleted, then the ResourceClaim
   is deallocated, and eventually deleted.
 
+e2e tests added for alpha: [SIG Node](https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-kind-dra-all&include-filter-by-regex=DRAWorkloadResourceClaims), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=DRAWorkloadResourceClaims)
+
+- [allocates devices for PodGroups](https://github.com/kubernetes/kubernetes/blob/b5a943f629904bda73a8f6784ad3cd8325ead57c/test/e2e/dra/dra.go#L2142)
+- [generates claims from templates for PodGroups](https://github.com/kubernetes/kubernetes/blob/b5a943f629904bda73a8f6784ad3cd8325ead57c/test/e2e/dra/dra.go#L2153)
+- [NoSchedule keeps pod with PodGroup claim pending](https://github.com/kubernetes/kubernetes/blob/b5a943f629904bda73a8f6784ad3cd8325ead57c/test/e2e/dra/dra.go#L2276)
+- [NoSchedule can be tolerated for PodGroup claims](https://github.com/kubernetes/kubernetes/blob/b5a943f629904bda73a8f6784ad3cd8325ead57c/test/e2e/dra/dra.go#L2285)
+- [DeviceTaintRule evicts pod with PodGroup claim](https://github.com/kubernetes/kubernetes/blob/b5a943f629904bda73a8f6784ad3cd8325ead57c/test/e2e/dra/dra.go#L2299)
 
 ### Graduation Criteria
 
@@ -1086,7 +1195,8 @@ kubelet will refuse to run those Pods since it will still check whether the
 Pods are referenced in the `status.reservedFor` list.
 
 If the API server is on a version that supports the feature, but the scheduler
-is not, the scheduler will not know about the new fields added, so it will put
+is not, the scheduler will not know how to match a Pod's claim with a claim made
+by its PodGroup, so it will put
 the reference to the Pod in the `status.reservedFor` list rather than the
 PodGroup. It will do this even if there is already a PodGroup reference in the
 `status.reservedFor` list. This leads to the challenge described in the previous
@@ -1135,7 +1245,7 @@ well as the [existing list] of feature gates.
 -->
 
 - [X] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: WorkloadPodGroupResourceClaimTemplate
+  - Feature gate name: DRAWorkloadResourceClaims
   - Components depending on the feature gate:
     - kube-apiserver
     - kube-controller-manager
@@ -1403,12 +1513,7 @@ Describe them, providing:
 -->
 
 This feature adds a new `spec.resourceClaims` list to the PodGroup API. It will
-have the same limits as the Pod API's `spec.resourceClaims`.
-
-The Pod API adds a new `spec.resourceClaims[].podGroupResourceClaim` field which
-is mutually exclusive with its sibling `resourceClaimName` and
-`resourceClaimTemplate` fields so it will not meaningfully impact the size of a
-Pod.
+be limited to 4 items.
 
 The size of a ResourceClaim's `spec.reservedFor` list will be reduced
 significantly when many Pods sharing the same claim make that claim through a
@@ -1504,6 +1609,7 @@ Major milestones might include:
 1.36:
   - 2025-12-12: KEP first draft published for review
   - 2026-01-28: Combined with [KEP-5194]
+  - 2026-03-23: [Initial implementation](https://github.com/kubernetes/kubernetes/pull/136989) merged
 
 ## Drawbacks
 
@@ -1549,14 +1655,6 @@ longer needs to be as flexible since true workloads can integrate with those
 common APIs. In order to integrate with this feature, true workload controllers
 create and delete PodGroup objects (which will also provide many additional
 features) and don't have to explicitly manage ResourceClaims.
-
-## Infrastructure Needed (Optional)
-
-<!--
-Use this section if you need things from the project/SIG. Examples include a
-new subproject, repos requested, or GitHub details. Listing these here allows a
-SIG to get the process for these resources started right away.
--->
 
 
 [KEP-4671]: https://kep.k8s.io/4671

--- a/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/README.md
+++ b/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/README.md
@@ -25,7 +25,7 @@ To get started with this template:
 - [X] **Fill out as much of the kep.yaml file as you can.**
   At minimum, you should fill in the "Title", "Authors", "Owning-sig",
   "Status", and date-related fields.
-- [ ] **Fill out this file as best you can.**
+- [X] **Fill out this file as best you can.**
   At minimum, you should fill in the "Summary" and "Motivation" sections.
   These should be easy if you've preflighted the idea of the KEP with the
   appropriate SIG(s).
@@ -436,7 +436,7 @@ type PodGroupTemplate struct {
 	// PodGroup's claim exactly. The claim must have the same name and refer to
 	// the same ResourceClaim or ResourceClaimTemplate.
 	//
-	// This is an alpha-level field and requires that the
+	// This is a beta-level field and requires that the
 	// DRAWorkloadResourceClaims feature gate is enabled.
 	//
 	// This field is immutable.
@@ -523,7 +523,7 @@ type PodGroupSpec struct {
 	// PodGroup's claim exactly. The claim must have the same name and refer to
 	// the same ResourceClaim or ResourceClaimTemplate.
 	//
-	// This is an alpha-level field and requires that the
+	// This is a beta-level field and requires that the
 	// DRAWorkloadResourceClaims feature gate is enabled.
 	//
 	// This field is immutable.
@@ -609,7 +609,7 @@ PodGroup is also recorded in the PodGroup's `status.resourceClaimStatuses`.
 The following example demonstrates the matching semantics:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: podgroup
@@ -691,7 +691,7 @@ The true workload controller then creates the following Workload API resources
 based on the true workload's definition:
 
 ```yaml
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: Workload
 metadata:
   name: my-workload
@@ -705,32 +705,30 @@ spec:
     - name: pg-claim
       resourceClaimTemplateName: pg-claim-template
 ---
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: my-podgroup-1
   namespace: default
 spec:
-  podGroupTemplateRef:
-    workload:
-      workloadName: my-workload
-      podGroupTemplateName: group
+  workloadRef:
+    workloadName: my-workload
+    templateName: group
   schedulingPolicy:
     basic: {}
   resourceClaims:
   - name: pg-claim
     resourceClaimTemplateName: pg-claim-template
 ---
-apiVersion: scheduling.k8s.io/v1alpha2
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PodGroup
 metadata:
   name: my-podgroup-2
   namespace: default
 spec:
-  podGroupTemplateRef:
-    workload:
-      workloadName: my-workload
-      podGroupTemplateName: group
+  workloadRef:
+    workloadName: my-workload
+    templateName: group
   schedulingPolicy:
     basic: {}
   resourceClaims:
@@ -866,12 +864,18 @@ expected to run, the creator of the PodGroup is responsible for deleting it to
 free up the devices allocated by its ResourceClaims.
 
 Claims reserved for a PodGroup can also be deallocated by the scheduler in the
-DynamicResource plugin's `PostFilter` phase. In `PostFilter`, the
+DynamicResource plugin's `Unreserve` phase when scheduling of a PodGroup failed
+and they are not reserved for any other resources (like other PodGroups). In that phase, the
 DynamicResources plugin uses the scheduler's internal view of PodGroups to
 determine if any of the group's Pods are scheduled. When no Pods in the group
 are scheduled, the scheduler removes the PodGroup from the claim's
-`status.reservedFor`. A future invocation of `PostFilter` will deallocate the
-ResourceClaim if its `status.reservedFor` list is still empty.
+`status.reservedFor`.
+
+The DynamicResources plugin will also implement the `PostFilter` phase of the
+PodGroup scheduling cycle which will perform a similar function to the Pod-level
+implementation. When a PodGroup fails to schedule, `PostFilter` will deallocate
+and unreserve the PodGroup's ResourceClaims which are reserved only for that
+PodGroup or for nobody.
 
 ### Determining Allowed Pods for a ResourceClaim
 
@@ -1349,12 +1353,43 @@ rollout. Similarly, consider large clusters and how enablement/disablement
 will rollout across nodes.
 -->
 
+The ResourceClaim controller run by kube-controller-manager may see a PodGroup
+with `spec.resourceClaims` even when the feature is disabled if a rollout has
+already enabled the feature for at least one kube-apiserver instance. When a Pod
+makes a claim for one of its PodGroup's ResourceClaimTemplates, whether the
+ResourceClaim controller should create a ResourceClaim once for the PodGroup or
+for each individual Pod is unclear. In Kubernetes 1.36, the controller creates
+one ResourceClaim for each Pod when the feature is disabled. In Kubernetes 1.37,
+the controller will not create a ResourceClaim for a Pod's claim which matches
+its PodGroup's when the feature is disabled.
+
+If a PodGroup has lingering `spec.resourceClaims` references to
+ResourceClaimTemplates meant to be replicated for each Pod, then an upgrade to
+Kubernetes 1.37 will not create new ResourceClaims for new Pods in the PodGroup
+with a matching claim.
+
+When downgrading to Kubernetes 1.36 with the feature disabled or disabling the
+feature on a 1.36 cluster, a ResourceClaimTemplate meant for a PodGroup will be
+replicated for each Pod while the feature is enabled for kube-apiserver and
+disabled for kube-controller-manager.
+
 ###### What specific metrics should inform a rollback?
 
 <!--
 What signals should users be paying attention to when the feature is young
 that might indicate a serious problem?
 -->
+
+A sudden increase in the `dynamic_resource_allocation_resourceclaim_creates_total`
+metric could mean that a ResourceClaimTemplate meant to be created for each
+PodGroup is being created for each Pod.
+
+An increase in the `scheduler_pending_pods` metric may indicate that the
+controller is not creating ResourceClaims that grouped Pods need in order to be
+schedulable.
+
+An increase in the `workqueue_retries_total{name="resource_claim"}` metric may
+indicate that the ResourceClaim controller is repeatedly running into errors.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
@@ -1364,11 +1399,43 @@ Longer term, we may want to require automated upgrade/rollback tests, but we
 are missing a bunch of machinery and tooling and can't do that now.
 -->
 
+New automated upgrade/downgrade tests will exercise the following scenario where
+a Kubernetes 1.36 cluster is upgraded to 1.37 and then rolled back to 1.36:
+
+1. Create a cluster on the older version with the DRAWorkloadResourceClaims
+   feature enabled.
+1. Create a PodGroup `group-1` with member Pods `pod-1` and `pod-2`. The
+   PodGroup and Pods define matching resource claims for the
+   ResourceClaimTemplate named `template-1`.
+1. Verify that one ResourceClaim is generated from `template-1` and is reserved
+   for PodGroup `group-1`. Verify that Pods `pod-1` and `pod-2` are using the
+   same generated ResourceClaim.
+1. Upgrade the cluster to the new version.
+1. Create Pod `pod-3` as a member of PodGroup `group-1`.
+1. Verify that the same generated ResourceClaim from `template-1` stays reserved
+   only for PodGroup `group-1` and that no other ResourceClaims are generated.
+1. Verify that `pod-3` uses the same generated ResourceClaim as `pod-1` and
+   `pod-2`.
+1. Delete Pod `pod-2`.
+1. Verify that the generated ResourceClaim stays allocated and reserved only for
+   PodGroup `group-1`.
+1. Roll back the cluster upgrade.
+1. Create Pod `pod-4` as a member of PodGroup `group-1`.
+1. Verify that the same generated ResourceClaim from `template-1` stays reserved
+   only for PodGroup `group-1` and that no other ResourceClaims are generated.
+1. Verify that `pod-4` uses the same generated ResourceClaim as `pod-1` and
+   `pod-3`.
+1. Delete Pod `pod-3`.
+1. Verify that the generated ResourceClaim stays allocated and reserved only for
+   PodGroup `group-1`.
+
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
 <!--
 Even if applying deprecation policies, they may still surprise some users.
 -->
+
+No.
 
 ### Monitoring Requirements
 
@@ -1387,6 +1454,16 @@ checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
 
+New `owner_api_group` and `owner_api_kind` labels will be added to the
+`dynamic_resource_allocation_resourceclaim_creates_total` metric to distinguish between claims
+created for a PodGroup or a Pod. A query for
+`dynamic_resource_allocation_resourceclaim_creates_total{owner_api_group="scheduling.k8s.io", owner_api_kind="PodGroup"}`
+shows how many ResourceClaims have been created for PodGroups.
+
+Pods using the feature can be identified by looking for the ResourceClaims in
+its `status.resourceClaimStatuses` whose `status.reservedFor` lists any items
+with `apiGroup` set to `scheduling.k8s.io` and `resource` set to `podgroups`.
+
 ###### How can someone using this feature know that it is working for their instance?
 
 <!--
@@ -1398,13 +1475,23 @@ and operation of this feature.
 Recall that end users cannot usually observe component logs or access metrics.
 -->
 
+<!--
 - [ ] Events
   - Event Reason: 
-- [ ] API .status
-  - Condition name: 
-  - Other field: 
+-->
+- [X] API
+  - Condition name: None
+  - Other field:
+    - When one of a Pod's `spec.resourceClaims` matches one of its PodGroup's
+      `spec.resourceClaims`, the ResourceClaim referenced in the Pod's
+      `status.resourceClaimStatuses` for that claim contains the PodGroup in its
+      `status.reservedFor` and not the Pod.
+    - ResourceClaims created from ResourceClaimTemplates for a PodGroup list the
+      PodGroup in its `metadata.ownerReferences`.
+<!--
 - [ ] Other (treat as last resort)
   - Details:
+-->
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
@@ -1423,18 +1510,27 @@ These goals will help you determine what you need to measure (SLIs) in the next
 question.
 -->
 
+This feature does not affect the existing SLOs for Pods using ResourceClaims as
+described by [KEP-4381].
+
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
 <!--
 Pick one more of these and delete the rest.
 -->
 
-- [ ] Metrics
-  - Metric name:
+- [X] Metrics
+  - Metric name: `dynamic_resource_allocation_resourceclaim_creates_total{owner_api_group="scheduling.k8s.io", owner_api_kind="PodGroup"}`,
+    `workqueue_*{name="resource_claim"}`
+  <!--
   - [Optional] Aggregation method:
+  -->
   - Components exposing the metric:
+    - kube-controller-manager
+<!--
 - [ ] Other (treat as last resort)
   - Details:
+-->
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
@@ -1442,6 +1538,8 @@ Pick one more of these and delete the rest.
 Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
 implementation difficulties, etc.).
 -->
+
+No.
 
 ### Dependencies
 
@@ -1465,6 +1563,8 @@ and creating new ones, as well as about cluster-level services (e.g. DNS):
       - Impact of its outage on the feature:
       - Impact of its degraded performance or high-error rates on the feature:
 -->
+
+No.
 
 ### Scalability
 
@@ -1589,6 +1689,19 @@ details). For now, we leave it here.
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
+When the API server is unavailable, the ResourceClaim controller is unable to
+see new Pods and PodGroups and cannot create ResourceClaims. Pods requiring
+those ResourceClaims in order to become schedulable will remain unschedulable
+until the API server becomes available again.
+
+Updates by kube-scheduler to ResourceClaims' `status.reservedFor` fields will
+also fail while the API server is unavailable. It will retry those updates with
+backoff until they succeed.
+
+The kubelet is still able to start Pods when they have already been scheduled,
+their `status.resourceClaimStatuses` are up to date, and their ResourceClaims'
+statuses are up to date.
+
 ###### What are other known failure modes?
 
 <!--
@@ -1603,6 +1716,8 @@ For each of them, fill in the following information by copying the below templat
       Not required until feature graduated to beta.
     - Testing: Are there any tests for failure mode? If not, describe why.
 -->
+
+No other known failure modes.
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
@@ -1623,6 +1738,8 @@ Major milestones might include:
   - 2025-12-12: KEP first draft published for review
   - 2026-01-28: Combined with [KEP-5194]
   - 2026-03-23: [Initial implementation](https://github.com/kubernetes/kubernetes/pull/136989) merged
+1.37:
+  - 2026-05-11: Beta promotion proposed
 
 ## Drawbacks
 
@@ -1670,6 +1787,7 @@ create and delete PodGroup objects (which will also provide many additional
 features) and don't have to explicitly manage ResourceClaims.
 
 
+[KEP-4381]: https://kep.k8s.io/4381
 [KEP-4671]: https://kep.k8s.io/4671
 [KEP-5832]: https://kep.k8s.io/5832
 [KEP-5194]: https://kep.k8s.io/5194

--- a/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/kep.yaml
+++ b/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/kep.yaml
@@ -38,7 +38,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: WorkloadPodGroupResourceClaimTemplate
+  - name: DRAWorkloadResourceClaims
     components:
       - kube-apiserver
       - kube-controller-manager

--- a/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/kep.yaml
+++ b/keps/sig-scheduling/5729-resourceclaim-support-for-workloads/kep.yaml
@@ -24,16 +24,17 @@ see-also:
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.36"
+  beta: "v1.37"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update KEP-5729 (DRA: ResourceClaim Support for Workloads) for beta promotion in Kubernetes 1.37.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5729

<!-- other comments or additional information -->
- Other comments: