### PR TITLE
KEP-5966: RangeStream kubernetes integration

### DIFF
--- a/keps/prod-readiness/sig-etcd/5966.yaml
+++ b/keps/prod-readiness/sig-etcd/5966.yaml
@@ -1,0 +1,3 @@
+kep-number: 5966
+beta:
+  approver: "@jpbetz"

--- a/keps/sig-etcd/5966-etcd-range-stream/README.md
+++ b/keps/sig-etcd/5966-etcd-range-stream/README.md
@@ -41,18 +41,18 @@
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
-- [ ] (R) Design details are appropriately documented
-- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [X] (R) KEP approvers have approved the KEP status as `implementable`
+- [X] (R) Design details are appropriately documented
+- [X] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
   - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
-- [ ] (R) Graduation criteria is in place
+- [X] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
-- [ ] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
+- [X] (R) Production readiness review completed
+- [X] (R) Production readiness review approved
+- [X] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
@@ -74,6 +74,9 @@ This KEP proposes a new server-streaming `RangeStream` RPC that reuses
 internally with adaptive chunk sizing and pins to a single MVCC revision for
 consistency. The total count is derived from the running tally of streamed
 keys, eliminating the separate index traversal required by paginated Range.
+
+The feature requires etcd 3.7+. With older etcd, kube-apiserver detects
+`Unimplemented` and continues using unary `Range` with no behavior change.
 
 ## Motivation
 
@@ -127,14 +130,16 @@ should retry the request.
 
 ### Risks and Mitigations
 
-- **etcd version skew.** Older etcd versions return gRPC `Unimplemented`.
-  kube-apiserver detects this at runtime, logs a warning, and falls back
-  to the existing paginated list path.
 - **Stream interrupted by compaction.** If the pinned revision is compacted
   mid-stream, the server returns `ErrCompacted`. kube-apiserver surfaces
   this as a watch cache initialization failure, and the cacher retries
   initialization. The behavior is identical to a paginated list that races
-  compaction.
+  compaction. A unary `Range` without pagination technically avoids this
+  problem, because a single non-streaming call does not pin a revision
+  across multiple reads. But at the scale where a stream takes longer than
+  kube-apiserver's compaction interval (5 minutes by default) to complete,
+  the unary response approaches protobuf's 2 GB message limit and is
+  itself unlikely to succeed.
 
 ## Design Details
 
@@ -217,6 +222,10 @@ The following components are modified:
 - **Client** (`client/v3/kv.go`): `RangeStreamToRangeResponse` — reassembles
   a stream into a single `RangeResponse` so callers can transparently switch
   between unary and streaming.
+- **etcdctl**: A `--stream` flag on `etcdctl get` issues a `RangeStream`
+  request and reassembles the chunks into a `RangeResponse` for display.
+  This provides a direct CLI entry point, useful for inspections and
+  comparisons against unary `get` on the same key range.
 
 ### Test Plan
 
@@ -235,9 +244,12 @@ assertion.
 
 - Server-side `RangeStream` chunking, revision pinning, and
   `CountOnly` short-circuit behavior.
-- kube-apiserver: `staging/src/k8s.io/apiserver/pkg/storage/etcd3` — new
-  tests cover `watcher.sync` routing through `syncStream`, `parseKV` event
-  construction, and the `Unimplemented` fallback path.
+- kube-apiserver: tests cover the watch cache initialization path
+  routing through `RangeStream` and event construction from streamed
+  chunks.
+- Backwards compatibility: unit tests cover the version skew case where
+  the gate is enabled against an etcd that returns `Unimplemented`,
+  confirming the fallback to unary `Range` does not regress.
 
 ##### Integration tests
 
