### PR TITLE
ignore deleted files in verify-toc-vs-template.sh

### DIFF
--- a/hack/verify-toc-vs-template.sh
+++ b/hack/verify-toc-vs-template.sh
@@ -78,8 +78,8 @@ result=0
 kep_readmes=()
 while IFS= read -r changed_file
 do
-    # make sure to ignore the template kep itself, we don't want to self-diff
-    if [[ "${changed_file}" == "keps"*"README.md" ]] && [[ "${changed_file}" != "${template_readme}" ]]; then
+    # make sure to ignore the template kep itself, we don't want to self-diff. Ignore deleted files.
+    if [[ "${changed_file}" == "keps"*"README.md" ]] && [[ "${changed_file}" != "${template_readme}" ]] && [[ -f "${changed_file}" ]]; then
         kep_readmes+=("${changed_file}")
     fi
 done < <(git diff-tree --no-commit-id --name-only -r "${base}".."${target}")


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… --> 
- One-line PR description: Fix `hack/verify-toc-vs-template.sh` to ignore deleted files and prevent CI failures during KEP directory renames.

<!-- link to the k/enhancements issue -->
- Issue link: N/A (fixes presubmit failure observed in https://github.com/kubernetes/enhancements/pull/6009)

<!-- other comments or additional information -->
- Other comments: