### PR TITLE
KEP-4671: Make the example PodGroup's podGroupTemplateRef match the Workload object

### DIFF
--- a/keps/sig-scheduling/4671-gang-scheduling/README.md
+++ b/keps/sig-scheduling/4671-gang-scheduling/README.md
@@ -254,8 +254,9 @@ metadata:
   name: training-worker-0
 spec:
   podGroupTemplateRef:
-    workloadName: training-policy
-    podGroupTemplateName: worker
+    workload:
+      workloadName: training-policy
+      podGroupTemplateName: worker
   schedulingPolicy:
     gang:
       minCount: 100
@@ -387,8 +388,9 @@ metadata:
   name: job-instance-worker-0
 spec:
   podGroupTemplateRef:
-    workloadName: job-policy
-    podGroupTemplateName: worker-template
+    workload:
+      workloadName: jobset
+      podGroupTemplateName: job-1
   # schedulingPolicy is copied from template on PodGroup creation.
   schedulingPolicy:
     gang:


### PR DESCRIPTION

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: fixed `PodGroup`'s `workloadName` and `podGroupTemplateName` to match what's there in the `Workload` object

<!-- link to the k/enhancements issue -->
- Issue link: N/A

<!-- other comments or additional information -->
- Other comments: N/A