### PR TITLE
KEP-4033: defer cgroup driver fallback removal to 1.38

### DIFF
--- a/keps/sig-node/4033-group-driver-detection-over-cri/README.md
+++ b/keps/sig-node/4033-group-driver-detection-over-cri/README.md
@@ -186,14 +186,14 @@ cgroupDriver option has been deprecated and will be dropped in a future release.
 The `--cgroup-driver` flag and the cgroupDriver configuration option will be
 deprecated when support for the feature is graduated to GA.
 The configurations flags (and the related fallback behavior) will be removed in
-Kubernetes 1.37. This aligns well with containerd v1.7 going out of support, which is the last
+Kubernetes 1.38. This aligns well with containerd v1.7 going out of support, which is the last
 remaining supported CRI that doesn't have support for this field.
 At the point the kubelet refuses to start if the CRI runtime does not support
 the feature.
 
 Between version 1.34 and 1.36, the kubelet will emit a counter metric (`cri_losing_support`) when a CRI implementation is
 used that doesn't have support for the RuntimeConfig CRI call. This metric will have a label describing the version support will be dropped by.
-If one node in a cluster has containerd running with 1.7, the metric will look like `cri_losing_support{,version="1.37"} 1`.
+If one node in a cluster has containerd running with 1.7, the metric will look like `cri_losing_support{,version="1.38"} 1`.
 
 Kubelet startup is modified so that connection to the CRI server (container
 runtime) is established and RuntimeConfig is queried before initializing the
@@ -332,8 +332,8 @@ CgroupDriver as they must be today.
 
 ###### What specific metrics should inform a rollback?
 
-`cri_losing_support` metric will be populated on nodes where the CRI implementation will one day lose support. After 1.37, kubelet will fatally error,
-so admins should upgrade their out of support CRI implementations (if `version==1.37`).
+`cri_losing_support` metric will be populated on nodes where the CRI implementation will one day lose support. After 1.38, kubelet will fatally error,
+so admins should upgrade their out of support CRI implementations (if `version==1.38`).
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
@@ -360,7 +360,7 @@ info`).
 
 ###### How can someone using this feature know that it is working for their instance?
 
-The metric `cri_losing_support` when `version == 1.37` will indicate those nodes will be out of support in 1.37.
+The metric `cri_losing_support` when `version == 1.38` will indicate those nodes will be out of support in 1.38.
 If that metric is unpopulated, the feature is on (as it's GA) and the flag fallback is not being used.
 
 After GA, the CgroupDriver configuration option and the `--cgroup-driver` flag
@@ -381,7 +381,7 @@ N/A.
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-The metric `cri_losing_support` when `version == 1.37` will indicate those nodes will be out of support in 1.37.
+The metric `cri_losing_support` when `version == 1.38` will indicate those nodes will be out of support in 1.38.
 If that metric is unpopulated, the feature is on (as it's GA) and the flag fallback is not being used.
 
 ### Dependencies

--- a/keps/sig-node/4033-group-driver-detection-over-cri/kep.yaml
+++ b/keps/sig-node/4033-group-driver-detection-over-cri/kep.yaml
@@ -22,7 +22,7 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:


### PR DESCRIPTION
- One-line PR description: Update KEP-4033 to defer the cgroup driver fallback removal timeline from Kubernetes 1.37 to Kubernetes 1.38.

- Issue link: #4033

- Other comments:
  This follows the discussion in https://github.com/kubernetes/kubernetes/pull/136731#issuecomment-4458010510, where Kubernetes 1.37 is planned to be cut on August 26, 2026, while containerd 1.7 reaches end of life in September 2026.

  This also updates the `cri_losing_support` metric examples and guidance to use `version="1.38"`, and sets `latest-milestone` to `v1.37`.

  Validation:
  - `git diff --check`
  - Verified the KEP references now use 1.38 for the removal target and `v1.37` for `latest-milestone`.