### PR TITLE
KEP-5793: update kep for beta in v1.37

### DIFF
--- a/keps/prod-readiness/sig-api-machinery/5793.yaml
+++ b/keps/prod-readiness/sig-api-machinery/5793.yaml
@@ -1,3 +1,5 @@
 kep-number: 5793
 alpha:
   approver: "@soltysh"
+beta:
+  approver: "@soltysh"

--- a/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
+++ b/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
@@ -325,8 +325,9 @@ machinery.
 `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` do not participate in this
 exclusion today. For beta, they will implement `WantsExcludedAdmissionResources` and skip
 dispatch for the same set, gated by a new `ExcludeAdmissionWebhookVirtualResources` feature
-gate that defaults to enabled in 1.37. The gate is opt-out for clusters that need the prior
-behavior temporarily.
+gate that defaults to enabled in 1.37. The gate is opt-out as a short-term escape hatch for
+clusters that need the prior behavior; it is not intended to remain disabled long-term and
+will be locked at GA per the graduation criteria below.
 
 Excluded resources (from `exclusion.Excluded()`, all API versions):
 
@@ -602,6 +603,13 @@ best tested via integration tests.
 - Stable usage in production environments for at least two releases
 - No regressions in API server startup time
 - All feedback from beta users addressed
+- `ExcludeAdmissionWebhookVirtualResources` gate handling:
+  - Consistent with Kubernetes behavior deprecation policies, the gate will remain unlocked
+    for 3 releases / 12 months before being locked to enabled at GA.
+  - If feedback prior to GA indicates webhook interception of `*SubjectAccessReview`
+    requests is being used and is still needed by the ecosystem, api-machinery will
+    consider adding admission configuration to allow cluster admins to opt back into
+    webhook interception of `*SubjectAccessReview` requests.
 
 ### Upgrade / Downgrade Strategy
 

--- a/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
+++ b/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
@@ -326,7 +326,7 @@ machinery.
 exclusion today. For beta, they will implement `WantsExcludedAdmissionResources` and skip
 dispatch for the same set, gated by a new `ExcludeAdmissionWebhookVirtualResources` feature
 gate that defaults to enabled in 1.37. The gate is opt-out for clusters that need the prior
-behavior.
+behavior temporarily.
 
 Excluded resources (from `exclusion.Excluded()`, all API versions):
 
@@ -527,12 +527,14 @@ This ensures that platform-level policies enforced via static config take preced
 `WantsExcludedAdmissionResources` and consume the same `exclusion.Excluded()` list that
 `generic.Plugin` already injects into `ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy`.
 At admit time, when the `ExcludeAdmissionWebhookVirtualResources` feature gate is enabled, a
-request whose GroupResource is in the excluded set is not dispatched to webhooks. When the gate
-is disabled, dispatch behaves as it does today.
+request whose GroupResource is in the excluded set is not dispatched to webhooks (both static
+and REST-based). When the gate is disabled, dispatch behaves as it does today.
 
 This change is independent of the `staticManifestsDir` machinery and does not require operators
-to configure manifest-based admission. It is grouped with this KEP at beta because it shares
-review surface and rollout messaging with the broader manifest-based admission work.
+to configure manifest-based admission. It is grouped with this KEP at beta because we want
+webhook and CEL admission to behave consistently before manifest-based admission graduates to
+beta, and it shares review surface and rollout messaging with the broader manifest-based
+admission work.
 
 ### Test Plan
 

--- a/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
+++ b/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
@@ -552,25 +552,46 @@ admission chain.
 
 ##### Unit tests
 
