### PR TITLE
KEP 1645: add endpointSliceObjectsPresence field to ServiceImport

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -629,6 +629,11 @@ type ServicePort struct {
 
 // ServiceImportStatus describes derived state of an imported service.
 type ServiceImportStatus struct {
+  // EndpointSliceObjects indicates whether imported EndpointSlice objects are
+  // present for this ServiceImport.
+  // +kubebuilder:validation:Enum=Present;Absent
+  // +optional
+  EndpointSliceObjects EndpointSliceObjectsStatus `json:"endpointSliceObjects,omitempty"`
   // +optional
   // +patchStrategy=merge
   // +patchMergeKey=cluster
@@ -647,6 +652,20 @@ type ServiceImportStatus struct {
 type ClusterStatus struct {
  Cluster string `json:"cluster"`
 }
+
+// EndpointSliceObjectsStatus indicates whether imported EndpointSlice objects
+// are present for a ServiceImport.
+type EndpointSliceObjectsStatus string
+
+const (
+  // EndpointSliceObjectsPresent indicates that imported EndpointSlice objects
+  // are present for a ServiceImport.
+  EndpointSliceObjectsPresent EndpointSliceObjectsStatus = "Present"
+
+  // EndpointSliceObjectsAbsent indicates that imported EndpointSlice objects are
+  // absent for a ServiceImport.
+  EndpointSliceObjectsAbsent EndpointSliceObjectsStatus = "Absent"
+)
 ```
 
 ```yaml
@@ -667,6 +686,7 @@ spec:
     port: 80
   sessionAffinity: None
 status:
+  endpointSliceObjects: Present
   conditions:
   - type: Ready
     reason: Ready
@@ -901,6 +921,13 @@ conform to the specification in the following section.
 
 _Optional to create, but specification defined if present._
 
+Implementations must publish whether imported `EndpointSlice` objects are
+present through `ServiceImport.Status.EndpointSliceObjects`. API consumers
+that would normally always use `EndpointSlice` objects (such as Gateway API
+implementations) can use this to decide whether to consume `EndpointSlice`
+objects directly, degrade to `ServiceImport` IPs if they support doing so,
+or fail if `EndpointSlice` objects are required.
+
 If an implementation does create `discovery.k8s.io/v1 EndpointSlice`s, they must
 conform to the following structure. This structure was originally required as
 part of this specification in alpha, and are the structure on which other
@@ -951,6 +978,7 @@ spec:
     port: 80
   sessionAffinity: None
 status:
+  endpointSliceObjects: Present
   clusters:
   - cluster: us-west2-a-my-cluster
 ---


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: add endpointSlicesAvailable field to ServiceImport

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/1645

<!-- other comments or additional information -->
- Other comments:

Add endpointSliceObjectsPresence to ServiceImport status so that consumer such as Gateway API implementations can decide if they should use EndpointSlice objects directly. Since surfacing EndpointSlices from remote clusters is optional without this fields consumers that wanted to directly reached the backends by reading the EndpointSlice objects had to fail in unclear ways or needed to have more complex probing logic to determine that info.

Cilium does not always sync back the EndpointSlice objects. We do that only if the ServiceImport is headless or if a certain annotation is present on the ServiceImport object (as the ServiceImport IPs load-balancing is not required
to have the EndpointSlice objects present in this implementation). Since EndpointSlice syncing is optional this is fully spec compliant. The addition of the `endpointSliceObjectsPresence` on ServiceImport would greatly benefit us if adopted by consumers, because  our users would probably see a clearer error that should led them to add the implementation specific annotation signaling that EndpointSlices should be synced.

Note that I decided to not propose a ServiceExport field to replace the Cilium annotation at this moment, since I am not sure that any other implementation have the same behavior (if at least one other implementation have something like that it too would probably be worth it though!).