### PR TITLE
KEP-3926: retarget beta milestone to v1.37, add as co-author

### DIFF
--- a/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
+++ b/keps/sig-auth/3926-handling-undecryptable-resources/kep.yaml
@@ -2,6 +2,7 @@ title: Handling undecryptable resources
 kep-number: 3926
 authors:
   - "@stlaz"
+  - "@ibihim"
 owning-sig: sig-auth
 participating-sigs:
   - sig-api-machinery
@@ -19,12 +20,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
-  beta: "v1.36"
+  beta: "v1.37"
   stable: ""
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
Description:
- One-line PR description: Retarget beta milestone from v1.36 to v1.37 and add @ibihim as co-author
- Issue link: https://github.com/kubernetes/enhancements/issues/3926
- Other comments: KEP did not graduate to beta in v1.36 as planned due to https://github.com/kubernetes/kubernetes/pull/137582