### PR TITLE
KEP-4192: Set SVM to stable in 1.37

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/4192.yaml
+++ b/keps/prod-readiness/sig-api-machinery/4192.yaml
@@ -3,3 +3,5 @@ alpha:
   approver: "@deads2k"
 beta:
   approver: "@jpbetz"
+stable:
+  approver: "@jpbetz"

--- a/keps/sig-api-machinery/4192-svm-in-tree/README.md
+++ b/keps/sig-api-machinery/4192-svm-in-tree/README.md
@@ -28,6 +28,7 @@
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
     - [Beta](#beta)
+    - [Stable](#stable)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
@@ -393,13 +394,18 @@ total:                                                                          
 
 #### Beta
 
-- Feature is enabled by default.
 - All of the above documented tests are complete.
 - Using Garbage Collection Cache means using RV as an integer to validate the freshness of the cache. Approval from SigArch is required on this RV semantics.
 - Unexpected event handling(i.e. interrupted migrations)
 - Usage of [RealFIFO](https://github.com/kubernetes/kubernetes/pull/129568) and gating on feature enablement
 - Ensuring that migration only runs for API objects that support Create/Update in its discovery document
 - Added support for automatically triggering an update on CRD storage version status field after migration is completed.
+
+#### Stable
+
+- Feature is enabled by default.
+- E2E testing of all associated APIs
+- GA of [RealFIFO](https://github.com/kubernetes/kubernetes/pull/136601)
 
 ### Upgrade / Downgrade Strategy
 The feature is enabled using the feature gate `StorageVersionMigrator`. During an upgrade, this gate must be set to true. During a downgrade, this gate must be set to false, and any remaining _StorageVersionMigration_ resources should be manually removed.

--- a/keps/sig-api-machinery/4192-svm-in-tree/kep.yaml
+++ b/keps/sig-api-machinery/4192-svm-in-tree/kep.yaml
@@ -20,8 +20,8 @@ see-also:
   - "keps/sig-api-machinery/2342-exposing-hashed-storage-versions-via-the-discovery-API"
   - "keps/sig-api-machinery/2343-automated-storage-version-migration-with-storage-version-hash"
   - "keps/sig-api-machinery/4020-unknown-version-interoperability-proxy"
-stage: beta
-latest-milestone: "v1.36"
+stage: stable
+latest-milestone: "v1.37"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.30"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Set SVM to stable milestone in 1.37

<!-- link to the k/enhancements issue -->
- Issue link: #4192 

<!-- other comments or additional information -->
- Other comments: Planned to GA the API and add E2E tests in 1.37