-Coverage areas:
-- Manifest file loading, parsing, and validation
-- Error handling for missing/unreadable/malformed files
-- Composite accessor merging manifest and API-based configurations
+Manifest-based admission (alpha, already in tree; permalinks pinned at
+[`e136f393`](https://github.com/kubernetes/kubernetes/tree/e136f39334a72b7d35069a97d373ccaa0211dcae)):
+
+- [`staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/manifest/loader/loader_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/manifest/loader/loader_test.go) — `TestLoadManifests`, `TestValidatingLoadResult_GetWebhookAccessors`, `TestMutatingLoadResult_GetWebhookAccessors` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestLoadManifests))
+- [`staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/manifest/source/source_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/manifest/source/source_test.go) — `TestValidatingSource_*` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestValidatingSource))
+- [`staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/manifest/loader/loader_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/manifest/loader/loader_test.go) — `TestLoadPolicyManifests` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestLoadPolicyManifests))
+- [`staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/manifest/source/source_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/manifest/source/source_test.go) — `TestStaticPolicySource_*` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestStaticPolicySource))
+- [`staging/src/k8s.io/apiserver/pkg/admission/plugin/manifest/validation_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/staging/src/k8s.io/apiserver/pkg/admission/plugin/manifest/validation_test.go) — `TestValidateStaticManifestsDir`, `TestValidateManifestName`, `TestValidateWebhookClientConfig`, `TestValidateBindingReferences` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestValidateStaticManifestsDir))
+
+`ExcludeAdmissionWebhookVirtualResources` (added at beta; links will be added when the
+implementation PR lands):
+
+- `k8s.io/apiserver/pkg/admission/plugin/webhook/validating`: unit tests covering `WantsExcludedAdmissionResources` initializer wiring and dispatcher skip behavior with the gate enabled and disabled.
+- `k8s.io/apiserver/pkg/admission/plugin/webhook/mutating`: same coverage as validating.
 
 ##### Integration tests
 
-Test scenarios:
-- Bootstrap enforcement: Manifest policy active immediately at startup
-- Hot reload: Adding/removing manifest files updates enforcement
-- Invalid config handling: Server continues with previous valid config on reload errors
-- Coexistence: Both manifest and API-based configurations invoked
-- Metrics: Existing metrics include manifest-based admission with `.static.k8s.io` names
+Manifest-based admission (alpha, already in tree; permalinks pinned at
+[`e136f393`](https://github.com/kubernetes/kubernetes/tree/e136f39334a72b7d35069a97d373ccaa0211dcae)):
+
+- [`test/integration/apiserver/admissionwebhook/static_manifest_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/test/integration/apiserver/admissionwebhook/static_manifest_test.go) — `TestStaticWebhookBlocksAPICreation`, `TestStaticWebhookComprehensive` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestStaticWebhookComprehensive))
+- [`test/integration/apiserver/cel/static_policy_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/test/integration/apiserver/cel/static_policy_test.go) — `TestStaticPolicyBlocksAPICreation`, `TestStaticPolicyComprehensive` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestStaticPolicyComprehensive))
+
+VAP/MAP exclusion parity (existing, used as the reference for the new webhook tests):
+
+- [`test/integration/apiserver/cel/excludedresources_test.go`](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/test/integration/apiserver/cel/excludedresources_test.go) — `TestExcludedResources` ([triage](https://storage.googleapis.com/k8s-triage/index.html?test=TestExcludedResources))
+
+`ExcludeAdmissionWebhookVirtualResources` (added at beta; links will be added when the
+implementation PR lands):
+
+- `test/integration/apiserver/admissionwebhook/`: new test mirroring `excludedresources_test.go`. Covers (a) gate enabled — webhook is not dispatched for any GroupResource in `exclusion.Excluded()`; (b) gate disabled — webhook is dispatched as before; (c) parity with the VAP/MAP exclusion list.
 
 ##### e2e tests
 
-Not possible. e2e tests run against a cluster configured outside of the test, so we cannot
-modify API server startup flags or place files on the control plane host. This feature is
-best tested via integration tests.
+Not applicable for either feature. The manifest-based path requires API server startup flags
+and on-disk files on the control plane host, which e2e tests (running against a cluster
+configured outside the test) cannot manipulate. The webhook virtual-resource exclusion is
+gate-toggled API-server-internal behavior with no user-visible API surface; the existing
+VAP/MAP exclusion (PR [kubernetes/kubernetes#123543](https://github.com/kubernetes/kubernetes/pull/123543))
+established the same integration-only precedent.
 
 ### Graduation Criteria
 
@@ -671,9 +692,13 @@ behavior can set the gate to `false`.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes. Disable the `ManifestBasedAdmissionControlConfig` feature gate or remove the
+`ManifestBasedAdmissionControlConfig`: Yes. Disable the feature gate or remove the
 `staticManifestsDir` entries from `AdmissionConfiguration` and restart API server.
-Manifest-based admission controls will no longer be enforced.
+Manifest-based admission controls will no longer be enforced. No state is persisted.
+
+`ExcludeAdmissionWebhookVirtualResources`: Yes. Set the gate to `false` and restart API
+server. `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` will resume dispatching
+admission for resources in `exclusion.Excluded()`. No state is persisted.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
@@ -693,6 +718,12 @@ Rollout failures:
 - Invalid manifest files cause API server startup failure
 - Misconfigured webhooks (unreachable URLs) will reject requests if `failurePolicy: Fail`
 - In HA setups, inconsistent manifest files across API servers cause inconsistent behavior
+
+Rollback failures:
+- Downgrading to a release that predates `ExcludeAdmissionWebhookVirtualResources` (i.e.,
+  pre-1.37) with the gate still listed in `--feature-gates` will fail API server startup
+  with an "unrecognized feature gate" error. Operators must remove the gate from
+  `--feature-gates` before rolling back to such a release.
 
 Impact on running workloads:
 - Already running workloads are not affected (admission only applies to API requests)
@@ -716,7 +747,14 @@ Will be tested during alpha/beta, including upgrade→downgrade→upgrade path.
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
-No.
+Yes. As of 1.37, webhook admission's ability to intercept resources in
+`exclusion.Excluded()` (`SubjectAccessReview`, `SelfSubjectAccessReview`,
+`LocalSubjectAccessReview`, `SelfSubjectRulesReview`, `SelfSubjectReview`, `TokenReview`)
+is deprecated. The `ExcludeAdmissionWebhookVirtualResources` gate is opt-out for 3 releases
+/ 12 months (consistent with the Kubernetes deprecation policy) before being locked to
+enabled at GA, after which webhook admission can no longer be used to intercept these
+virtual resources. This brings webhook admission into parity with `ValidatingAdmissionPolicy`
+and `MutatingAdmissionPolicy`, which have always excluded these resources.
 
 ### Monitoring Requirements
 
@@ -821,6 +859,7 @@ for details on other platforms.
 | File permission errors on startup | `apiserver_manifest_admission_config_controller_automatic_reloads_total{status="failure"}` | Fix file permissions; Restart | API server logs show permission errors |
 | File permission errors on reload | `apiserver_manifest_admission_config_controller_automatic_reloads_total{status="failure"}` | Fix file permissions; Wait for reload or restart | API server logs show permission errors |
 | Configuration drift across HA | Inconsistent admission decisions | Use configuration management | Compare manifest files across API servers |
+| Webhook silently stops receiving `*SubjectAccessReview` / `TokenReview` / `SelfSubjectReview` after 1.37 upgrade | Existing `ValidatingWebhookConfiguration` / `MutatingWebhookConfiguration` rules cover GroupResources in `exclusion.Excluded()` and the webhook reports no such admission requests after upgrade | Set `ExcludeAdmissionWebhookVirtualResources=false` as a temporary escape hatch; remove webhook rules for those GroupResources as the long-term fix before the gate is locked at GA | Cross-reference webhook configuration `rules` against `pkg/kubeapiserver/admission/exclusion/resources.go`; webhook side has no observed admission requests for those resources |
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 

--- a/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
+++ b/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
@@ -24,6 +24,7 @@
   - [Metrics and Audit Annotations](#metrics-and-audit-annotations)
   - [Implementation](#implementation)
   - [Webhook Virtual Resource Exclusion Implementation](#webhook-virtual-resource-exclusion-implementation)
+    - [Deprecation Warnings for Affected Webhook Configurations](#deprecation-warnings-for-affected-webhook-configurations)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
@@ -537,6 +538,14 @@ webhook and CEL admission to behave consistently before manifest-based admission
 beta, and it shares review surface and rollout messaging with the broader manifest-based
 admission work.
 
+#### Deprecation Warnings for Affected Webhook Configurations
+
+To give cluster admins a pre-upgrade signal, the admission registration validator emits a
+deprecation warning on `CREATE`/`UPDATE` of `ValidatingWebhookConfiguration` /
+`MutatingWebhookConfiguration` whose rule explicitly names an excluded virtual resource in
+`apiGroups`, `apiVersions`, and `resources` (wildcards are not flagged because intent is
+ambiguous). At startup, pre-existing affected configurations are logged by name.
+
 ### Test Plan
 
 [x] I/we understand the owners of the involved components may require updates to
@@ -614,6 +623,9 @@ established the same integration-only precedent.
 - `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` implement
   `WantsExcludedAdmissionResources` and skip dispatch for the resources in
   `exclusion.Excluded()` when the gate is enabled
+- Deprecation warning on `CREATE`/`UPDATE` of webhook configurations whose rules
+  explicitly name an excluded virtual resource, plus a startup log for pre-existing
+  affected configurations
 - Integration tests covering webhook dispatch behavior with the gate enabled and disabled, and
   parity with the `ValidatingAdmissionPolicy` / `MutatingAdmissionPolicy` exclusion list
 - All known alpha issues resolved
@@ -740,6 +752,10 @@ Mitigation:
 - `apiserver_admission_webhook_rejection_count{name=~".*\\.static\\.k8s\\.io"}` unexpectedly high
 - API server crash loops (check container restart count)
 - Increased API request latency (webhook timeouts)
+- For `ExcludeAdmissionWebhookVirtualResources`: any deprecation warning on webhook
+  configuration writes (or startup log line) names a config that will lose traffic after
+  upgrade. No runtime counter is exposed because the signal is statically derivable from
+  configuration.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
@@ -755,6 +771,10 @@ is deprecated. The `ExcludeAdmissionWebhookVirtualResources` gate is opt-out for
 enabled at GA, after which webhook admission can no longer be used to intercept these
 virtual resources. This brings webhook admission into parity with `ValidatingAdmissionPolicy`
 and `MutatingAdmissionPolicy`, which have always excluded these resources.
+
+A deprecation warning is emitted on `CREATE`/`UPDATE` of webhook configurations whose
+rules explicitly name an excluded virtual resource, and pre-existing affected
+configurations are logged at startup.
 
 ### Monitoring Requirements
 
@@ -859,7 +879,7 @@ for details on other platforms.
 | File permission errors on startup | `apiserver_manifest_admission_config_controller_automatic_reloads_total{status="failure"}` | Fix file permissions; Restart | API server logs show permission errors |
 | File permission errors on reload | `apiserver_manifest_admission_config_controller_automatic_reloads_total{status="failure"}` | Fix file permissions; Wait for reload or restart | API server logs show permission errors |
 | Configuration drift across HA | Inconsistent admission decisions | Use configuration management | Compare manifest files across API servers |
-| Webhook silently stops receiving `*SubjectAccessReview` / `TokenReview` / `SelfSubjectReview` after 1.37 upgrade | Existing `ValidatingWebhookConfiguration` / `MutatingWebhookConfiguration` rules cover GroupResources in `exclusion.Excluded()` and the webhook reports no such admission requests after upgrade | Set `ExcludeAdmissionWebhookVirtualResources=false` as a temporary escape hatch; remove webhook rules for those GroupResources as the long-term fix before the gate is locked at GA | Cross-reference webhook configuration `rules` against `pkg/kubeapiserver/admission/exclusion/resources.go`; webhook side has no observed admission requests for those resources |
+| Webhook silently stops receiving `*SubjectAccessReview` / `TokenReview` / `SelfSubjectReview` after 1.37 upgrade | Pre-upgrade deprecation warning on webhook config writes (and startup log) names affected configurations; webhook reports no such admission requests after upgrade | Set `ExcludeAdmissionWebhookVirtualResources=false` as a temporary escape hatch; remove webhook rules for those GroupResources as the long-term fix before the gate is locked at GA | Cross-reference webhook configuration `rules` against `pkg/kubeapiserver/admission/exclusion/resources.go`; webhook side has no observed admission requests for those resources |
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 

--- a/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
+++ b/keps/sig-api-machinery/5793-manifest-based-admission-control-config/README.md
@@ -14,6 +14,7 @@
     - [Story 3: Bootstrapping Cluster Security](#story-3-bootstrapping-cluster-security)
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)
+  - [Unifying Excluded Virtual Resources for Webhook Admission](#unifying-excluded-virtual-resources-for-webhook-admission)
 - [Design Details](#design-details)
   - [New AdmissionConfiguration Schema](#new-admissionconfiguration-schema)
   - [Manifest File Format](#manifest-file-format)
@@ -22,6 +23,7 @@
   - [Decoding, Defaulting, and Validation](#decoding-defaulting-and-validation)
   - [Metrics and Audit Annotations](#metrics-and-audit-annotations)
   - [Implementation](#implementation)
+  - [Webhook Virtual Resource Exclusion Implementation](#webhook-virtual-resource-exclusion-implementation)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
@@ -88,6 +90,12 @@ This is achieved by augmenting the `AdmissionConfiguration` schema to include pa
 containing webhook and policy configurations that are loaded at API server startup and watched for
 changes at runtime.
 
+For beta, this KEP also proposes excluding the same set of authentication and authorization
+virtual resources from `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` that
+`ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy` already exclude. See
+[Webhook Virtual Resource Exclusion](#unifying-excluded-virtual-resources-for-webhook-admission)
+for details.
+
 ## Motivation
 
 Today, most policy enforcement in Kubernetes is implemented through:
@@ -139,6 +147,15 @@ controls that operates independently of the Kubernetes API.
    that cannot be used by REST-based objects. Existing REST-based configurations that need to
    be converted to manifest-based configurations must have the `.static.k8s.io` suffix added
    to their names.
+
+7. Consistent virtual resource exclusion across admission plugins:
+   `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` exclude the same authentication
+   and authorization virtual resources that `ValidatingAdmissionPolicy` and
+   `MutatingAdmissionPolicy` already exclude via `exclusion.Excluded()`. This closes the
+   inconsistency where a webhook intercepting these non-persisted resources can wedge a cluster
+   out of its own auth path. See
+   [kubernetes/kubernetes#122205](https://github.com/kubernetes/kubernetes/issues/122205) and
+   [kubernetes/kubernetes#123543](https://github.com/kubernetes/kubernetes/pull/123543).
 
 ### Non-Goals
 
@@ -290,6 +307,36 @@ for all relevant requests from API server startup, eliminating the bootstrap gap
 | Configuration drift | In HA setups, different API servers might have different manifest configurations. | This is documented as expected behavior (similar to other file-based configs). Operators must use external tooling to ensure consistency. |
 | Versioning | Manifest format must match API server version. | Standard API machinery decoding is used, supporting version conversion where applicable. |
 | Debugging difficulty | Manifest-based configurations are not visible via the API. | Dedicated metrics expose loaded configuration counts and health. Audit annotations indicate manifest-based sources. API server logs show loaded configurations at startup. |
+| Webhook behavior change from virtual resource exclusion | Clusters relying on a `ValidatingWebhookConfiguration` or `MutatingWebhookConfiguration` to intercept the excluded auth and authz virtual resources will stop receiving those requests when `ExcludeAdmissionWebhookVirtualResources` is enabled. | The feature gate is opt-out, so operators can disable it to restore prior behavior. Release notes and upgrade docs call this out so operators can audit existing webhook rules before upgrade. |
+
+### Unifying Excluded Virtual Resources for Webhook Admission
+
+[kubernetes/kubernetes#123543](https://github.com/kubernetes/kubernetes/pull/123543) introduced
+a fixed list of non-persisted authentication and authorization resources that
+`ValidatingAdmissionPolicy` skips to address the brickable resources problem
+([kubernetes/kubernetes#122205](https://github.com/kubernetes/kubernetes/issues/122205)): an
+admission control intercepting these resources can wedge a cluster out of its own auth path.
+The list lives in
+[`pkg/kubeapiserver/admission/exclusion`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubeapiserver/admission/exclusion/resources.go)
+and is plumbed into admission plugins via the `WantsExcludedAdmissionResources` initializer.
+`MutatingAdmissionPolicy` inherits this exclusion because it shares the same `generic.Plugin`
+machinery.
+
+`ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` do not participate in this
+exclusion today. For beta, they will implement `WantsExcludedAdmissionResources` and skip
+dispatch for the same set, gated by a new `ExcludeAdmissionWebhookVirtualResources` feature
+gate that defaults to enabled in 1.37. The gate is opt-out for clusters that need the prior
+behavior.
+
+Excluded resources (from `exclusion.Excluded()`, all API versions):
+
+| Group | Resources |
+|-------|-----------|
+| `authentication.k8s.io` | `selfsubjectreviews`, `tokenreviews` |
+| `authorization.k8s.io`  | `localsubjectaccessreviews`, `selfsubjectaccessreviews`, `selfsubjectrulesreviews`, `subjectaccessreviews` |
+
+Using the existing list rather than introducing a webhook-specific one keeps the four
+admission plugins in sync if the set ever changes.
 
 ## Design Details
 
@@ -474,6 +521,19 @@ This ensures that platform-level policies enforced via static config take preced
 4. Feature gate: `ManifestBasedAdmissionControlConfig`, defaulting to false for alpha
 5. Metrics: Add reload metrics for manifest loading health
 
+### Webhook Virtual Resource Exclusion Implementation
+
+`ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` will implement
+`WantsExcludedAdmissionResources` and consume the same `exclusion.Excluded()` list that
+`generic.Plugin` already injects into `ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy`.
+At admit time, when the `ExcludeAdmissionWebhookVirtualResources` feature gate is enabled, a
+request whose GroupResource is in the excluded set is not dispatched to webhooks. When the gate
+is disabled, dispatch behaves as it does today.
+
+This change is independent of the `staticManifestsDir` machinery and does not require operators
+to configure manifest-based admission. It is grouped with this KEP at beta because it shares
+review surface and rollout messaging with the broader manifest-based admission work.
+
 ### Test Plan
 
 [x] I/we understand the owners of the involved components may require updates to
@@ -525,7 +585,13 @@ best tested via integration tests.
 
 #### Beta
 
-- Feature gate defaults to enabled
+- `ManifestBasedAdmissionControlConfig` defaults to enabled
+- `ExcludeAdmissionWebhookVirtualResources` introduced and defaults to enabled in 1.37
+- `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` implement
+  `WantsExcludedAdmissionResources` and skip dispatch for the resources in
+  `exclusion.Excluded()` when the gate is enabled
+- Integration tests covering webhook dispatch behavior with the gate enabled and disabled, and
+  parity with the `ValidatingAdmissionPolicy` / `MutatingAdmissionPolicy` exclusion list
 - All known alpha issues resolved
 
 #### GA
@@ -541,6 +607,11 @@ Upgrade:
 - Enabling the feature and providing manifest configuration is opt-in
 - Existing clusters without manifest configuration see no change
 - Clusters can gradually adopt by adding manifest files without disruption
+- On upgrade to 1.37, `ExcludeAdmissionWebhookVirtualResources` is enabled by default. Existing
+  `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` rules that intercept any
+  resource in `exclusion.Excluded()` will stop receiving admission requests for those
+  resources. Operators should audit existing webhook rules before upgrade. Setting the gate to
+  `false` preserves the prior behavior.
 
 Downgrade:
 - Before downgrading to a version without this feature, operators must:
@@ -569,6 +640,8 @@ In HA setups with multiple API servers:
 - [x] Feature gate (also fill in values in `kep.yaml`)
   - Feature gate name: `ManifestBasedAdmissionControlConfig`
   - Components depending on the feature gate: `kube-apiserver`
+  - Feature gate name: `ExcludeAdmissionWebhookVirtualResources`
+  - Components depending on the feature gate: `kube-apiserver`
 - [x] Other
   - Mechanism: `--admission-control-config-file` pointing to an `AdmissionConfiguration` with
     `staticManifestsDir` configured
@@ -577,8 +650,14 @@ In HA setups with multiple API servers:
 
 ###### Does enabling the feature change any default behavior?
 
-No. Enabling the feature gate alone does not change behavior. Behavior changes only when manifest
-files are explicitly configured in `AdmissionConfiguration`.
+`ManifestBasedAdmissionControlConfig`: No. Behavior changes only when manifest files are
+configured in `AdmissionConfiguration`.
+
+`ExcludeAdmissionWebhookVirtualResources`: Yes. When enabled (the default in 1.37),
+`ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` no longer dispatch admission for
+the resources in `exclusion.Excluded()`, matching the behavior already in place for
+`ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy`. Clusters that need the prior
+behavior can set the gate to `false`.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
@@ -747,6 +826,10 @@ for details on other platforms.
 - 2020-04-21: Original KEP-1872 introduced for manifest-based admission webhooks
 - 2026-01-15: KEP-5793 created, expanding scope to include CEL-based policies (VAP/MAP)
 - 2026-03-12: Alpha implementation merged ([kubernetes/kubernetes#137346](https://github.com/kubernetes/kubernetes/pull/137346))
+- 2026-05-14: Beta KEP update to exclude the same auth and authz virtual resources from
+  `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook` that
+  `ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy` already exclude, behind the
+  `ExcludeAdmissionWebhookVirtualResources` opt-out feature gate, targeting v1.37
 
 ## Drawbacks
 

--- a/keps/sig-api-machinery/5793-manifest-based-admission-control-config/kep.yaml
+++ b/keps/sig-api-machinery/5793-manifest-based-admission-control-config/kep.yaml
@@ -19,17 +19,20 @@ see-also:
 replaces:
   - "/keps/sig-api-machinery/1872-manifest-based-admission-webhooks"
 
-stage: alpha
+stage: beta
 
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 milestone:
   alpha: "v1.36"
-  beta:
+  beta: "v1.37"
   stable:
 
 feature-gates:
   - name: ManifestBasedAdmissionControlConfig
+    components:
+      - kube-apiserver
+  - name: ExcludeAdmissionWebhookVirtualResources
     components:
       - kube-apiserver
 disable-supported: true


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Promote KEP-5793 to beta in v1.37

<!-- link to the k/enhancements issue -->
- Issue link: #5793 

<!-- other comments or additional information -->
- Other comments:
  -  proposal to make webhook admission consistent with CEL admission by excluding the same virtual resources (*SAR, TokenReview) for the same reasons mentioned in https://github.com/kubernetes/kubernetes/pull/123543 with a distinct escape-hatch gate around the exclusion change.

/sig api-machinery
/assign liggitt
/cc BenTheElder