### PR TITLE
Mark DRA Prioritized List as implemented

### DIFF
--- a/keps/sig-scheduling/4816-dra-prioritized-list/kep.yaml
+++ b/keps/sig-scheduling/4816-dra-prioritized-list/kep.yaml
@@ -7,7 +7,7 @@ owning-sig: sig-scheduling
 participating-sigs:
   - sig-node
   - sig-autoscaling
-status: implementable
+status: implemented
 creation-date: 2024-09-24
 reviewers:
   - "@pohly"
@@ -44,7 +44,7 @@ feature-gates:
       - kube-apiserver
       - kube-controller-manager
       - kube-scheduler
-disable-supported: true
+disable-supported: false
 
 # The following PRR answers are required at beta release
 metrics:


### PR DESCRIPTION
- One-line PR description: The DRA Prioritized List is GA and implemented

- Issue link: https://github.com/kubernetes/enhancements/issues/4816

- Other comments:

PR to lock the feature to default-on for 1.37: https://github.com/kubernetes/kubernetes/pull/139110