### PR TITLE
KEP-5982: ReplicaSet Consolidation-Aware Scale-In Strategy

### DIFF
--- a/keps/sig-apps/5982-replicaset-consolidation-scale-in/README.md
+++ b/keps/sig-apps/5982-replicaset-consolidation-scale-in/README.md
@@ -1,0 +1,42 @@
+# KEP-5982: ReplicaSet Consolidation-Aware Scale-In Strategy
+
+<!-- toc -->
+<!-- /toc -->
+
+## Summary
+
+Add a `ConsolidatingScaleDown` feature gate to `kube-controller-manager` that changes the ReplicaSet controller's pod deletion sort order during scale-down. When enabled, the controller prefers deleting pods on nodes with fewer total active pods, enabling node autoscalers to reclaim nodes with less disruption.
+
+## Motivation
+
+The ReplicaSet controller's current scale-down heuristic spreads pod deletions evenly across nodes. This works against node autoscalers (Karpenter, cluster-autoscaler) which need nodes to become empty or underutilized before they can remove them. The spreading heuristic leaves every node partially occupied after a scale-down, requiring the autoscaler to evict additional pods to consolidate — increasing total disruption.
+
+### Goals
+
+- Provide an alternative pod deletion heuristic that supports node consolidation during workload scale-down
+- Reduce total pod disruption by enabling scale-down events to naturally empty nodes
+- Complement KEP-2255 (PodDeletionCost) — both mechanisms coexist, with PodDeletionCost taking precedence
+
+### Non-Goals
+
+- Changing scheduler placement decisions
+- Modifying StatefulSet or Job scale-down behavior
+- Replacing or deprecating PodDeletionCost (KEP-2255)
+- Guaranteeing optimal node packing (this is a heuristic improvement)
+
+## Proposal
+
+*Details to be added as the design evolves. See [kubernetes/enhancements#5982](https://github.com/kubernetes/enhancements/issues/5982) for discussion.*
+
+## Design Details
+
+*To be added.*
+
+## Alternatives
+
+- **KEP-2255 (PodDeletionCost):** External controller sets annotations to influence pod deletion order. Works today but requires continuous annotation management and API server writes.
+- **Eviction Request API (KEP-4563):** More general eviction coordination mechanism. Operates at the eviction layer rather than the RS controller's pod selection layer.
+
+## Infrastructure Needed
+
+None.

--- a/keps/sig-apps/5982-replicaset-consolidation-scale-in/kep.yaml
+++ b/keps/sig-apps/5982-replicaset-consolidation-scale-in/kep.yaml
@@ -1,0 +1,29 @@
+title: ReplicaSet Consolidation-Aware Scale-In Strategy
+kep-number: 5982
+authors:
+  - "@nathangeology"
+owning-sig: sig-apps
+participating-sigs:
+  - sig-autoscaling
+status: provisional
+creation-date: 2026-03-27
+reviewers:
+  - TBD
+approvers:
+  - TBD
+
+see-also:
+  - "/keps/sig-apps/2255-pod-cost"
+
+stage: alpha
+
+latest-milestone: "v1.37"
+
+milestone:
+  alpha: "v1.37"
+
+feature-gates:
+  - name: ConsolidatingScaleDown
+    components:
+      - kube-controller-manager
+disable-supported: true

--- a/keps/sig-apps/5982-replicaset-consolidation-scale-in/kep.yaml
+++ b/keps/sig-apps/5982-replicaset-consolidation-scale-in/kep.yaml
@@ -5,6 +5,8 @@ authors:
 owning-sig: sig-apps
 participating-sigs:
   - sig-autoscaling
+  - sig-node
+  - sig-scheduling
 status: provisional
 creation-date: 2026-03-27
 reviewers:


### PR DESCRIPTION
Provisional KEP for adding a consolidation-aware pod deletion heuristic to the ReplicaSet controller.

Tracking issue: https://github.com/kubernetes/enhancements/issues/5982

/sig apps