### PR TITLE
Update sig-etcd leadership

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -55,7 +55,8 @@ aliases:
     - salaxander
   sig-etcd-leads:
     - ahrtr
-    - jmhbnz
+    - ivanvc
+    - jberkus
     - serathius
     - siyuanfoundation
   sig-instrumentation-leads:


### PR DESCRIPTION
Updated SIG-etcd aliases per https://github.com/kubernetes/community/issues/8942

Ivan was also missing from the alias for some reason.