@@ -250,11 +262,8 @@ assertion.
 - Robustness tests (Note: `tests/robustness/coverage` in the etcd repository
   will need updating once Kubernetes actually starts making calls, as monitored
   in [ci-etcd-k8s-coverage-amd64](https://testgrid.k8s.io/sig-etcd-periodics#ci-etcd-k8s-coverage-amd64)).
-- kube-apiserver: `test/integration/apiserver/rangestream_test.go`
-  (`TestRangeStreamList`) creates 200 Secrets, restarts kube-apiserver with
-  the `RangeStream` feature gate enabled, and verifies that
-  `apiserver_watch_cache_initialization_duration_seconds_count` increments via
-  the streaming path.
+- kube-apiserver: integration tests will be added for correctness and
+  benchmarks against the unary `Range` path.
 
 ##### e2e tests
 
@@ -262,7 +271,7 @@ e2e tests will be added to exercise the streaming behavior.
 
 ### Kubernetes API Server Integration
 
-RangeStream is gated behind a `RangeStream` feature gate in kube-apiserver
+RangeStream is gated behind a `EtcdRangeStream` feature gate in kube-apiserver
 (Beta in 1.37, default enabled).
 
 The primary integration point is the watch cache initialization path.
@@ -282,12 +291,13 @@ limit. The `storage.Interface` is unchanged.
 
 #### Beta
 
-- Feature implemented behind the `RangeStream` feature gate, default on.
+- Feature implemented behind the `EtcdRangeStream` feature gate, default on.
 - Watch cache initialization routes through `RangeStream` with
   automatic `Unimplemented` fallback for older etcd.
 - Feature is covered with unit, integration, and e2e tests.
 - Scalability test on a 5000-node cluster measuring latency on large
   list responses.
+- `etcdctl get --stream` available for direct CLI access to `RangeStream`.
 
 #### GA
 
@@ -308,22 +318,26 @@ Skew is between kube-apiserver and etcd. The supported combinations:
 - gate on + etcd 3.6 or older: falls back to unary `Range`.
 - gate off + any etcd version: uses unary `Range`.
 
-kube-apiserver caches the result of feature discovery rather than
-probing `RangeStream` on every list. The cache is refreshed
-periodically so an etcd upgrade is picked up without a kube-apiserver
-restart.
+We will reuse kube-apiserver's existing
+`storage.FeatureSupportChecker` to cache the feature result and avoid
+calling the streaming endpoint repeatedly when running against an
+older etcd version. The checker probes etcd periodically, so an
+etcd upgrade from 3.6 to 3.7 is picked up by a running kube-apiserver
+without a restart. If the cached response is incorrect (eg: cluster
+downgrade), the `Unimplemented` fallback will still fall back to
+`Range`.
 
 For HA kube-apiserver during a rolling upgrade, each apiserver
 negotiates with etcd on its own. An apiserver on the old version uses
 unary `Range` and one on the new version uses `RangeStream` when
-available. Watch cache state is per-apiserver, so they don't interact. For an etcd cluster rolling upgrade,
-requests may land on different members during the transition. Once a
-`RangeStream` call fails, kube-apiserver falls back to unary `Range`
-until the next feature-discovery refresh, then picks up RangeStream
-when every member supports it. For an etcd downgrade after
-kube-apiserver has started using RangeStream, the fallback is always
-live. The next call returns `Unimplemented` and kube-apiserver reverts
-to unary `Range`. Nothing on the apiserver side needs to be migrated.
+available. Watch cache state is per-apiserver, so they don't interact.
+For an etcd cluster rolling upgrade, requests may land on different
+members during the transition. Once a `RangeStream` call fails,
+kube-apiserver falls back to unary `Range`. For an etcd downgrade
+after kube-apiserver has started using RangeStream, the fallback is
+always live. The next call returns `Unimplemented` and kube-apiserver
+reverts to unary `Range`. Nothing on the apiserver side needs to be
+migrated.
 
 ## Production Readiness Review Questionnaire
 
@@ -332,7 +346,7 @@ to unary `Range`. Nothing on the apiserver side needs to be migrated.
 ###### How can this feature be enabled / disabled in a live cluster?
 
 - [X] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: `RangeStream`
+  - Feature gate name: `EtcdRangeStream`
   - Components depending on the feature gate: `kube-apiserver`
 
 On the etcd side, the feature is always on at v3.7+.
@@ -343,9 +357,13 @@ Watch cache initialization internally switches from a paginated `Range` loop to 
 `RangeStream` call. The data returned is the same and there is no visible user facing change.
 It is estimated that etcd memory and watch cache initialization time will improve.
 
+Clusters on etcd 3.6 or older are unaffected: the gate is on but
+kube-apiserver falls back to unary `Range` on the first `Unimplemented`
+response.
+
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes. Setting `RangeStream=false` and restarting kube-apiserver fully
+Yes. Setting `EtcdRangeStream=false` and restarting kube-apiserver fully
 disables the feature. The feature is stateless.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
@@ -475,9 +493,10 @@ No.
 ###### What are other known failure modes?
 
 - **Stream interrupted by compaction**
-  - Detection: cacher initialization metrics show repeated retries.
-    Apiserver logs include `mvcc: required revision has been compacted`.
-  - Mitigations: Increase `--etcd-compaction-interval`.
+  - Detection: apiserver logs include `mvcc: required revision has been
+    compacted`.
+  - Mitigations: kube-apiserver retries the watch cache initialization
+    with a newer revision.
   - Diagnostics: structured error from etcd is propagated.
   - Testing: covered by etcd integration tests in
     `tests/integration/v3_grpc_test.go`.

--- a/keps/sig-etcd/5966-etcd-range-stream/README.md
+++ b/keps/sig-etcd/5966-etcd-range-stream/README.md
@@ -272,7 +272,7 @@ e2e tests will be added to exercise the streaming behavior.
 ### Kubernetes API Server Integration
 
 RangeStream is gated behind a `EtcdRangeStream` feature gate in kube-apiserver
-(Beta in 1.37, default enabled).
+(Beta in 1.37).
 
 The primary integration point is the watch cache initialization path.
 When the feature gate is enabled, the watch cache `sync()` uses
@@ -291,7 +291,9 @@ limit. The `storage.Interface` is unchanged.
 
 #### Beta
 
-- Feature implemented behind the `EtcdRangeStream` feature gate, default on.
+- Feature implemented behind the `EtcdRangeStream` feature gate, default off
+  initially. May flip to default on within Beta if testing data and
+  API Machinery leads agree there is sufficient signal of stability.
 - Watch cache initialization routes through `RangeStream` with
   automatic `Unimplemented` fallback for older etcd.
 - Feature is covered with unit, integration, and e2e tests.

--- a/keps/sig-etcd/5966-etcd-range-stream/README.md
+++ b/keps/sig-etcd/5966-etcd-range-stream/README.md
@@ -372,19 +372,17 @@ Same as enabling the feature for the first time.
 
 ###### Are there any tests for feature enablement/disablement?
 
-Yes, testing will be added for parity of watch cache behavior with RangeStream on and off.
+Yes, testing will be added for parity of watch cache behavior with
+RangeStream on and off. Skew against an etcd without `RangeStream` is
+covered by unit tests that inject an `Unimplemented` response and
+assert kube-apiserver falls back to paginated `Range`, plus manual
+verification against older etcd binaries.
 
 ### Rollout, Upgrade and Rollback Planning
 
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-- **etcd does not support `RangeStream`.** kube-apiserver detects
-  `Unimplemented` and falls back to paginated list. No impact on
-  running workloads.
-- **etcd compacts the pinned revision mid-stream.** kube-apiserver
-  surfaces `ErrCompacted` to the cacher, which retries
-  initialization. This is identical to a paginated list racing
-  compaction. Watches that were already established are unaffected.
+No known failure modes.
 
 ###### What specific metrics should inform a rollback?
 
@@ -394,7 +392,9 @@ Yes, testing will be added for parity of watch cache behavior with RangeStream o
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
-n/a.
+Yes. We will specifically test the upgrade, downgrade, and upgrade
+path. Tests cover both the startup `storage.FeatureSupportChecker`
+decision and the runtime `Unimplemented` fallback.
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 

--- a/keps/sig-etcd/5966-etcd-range-stream/README.md
+++ b/keps/sig-etcd/5966-etcd-range-stream/README.md
@@ -302,6 +302,8 @@ limit. The `storage.Interface` is unchanged.
 #### GA
 
 - Conformance tests.
+- At least two cloud providers have run the feature in production and
+  confirmed it is stable.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-etcd/5966-etcd-range-stream/README.md
+++ b/keps/sig-etcd/5966-etcd-range-stream/README.md
@@ -1,12 +1,14 @@
 # KEP-5966: etcd RangeStream
 
 <!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
 - [Summary](#summary)
 - [Motivation](#motivation)
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [API Changes](#api-changes)
   - [Stream Message Layout](#stream-message-layout)
@@ -15,12 +17,49 @@
   - [Unsupported Pass Through](#unsupported-pass-through)
   - [Implementation Changes](#implementation-changes)
   - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
       - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
   - [Kubernetes API Server Integration](#kubernetes-api-server-integration)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Beta](#beta)
+    - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
 - [Implementation History](#implementation-history)
 <!-- /toc -->
+
+## Release Signoff Checklist
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
 
 ## Summary
 
@@ -86,6 +125,17 @@ should retry the request.
   avoids the bbolt caveat where long-running read transactions can block write
   transactions when the database needs to remap/allocate new pages.
 
+### Risks and Mitigations
+
+- **etcd version skew.** Older etcd versions return gRPC `Unimplemented`.
+  kube-apiserver detects this at runtime, logs a warning, and falls back
+  to the existing paginated list path.
+- **Stream interrupted by compaction.** If the pinned revision is compacted
+  mid-stream, the server returns `ErrCompacted`. kube-apiserver surfaces
+  this as a watch cache initialization failure, and the cacher retries
+  initialization. The behavior is identical to a paginated list that races
+  compaction.
+
 ## Design Details
 
 ### API Changes
@@ -140,7 +190,7 @@ unary `Range` RPC instead.
 ### Chunk Sizing
 
 The streaming handler reuses the existing range path with an adaptive
-key-count limit. The first chunk uses a small initial limit; after
+key-count limit. The first chunk uses a small initial limit. After
 each chunk the limit is doubled or halved based on the previous
 response size relative to a target derived from `MaxRequestBytes`,
 letting the server converge on chunk sizes appropriate for the
@@ -170,10 +220,24 @@ The following components are modified:
 
 ### Test Plan
 
+[X] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+No prerequisite test refactors are required. The kube-apiserver integration
+reuses the existing watch cache initialization test surface. The etcd
+integration extends existing Range test cases with a `RangeStream` parallel
+assertion.
+
 ##### Unit tests
 
 - Server-side `RangeStream` chunking, revision pinning, and
   `CountOnly` short-circuit behavior.
+- kube-apiserver: `staging/src/k8s.io/apiserver/pkg/storage/etcd3` — new
+  tests cover `watcher.sync` routing through `syncStream`, `parseKV` event
+  construction, and the `Unimplemented` fallback path.
 
 ##### Integration tests
 
@@ -186,11 +250,20 @@ The following components are modified:
 - Robustness tests (Note: `tests/robustness/coverage` in the etcd repository
   will need updating once Kubernetes actually starts making calls, as monitored
   in [ci-etcd-k8s-coverage-amd64](https://testgrid.k8s.io/sig-etcd-periodics#ci-etcd-k8s-coverage-amd64)).
+- kube-apiserver: `test/integration/apiserver/rangestream_test.go`
+  (`TestRangeStreamList`) creates 200 Secrets, restarts kube-apiserver with
+  the `RangeStream` feature gate enabled, and verifies that
+  `apiserver_watch_cache_initialization_duration_seconds_count` increments via
+  the streaming path.
+
+##### e2e tests
+
+e2e tests will be added to exercise the streaming behavior.
 
 ### Kubernetes API Server Integration
 
 RangeStream is gated behind a `RangeStream` feature gate in kube-apiserver
-(Alpha in 1.37, default disabled).
+(Beta in 1.37, default enabled).
 
 The primary integration point is the watch cache initialization path.
 When the feature gate is enabled, the watch cache `sync()` uses
@@ -205,6 +278,21 @@ decode. When the server returns `Unimplemented` or the feature gate is
 disabled, the store falls back to paginated `List` with a conservative
 limit. The `storage.Interface` is unchanged.
 
+### Graduation Criteria
+
+#### Beta
+
+- Feature implemented behind the `RangeStream` feature gate, default on.
+- Watch cache initialization routes through `RangeStream` with
+  automatic `Unimplemented` fallback for older etcd.
+- Feature is covered with unit, integration, and e2e tests.
+- Scalability test on a 5000-node cluster measuring latency on large
+  list responses.
+
+#### GA
+
+- Conformance tests.
+
 ### Upgrade / Downgrade Strategy
 
 RangeStream is a new server-side RPC. Older clients that do not call
@@ -212,7 +300,199 @@ RangeStream is a new server-side RPC. Older clients that do not call
 without `RangeStream`, clients calling the RPC will receive an
 `Unimplemented` gRPC error and should fall back to unary `Range`.
 
+### Version Skew Strategy
+
+Skew is between kube-apiserver and etcd. The supported combinations:
+
+- gate on + etcd 3.7 or newer: uses `RangeStream`.
+- gate on + etcd 3.6 or older: falls back to unary `Range`.
+- gate off + any etcd version: uses unary `Range`.
+
+kube-apiserver caches the result of feature discovery rather than
+probing `RangeStream` on every list. The cache is refreshed
+periodically so an etcd upgrade is picked up without a kube-apiserver
+restart.
+
+For HA kube-apiserver during a rolling upgrade, each apiserver
+negotiates with etcd on its own. An apiserver on the old version uses
+unary `Range` and one on the new version uses `RangeStream` when
+available. Watch cache state is per-apiserver, so they don't interact. For an etcd cluster rolling upgrade,
+requests may land on different members during the transition. Once a
+`RangeStream` call fails, kube-apiserver falls back to unary `Range`
+until the next feature-discovery refresh, then picks up RangeStream
+when every member supports it. For an etcd downgrade after
+kube-apiserver has started using RangeStream, the fallback is always
+live. The next call returns `Unimplemented` and kube-apiserver reverts
+to unary `Range`. Nothing on the apiserver side needs to be migrated.
+
+## Production Readiness Review Questionnaire
+
+### Feature Enablement and Rollback
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+- [X] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name: `RangeStream`
+  - Components depending on the feature gate: `kube-apiserver`
+
+On the etcd side, the feature is always on at v3.7+.
+
+###### Does enabling the feature change any default behavior?
+
+Watch cache initialization internally switches from a paginated `Range` loop to a single
+`RangeStream` call. The data returned is the same and there is no visible user facing change.
+It is estimated that etcd memory and watch cache initialization time will improve.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+Yes. Setting `RangeStream=false` and restarting kube-apiserver fully
+disables the feature. The feature is stateless.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+Same as enabling the feature for the first time.
+
+###### Are there any tests for feature enablement/disablement?
+
+Yes, testing will be added for parity of watch cache behavior with RangeStream on and off.
+
+### Rollout, Upgrade and Rollback Planning
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+- **etcd does not support `RangeStream`.** kube-apiserver detects
+  `Unimplemented` and falls back to paginated list. No impact on
+  running workloads.
+- **etcd compacts the pinned revision mid-stream.** kube-apiserver
+  surfaces `ErrCompacted` to the cacher, which retries
+  initialization. This is identical to a paginated list racing
+  compaction. Watches that were already established are unaffected.
+
+###### What specific metrics should inform a rollback?
+
+- `apiserver_watch_cache_initialization_duration_seconds{group, resource}`
+  increases significantly compared to average.
+- `etcd_request_duration_seconds{operation="listStream"}` p99 reports extremely high numbers.
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+n/a.
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+No.
+
+### Monitoring Requirements
+
+###### How can an operator determine if the feature is in use by workloads?
+
+Check whether `etcd_request_duration_seconds_count{operation="listStream"}`
+is present and greater than zero. If the gate is on but the metric is
+absent or stays at zero, the etcd server is returning `Unimplemented`
+(look for the `etcd server does not support RangeStream` warning in
+apiserver logs).
+
+###### How can someone using this feature know that it is working for their instance?
+
+  - Details: This is a backend-only optimization. It has no per-object
+    user-visible signal. Operators verify behavior via two metrics:
+    1. `etcd_request_duration_seconds_count{operation="listStream"}`
+       increments after each watch cache sync.
+    2. `apiserver_watch_cache_initialization_duration_seconds` for the
+       affected resources is lower than the pre-enablement baseline.
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+No regression from the previous behavior of using unary `Range`.
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+- [X] Metrics
+  - Metric name: `apiserver_watch_cache_initialization_duration_seconds`
+  - Components exposing the metric: kube-apiserver
+- [X] Metrics
+  - Metric name: `etcd_request_duration_seconds`
+  - Components exposing the metric: kube-apiserver
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+n/a.
+
+### Dependencies
+
+###### Does this feature depend on any specific services running in the cluster?
+
+The feature depends on the etcd server supporting the `RangeStream`
+RPC. This is an version dependency (etcd 3.7+), not an additional
+cluster service.
+
+### Scalability
+
+###### Will enabling / using this feature result in any new API calls?
+
+Yes, but they replace existing calls rather than adding new traffic.
+On a kube-apiserver with the gate on:
+
+- API call type: `RangeStream` (gRPC server-streaming) to etcd.
+- Estimated throughput: one `RangeStream` request instead of `Range` request for list requests to etcd. In cases of pagination, N range requests are condensed into one RangeStream request.`
+- Originating component: kube-apiserver.
+
+###### Will enabling / using this feature result in introducing new API types?
+
+No.
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+No.
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+No.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+No.
+
+[slo]: https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+No.
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+No.
+
+### Troubleshooting
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+- **etcd unavailable:** identical to today. The watch cache
+  initialization fails, the cacher retries with backoff.
+- **kube-apiserver unavailable:** The feature will not function
+  without kube-apiserver availability.
+
+###### What are other known failure modes?
+
+- **Stream interrupted by compaction**
+  - Detection: cacher initialization metrics show repeated retries.
+    Apiserver logs include `mvcc: required revision has been compacted`.
+  - Mitigations: Increase `--etcd-compaction-interval`.
+  - Diagnostics: structured error from etcd is propagated.
+  - Testing: covered by etcd integration tests in
+    `tests/integration/v3_grpc_test.go`.
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+1. Confirm the feature is in use:
+   `etcd_request_duration_seconds_count{operation="listStream"}` > 0.
+2. Compare `apiserver_watch_cache_initialization_duration_seconds` to the
+   pre-enablement baseline for the affected `group, resource`. If the
+   metric regressed, disable the gate.
+
 ## Implementation History
 
 - 2026-03-18: KEP created
+- 2026-05-08: Expanded design with kube-apiserver integration details and
+  filled out the production readiness review for beta targeting v1.37.
 

--- a/keps/sig-etcd/5966-etcd-range-stream/kep.yaml
+++ b/keps/sig-etcd/5966-etcd-range-stream/kep.yaml
@@ -25,7 +25,7 @@ milestone:
   beta: "v1.37"
 
 feature-gates:
-  - name: RangeStream
+  - name: EtcdRangeStream
     components:
       - kube-apiserver
 disable-supported: true

--- a/keps/sig-etcd/5966-etcd-range-stream/kep.yaml
+++ b/keps/sig-etcd/5966-etcd-range-stream/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-etcd
 participating-sigs:
   - sig-api-machinery
-status: provisional
+status: implementable
 creation-date: 2026-03-18
 reviewers:
   - "@ahrtr"
@@ -15,3 +15,20 @@ approvers:
   - "@ahrtr"
   - "@fuweid"
   - "@serathius"
+  - "@jpbetz"
+
+stage: beta
+
+latest-milestone: "v1.37"
+
+milestone:
+  beta: "v1.37"
+
+feature-gates:
+  - name: RangeStream
+    components:
+      - kube-apiserver
+disable-supported: true
+
+metrics:
+  - apiserver_watch_cache_initialization_duration_seconds


### PR DESCRIPTION
KEP 5966: RangeStream kubernetes integration

etcd has already been implemented https://github.com/etcd-io/etcd/issues/21619

etcd benchmarks: https://github.com/etcd-io/etcd/pull/21701

This update documents the Kubernetes integration.

watch cache benchmarks can be found https://github.com/kubernetes/kubernetes/issues/138815.