### PR TITLE
KEP-5647: Bump to Beta in 1.36

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/5647.yaml
+++ b/keps/prod-readiness/sig-api-machinery/5647.yaml
@@ -1,3 +1,5 @@
 kep-number: 5647
 alpha:
   approver: "@jpbetz"
+beta:
+  approver: "@jpbetz"

--- a/keps/sig-api-machinery/5647-stale-controller-handling/README.md
+++ b/keps/sig-api-machinery/5647-stale-controller-handling/README.md
@@ -19,8 +19,8 @@
       - [Integration tests](#integration-tests)
       - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
-    - [Alpha](#alpha)
     - [Beta](#beta)
+    - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
@@ -329,13 +329,13 @@ If e2e tests are not necessary or useful, explain why.
 
 ### Graduation Criteria
 
-#### Alpha
+#### Beta
 - Addition of new bookmark function for informers
 - Feature implemented behind a feature flag for 1 or more controllers
 - Unit tests for controllers/bookmark function
 - Addition of e2e tests for the controllers with feature gate enabled
 
-#### Beta
+#### GA
 - Analysis of onboarded controllers and addition of others that may have the same staleness issues
 - Addition of additional E2E tests and stress tests to ensure edge cases are fully tested
 

--- a/keps/sig-api-machinery/5647-stale-controller-handling/kep.yaml
+++ b/keps/sig-api-machinery/5647-stale-controller-handling/kep.yaml
@@ -16,7 +16,7 @@ approvers:
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
@@ -25,7 +25,7 @@ latest-milestone: "v1.36"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v1.36"
+  beta: "v1.36"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bump kep to beta in 1.36

<!-- link to the k/enhancements issue -->
- Issue link: #5647 

<!-- other comments or additional information -->
- Other comments: Lot's of feature gates are beta/ on by default since this has no api changes. Bumping the KEP to beta to reflect the real state of this KEP