### PR TITLE
KEP-5710: Update Workload-aware preemption KEP for beta in v1.37

### DIFF
--- a/keps/prod-readiness/sig-scheduling/5710.yaml
+++ b/keps/prod-readiness/sig-scheduling/5710.yaml
@@ -1,3 +1,5 @@
 kep-number: 5710
 alpha:
   approver: "@kannon92"
+beta:
+  approver: "@kannon92"

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -429,15 +429,27 @@ For Beta and GA, we will disallow the divergence between the priority of the `Po
 This will be done by the scheduler, which will fail scheduling of the `PodGroup`, once it observes such divergence.
 This mechanism will follow a similar mechanism already implemented in scheduler that disallows `PodGroup` with pods having different `spec.schedulerName`.
 We will check only the numerical value of the priority, not the priority class from which the value was derived.
-This information will be visible to the user in the description of the `PodScheduled` `Conditions` in the `Pod.Status` and `PodGroup.Status`:
+This information will be visible to the user in the description of the `PodScheduled` `Conditions` in the `Pod.Status` and 
+`PodGroupInitiallyScheduled` in `PodGroup.Status`:
 
 ```yaml
-status:
-  conditions:
-  - type: PodScheduled
-    status: "False"
-    reason: SchedulerError
+Pod:
+  status:
+    conditions:
+    - type: PodScheduled
+      status: "False"
+      reason: SchedulerError
     message: 'all pods in a single pod group should match the priority of the pod group, got: 1 and 2'
+```
+
+```yaml
+PodGroup:
+  status:
+    conditions:
+    - type: PodGroupInitiallyScheduled
+      status: "False"
+      reason: SchedulerError
+      message: 'all pods in a single pod group should match the priority of the pod group, got: 1 and 2'
 ```
 
 and via `FailedScheduling` event:
@@ -597,7 +609,9 @@ with preemption:
       of potential placements. For the alpha support of TAS, we will only assume the best placement (based on
       TAS Placement Scoring plugins). With the progression of TAS to Beta, we might change the algorithm to 
       consider top N placements and adjust their scores based on the amount of preemption victims each placement yields,
-      and only after that selecting the best one.
+      and only after that selecting the best one. For cases where TAS is rerun with some of the 
+      PodGroup pods already scheduled, the current placement of those pods will be selected by
+      TAS as the only placement.
       We can also see a future where if the algorithm is performant enough, even for the non TAS case,
       we will generate multiple potential placements and consider them, to select a placement that yields 
       the lowest amount of disruptions. 
@@ -712,9 +726,10 @@ extension point. As part of the beta promotion we will provide the implementatio
 tree plugin that implements the PostFilter interface (namely the DRA Plugin). We expect owners
 of out of tree PostFilters to follow with their own implementations.
 
-We will introduce additional safety check during the initialization, that will output a warning
+We will introduce additional safety check during the initialization, that will output an error
 log line when we detect plugins that implement PostFilter interface without implementing
-PodGroupPostFilter interface.
+PodGroupPostFilter interface. This check will be only enabled when `GenericWorkload` feature gate
+is enabled.
 
 The evaluation of PodGroupPostFilter plugins will reuse the same logic as the PostFilter one. Mainly,
 the plugins will be executed in the same order as they appear in the scheduler configuration,

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -21,6 +21,7 @@
   - [Pod Group priorities](#pod-group-priorities)
   - [Preemption algorithm](#preemption-algorithm)
     - [In place victim reprieval](#in-place-victim-reprieval)
+    - [CycleState retention](#cyclestate-retention)
   - [Pod Group Post Filter](#pod-group-post-filter)
   - [Potential future extensions](#potential-future-extensions)
   - [Test Plan](#test-plan)
@@ -593,14 +594,16 @@ with preemption:
           least ones). Tentatively, the function will sort first by their priority, and within a single
           priority prioritizing pod groups over individual pods.
 
-      1.  Perform best-effort reprieval of pod groups and pods violating PodDisruptionBudgets. We achieve
-          it by temporarily scheduling the preemptor (assuming that all potential victims are removed),
-          and then iterating over potential victims that would violate PodDisruptionBudget to check if these
-          can be placed in the exact same place they are running now.
-          If they can we simply leave them where they are running now and remove from the potential victims
-          list.
+      1.  Temprarily schedule the preemptor on the chosen placement (assuming that all potential victims are removed).
+ 
+      1.  Perform best-effort reprieval of pod groups and pods violating PodDisruptionBudgets. We achieve it by iterating 
+          over potential victims that would violate PodDisruptionBudget to check if these can be placed in the exact 
+          same place they are running now. If they can we simply leave them where they are running now and remove them 
+          from the potential victims list.
 
-          For domain D being a single node (current pod-based preemption), the above algorithm works
+      1.  Perform best-effort reprieval of remaining victims. We achieve it in the same manner as in the step above.
+
+          For the current pod-based preemption, the above algorithm works
           identically to the current algorithm. For larger domains, different placements of a preemptor
           are potentially possible and may result in potentially different sets of victims violating
           PodDisruptionBudgets to remain feasible. This means that the proposed algorithm is not necessarily
@@ -689,17 +692,40 @@ For currently implemented in-tree plugins that implement FilterPlugin interface 
 - TaintToleration: No-op. Scheduling constraint without inter pod constraints.
 - NodeResourceFit: The Reprieve method will check whether there is enough space for the victim pod given the current state of the node (with preemptor assumed).
 - NodeUnschedulable: No-op. Scheduling constraint without inter pod constraints. 
-- VolumeBinding:  The reprieve method will check whether reprieving victim will not cause exceed the CSI storage capacity limity for any storage class on a given node.
+- VolumeBinding:  No-op with the current implementation. No change in NodeInfoSnapshot can change the csiStorageCapacityLister output, thus allow preemptor to schedule in a way that breaks CSI storage capacity limity.
 - VolumeRestrictions: The Reprieve method will check whether the volume of victim does not conflict with the node local volumes of the preemptor pods. It will also check whether victim is not trying using `ReadWriteOncePod` PVC that is taken by any of the preemptor pod.
 - VolumeZone: No-op. Scheduling constraint between pod's PVs and node labels
 - PodTopologySpread: The reprieve method has to check whether reprieving a victim pod will not cause the skew of topologySpreadConstraint on the preemptor pod. This one can be potentially the hardest one to implement efficiently as it might require iterating over multiple nodes to calculate skew.
 - InterPodAffinity: We need to check whether preemptor does not have hard anti affinity to the victim pod. If so, reprieving victim would break the schedulability of the preemptor.  We also need to check whether reprieving back the victim pod won't violate any topology constraints (preemptor pod cannot be scheduled in a topology with specific pods running and victim is one of those specific pods). 
 - NodeDeclaredFeatures: No-op. Scheduling constraint.
-- NodeVolumeLimits: The Reprieve method will check whether the limits on the maximum volume attachment count per node won't be broken with assumed preemptor and reprieved victim. 
-- DynamicResources: No-op with current implementation. There is no way to simulate de allocation of the DRA devices  in the preemption, so the preemptor pods cannot take over the devices from victim pods.
+- NodeVolumeLimits: No-op with the current implementation. No change in NodeInfoSnapshot can change the csiManager output, thus allow preemptor to schedule in a way that breaks node volume limits.
+- DynamicResources: No-op with current implementation. There is no way to simulate de allocation of the DRA devices in the preemption, so the preemptor pods cannot take over the devices from victim pods.
+
+> **Note:**
+> DynamicResources, NodeVolumeLimits and VolumeBinding plugins do not work well with preemption right now.
+> They do not support PreFilterExtension interface and they work on a data provided by informer based
+> managers which does not reflect changes in NodeInfo snapshot. As a result they produce false negatives.
+> We do not expect to improve on this when introducing WAP and reprieval method.
 
 When trying to reprieve Pods belonging to the PodGroup with `DisruptionMode=All` the preemption logic will be responsible,
-for making sure that either all of Pods can be reprieved or none of them will be reprieved.
+for making sure that either all of Pods can be reprieved or none of them will be reprieved. This will be achieved 
+by reprieving all pods from PodGroup one by one. After each victim is reprieved, it will be added to the state
+of the cluster and kept in a list of pods to rollback. If any of the pods from PodGroup fails the Reprieve call
+all pods from rollback list will be removed from cluster representation.
+
+#### CycleState retention
+
+In the Alpha implementation of WAP the whole PodGroupScheduling function is executed for each victim "reprieval". It includes 
+building a new CycleState for each of the preemptor pods. This assumes that each of the plugin can create a valid
+CycleState based on the current NodeInfoSnapshot which is updated as victim pods are removed and added. This might not be true
+for plugins that use information from external informer and rely on the PreFilterExtension to keep a diff that is applied
+on top of the informer to simulate current state of the world (See [DRA Preemption Proposal](https://github.com/kubernetes/enhancements/issues/5690)). That's why for Beta promotion, we will refactor the PodGroupSchedulingAlgorithm to allow CycleState to be reused across the original scheduling atttempt and attempts in the WAP.
+
+In the current implementation of PodGroupSchedulingAlgorithm the CycleState for Nth Pod from PodGroup is created with previous (N-1) pods from the same PodGroup assumed. 
+To revert that from the CycleState of Nth Pod, we will need to run PreFilterExtension.RemovePod() for each of the (N-1) pods as part of clean up function that we currently run to remove Nth Pod from the NodeInfoSnapshot.
+
+This is akin to the current implementation of PostFilter, where the CycleState from original scheduling attempt is passed
+to Postfilter method.
 
 ### Pod Group Post Filter
 
@@ -767,6 +793,14 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
    consider multiple different placements. This will have much bigger impact once kube-scheduler
    supports topology-aware scheduling. As a result, we're leaving it as a future extension -
    the algorithm can always be improved and will result in pretty local code changes.
+
+1. Binary search during preemption
+
+   One of the potential optimizations for the workload aware preemption algorithm presented in this 
+   KEP, is a special step that would use a binary search across victim priorities to try to fin
+   a minimal priority N for which, we can schedule a preemptor PodGroup without preempting
+   any victims with priority higher than N. This could limit the number of the potential victims
+   to check at the cost of additional scheduling feasibility checks.
 
 1. Non-uniform priority across CompositePodGroups.
 
@@ -1068,7 +1102,8 @@ behavior).
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
-No.
+During promotion to Beta, the `WorkloadAwarePreemption` feature gate will be removed and
+Workload Aware Preemption features will be moved behind the `GenericWorkload` feature gate.
 
 ### Monitoring Requirements
 

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -14,7 +14,6 @@
     - [AI Training Job as preemptor](#ai-training-job-as-preemptor)
     - [Preemption of Multihost Inference](#preemption-of-multihost-inference)
     - [Preemption of Multihost Inference that can run in a degraded mode](#preemption-of-multihost-inference-that-can-run-in-a-degraded-mode)
-    - [Preemption cost](#preemption-cost)
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -79,7 +78,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [X] (R) Production readiness review approved
 - [X] "Implementation History" section is up-to-date for milestone
 - [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [X] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
 **Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
@@ -157,8 +156,8 @@ and many others) and bring the true value for every Kubernetes user.
 
 ## Proposal
 
-This KEP is tightly coupled with [KEP-4671: Gang Scheduling using Workload Object] one. It is building
-on foundations introduced there and assumes the knowledge of the concepts introduces there. 
+This KEP is tightly coupled with [KEP-4671: Gang Scheduling using Workload Object] one.
+It is building on foundations introduced there and assumes the knowledge of the concepts introduced there.
 
 We believe that providing a Gang Scheduling capability without a dedicated preemption mechanism for it
 is of no use for the high performance batch workloads for which this feature is primarily designed.
@@ -228,18 +227,13 @@ I don't want to preempt the whole replica (one leader and N workers) if a single
 would be preempted, because I prefer to serve in a degraded mode than be completely
 disrupted.
 
-#### Preemption cost
-
-When a long-running AI Training job, its cost of preemption differs over time and depends
-on how long ago it checkpointed its state. I want to be able to somehow influence the
-preemption priority of my job based on how much would it really cost me.
-
-This story is treated directionally and will not be addressed in Alpha and Beta.
-
 
 ### Notes/Constraints/Caveats
 
-For alpha we defined a Workload Aware Preemption as a separate feature that can be disabled independently of the Gang Scheduling. We acknowledge that for Beta, releasing the Gang Scheduling without Workload Aware Preemption does not provide enough value for the end users. That's why in Beta we merge those two features and progress them together under single `GenericWorkload` feature gate.
+For alpha we defined a Workload Aware Preemption as a separate feature that can be disabled
+independently of the Gang Scheduling. We acknowledge that for Beta, releasing the Gang Scheduling
+without Workload Aware Preemption does not provide enough value for the end users. That's why in
+Beta we merge those two features and progress them together under single `GenericWorkload` feature gate.
 
 <!--
 What are the caveats to the proposal?
@@ -326,8 +320,6 @@ type PodGroupSpec struct {
     // Controllers are expected to fill this field by copying it from a PodGroupTemplate.
     // One of Single, All. Defaults to Single if unset.
     // This field is immutable.
-    // This field is available only when the GangScheduling feature gate
-    // is enabled.
     DisruptionMode *DisruptionMode 
 }
 ```
@@ -422,7 +414,7 @@ the possible divergence in the documentation.
 For Beta and GA, we will disallow the divergence between the priority of the `Pod` and the `PodGroup`. 
 This will be done by the scheduler, which will fail scheduling of the `PodGroup`, once it observes such divergence.
 This mechanism will follow a similar mechanism already implemented in scheduler that disallows `PodGroup` with pods having different `spec.schedulerName`.
-This information will be visible to the user in the description of the `PodScheduled` `Conditions` in the `Pod.Status`
+This information will be visible to the user in the description of the `PodScheduled` `Conditions` in the `Pod.Status` and `PodGroup.Status`:
 
 ```yaml
 status:
@@ -431,6 +423,29 @@ status:
     status: "False"
     reason: SchedulerError
     message: 'all pods in a single pod group should match the priority of the pod group, got: 1 and 2'
+```
+
+and via `FailedScheduling` event:
+
+```json
+{
+  "apiVersion": "v1",
+  "kind": "Event",
+  "metadata": {
+    ...
+  },
+  "involvedObject": {
+    ...
+  },
+  "reason": "FailedScheduling",
+  "message": "all pods in a single pod group should have the same .spec.schedulerName set, got: \"custom-scheduler-1\" and \"custom-scheduler-2\"",
+  "source": {
+    "component": "default-scheduler"
+  },
+  "type": "Warning",
+  "action": "Scheduling",
+  "reportingComponent": "default-scheduler"
+}
 ```
 
 We might relax this restriction in the future if there is a strong use cases that justify it. 
@@ -554,10 +569,10 @@ with preemption:
 1. For every domain computed above run the following points:
 
    1. Identify the list of all potential victims in that domain:
-      - all running pod groups with (preemption) priority lower then preemptor priority; note that
+      - all running pod groups with (preemption) priority lower than preemptor priority; note that
         some pods from that pod group may be running outside of currently considered domain D - they
         need to contribute to scoring, but they won't contribute to feasibility of domain D.
-      - all individual pods with priority lower then preemptor priority
+      - all individual pods with priority lower than preemptor priority
 
    1. If removing all potential victims would not make the preemptor schedulable, the preemptor
       is unschedulable with preemption in currently considered domain D.
@@ -625,116 +640,15 @@ we will be able to achieve in-place replacement with relatively localized change
 The algorithm described above assumes that we can cheaply check if a potential victim pod can be placed back where they are currently running after preemptor has been `assumed` on the target node. However there is no extension point like this implemented in the scheduler as of right now. During scheduling, the scheduler uses Filter plugins to check whether a pod can run on a given node. This process is heavy and requires to build a `cycleState` object, particularly for plugins that have inter pod constraints such as pod affinity (pod running on node A can fail "Filter" on node B). Running `Filter()` and building a `cycleState` for all of the victims does not seem like a feasible option from performance perspective.
 
 However, one can note that actually do not need a full Filter check. Instead of checking if the victim pod can be scheduled back on its node, we need to check whether keeping the victim pod on a node will break the schedulability of the preemptor that we assumed. Mainly, this means that we do not have to meet the scheduling constraints for victim pod, and we only care about scheduling constraints of the preemptor pod that could be broken. Such check can be implemented by extending Filter plugins with a new method.
-We propose to tenantively call it `Reprieve` with following semantics for Beta:
+We propose to tenantively call it `Reprieve` with following semantics:
 
 ```go 
-// ReprieveExtension is an interface that is included in Filter plugins that allow specifying
-// reprieve method used by workload aware preemption.
-type ReprieveExtension interface {
-    // Reprieve is called by the workload aware preemption.
-    // All FilterPlugins should return "Success" to declare that
-    // the given victim pod can be placed back on the given node
-    // without breaking the schedulability of the preemptor pod on this node.
-    // If Reprieve does not return "Success", it will return "Unschedulable"
-    // or "Error".
-    //
-    // "Error" aborts preemption.
-    //
-    // For the node being evaluated Filter plugins should look at the passed
-    // nodeInfo reference for this particular node's information instead of
-    // looking it up in the NodeInfoSnapshot because during preemption
-    // the state of the node can be mutated to evaluate the possibility of  preempting 
-    // them to schedule preemptor pods. The same stands for all nodes belonging 
-    // to the cluster, as they might be out of sync with NodeInfoSnapshot.
-
-    // Plugins are encouraged to check the context for cancellation.
-    // Once canceled, they should return as soon as possible with
-    // an Unschedulable status that includes the
-    // `context.Cause(ctx)` error explanation.
-    Reprieve(ctx context.Context, victimPod *v1.Pod, nodeInfo NodeInfo,  preemptorPods []*v1.Pod clusterNodes []NodeInfo) *Status
-}
-
-// FilterPlugin is an interface for Filter plugins. These plugins are called at the
-// filter extension point for filtering out hosts that cannot run a pod.
-// This concept used to be called 'predicate' in the original scheduler.
-// These plugins should return "Success", "Unschedulable" or "Error" in Status.code.
-// However, the scheduler accepts other valid codes as well.
-// Anything other than "Success" will lead to exclusion of the given host from
-// running the pod. Plugins that implement FilterPlugin should
-// also implement SignPlugin to enable batching optimizations.
+// ...
+// FilterPlugin also needs to implement Reprieve method
+// for effective preemption for pod groups.
 type FilterPlugin interface {
     Plugin
-    // Filter is called by the scheduling framework.
-    // All FilterPlugins should return "Success" to declare that
-    // the given node fits the pod. If Filter doesn't return "Success",
-    // it will return "Unschedulable", "UnschedulableAndUnresolvable" or "Error".
-    //
-    // "Error" aborts pod scheduling and puts the pod into the backoff queue.
-    //
-    // For the node being evaluated, Filter plugins should look at the passed
-    // nodeInfo reference for this particular node's information (e.g., pods
-    // considered to be running on the node) instead of looking it up in the
-    // NodeInfoSnapshot because we don't guarantee that they will be the same.
-    // For example, during preemption, we may pass a copy of the original
-    // nodeInfo object that has some pods removed from it to evaluate the
-    // possibility of preempting them to schedule the target pod.
-    //
-    // Plugins are encouraged to check the context for cancellation.
-    // Once canceled, they should return as soon as possible with
-    // an UnschedulableAndUnresolvable status that includes the
-    // `context.Cause(ctx)` error explanation. For example, the
-    // context gets canceled when a sufficient number of suitable
-    // nodes have been found and searching for more isn't necessary
-    // anymore.
-    Filter(ctx context.Context, state CycleState, pod *v1.Pod, nodeInfo NodeInfo) *Status 
-    // ReprieveExtension returns a ReprieveExtension interface if the plugin implements one,
-    // or nil if it does not.
-    ReprieveExtension() ReprieveExtension
-}
-```
 
-We expect that for Filter plugins that do not enforce inter pod constraints the implementation should be trivial. We will
-provide an implementation for all the in-tree Filter plugins. We expect that the owners of out-of-tree plugins will 
-follow with the implementation of `Reprieve` for their plugins.
-
-For Beta, the workload aware preemption, thus the gang scheduling will be disabled if any of the Filter plugins registered does not support the Reprieve extension.
-
-For GA, we state that the Reprieve method is required for an effective workload aware preemption. That's why we will promote the Reprieve extension to become a method of the FilterPlugin interface as follows:
-
-```go
-// FilterPlugin is an interface for Filter plugins. These plugins are called at the
-// filter extension point for filtering out hosts that cannot run a pod.
-// This concept used to be called 'predicate' in the original scheduler.
-// These plugins should return "Success", "Unschedulable" or "Error" in Status.code.
-// However, the scheduler accepts other valid codes as well.
-// Anything other than "Success" will lead to exclusion of the given host from
-// running the pod. Plugins that implement FilterPlugin should
-// also implement SignPlugin to enable batching optimizations.
-type FilterPlugin interface {
-    Plugin
-    // Filter is called by the scheduling framework.
-    // All FilterPlugins should return "Success" to declare that
-    // the given node fits the pod. If Filter doesn't return "Success",
-    // it will return "Unschedulable", "UnschedulableAndUnresolvable" or "Error".
-    //
-    // "Error" aborts pod scheduling and puts the pod into the backoff queue.
-    //
-    // For the node being evaluated, Filter plugins should look at the passed
-    // nodeInfo reference for this particular node's information (e.g., pods
-    // considered to be running on the node) instead of looking it up in the
-    // NodeInfoSnapshot because we don't guarantee that they will be the same.
-    // For example, during preemption, we may pass a copy of the original
-    // nodeInfo object that has some pods removed from it to evaluate the
-    // possibility of preempting them to schedule the target pod. The same stands for
-    // all nodes belonging to the cluster, as they might be out of sync with NodeInfoSnapshot.
-    //
-    // Plugins are encouraged to check the context for cancellation.
-    // Once canceled, they should return as soon as possible with
-    // an UnschedulableAndUnresolvable status that includes the
-    // `context.Cause(ctx)` error explanation. For example, the
-    // context gets canceled when a sufficient number of suitable
-    // nodes have been found and searching for more isn't necessary
-    // anymore.
     Filter(ctx context.Context, state CycleState, pod *v1.Pod, nodeInfo NodeInfo) *Status
 
     // Reprieve is called by the preemption.
@@ -760,21 +674,46 @@ type FilterPlugin interface {
 }
 ```
 
+We expect that for Filter plugins that do not enforce inter pod constraints the implementation should be trivial. We will
+provide an implementation for all the in-tree Filter plugins. We expect that the owners of out-of-tree plugins will
+follow with the implementation of `Reprieve` for their plugins.
+
+<!-- TODO(argh4k): Add short description of implementation of reprieve for in-tree Filter Plugins -->
+
+When trying to reprieve Pods belonging to the PodGroup with `DisruptionMode=All` the preemption logic will be responsible,
+for making sure that either all of Pods can be reprieved or none of them will be reprieved.
+
+
 ### Pod Group Post Filter
 
-As part of minimizing preemptions goal, arguably the most important thing to do is to avoid unnecessary preemptions. However, with the current model of preemption when preemption is triggered immediately after the victims are decided and PostFilter is run per Pod in PodGroup, it doesn't achieve this goal. The reason for that is that the proposed placement (nomination) can actually appear to be invalid and not be proceeded with, if the whole PodGroup fails to schedule. In such case we will not even proceed to binding and the preemption will be completely unnecessary disruption.
+As part of minimizing preemptions goal, arguably the most important thing to do is to avoid unnecessary preemptions. However, with the model of preemption when preemption is triggered immediately after the victims are decided and PostFilter is run per Pod in PodGroup, it doesn't achieve this goal. The reason for that is that the proposed placement (nomination) can actually appear to be invalid and not be proceeded with, if the whole PodGroup fails to schedule. In such case we will not even proceed to binding and the preemption will be completely unnecessary disruption.
 
-For alpha, to avoid triggering unnecessary preemptions, we disabled the default preemption plugin in PostFilter for pods from PodGroup if the workload aware preemption was enabled.
+For alpha, to avoid triggering unnecessary preemptions, we disabled the default preemption
+plugin in PostFilter for pods from PodGroup if the workload aware preemption was enabled.
 
-For beta, we acknowledge that the default preemption is not the only PostFilter plugin out there. Other PostFilter plugins can also perform disruptive actions. In the current model, those plugins works only on the outcome of single pod scheduling cycle, within a PodGroup cycle. With that they do not have a full picture of the pod group scheduling outcome and can perform actions that are either not optimal or in the worst case will not make the PodGroup schedulable anwyay.
+For beta, we acknowledge that the default preemption is not the only PostFilter plugin out there.
+Other PostFilter plugins can also perform disruptive actions. In the current model, those plugins
+works only on the outcome of single pod scheduling cycle, within a PodGroup cycle. With that they
+do not have a full picture of the pod group scheduling outcome and can perform actions that are
+either not optimal or in the worst case will not make the PodGroup schedulable anwyay.
 
-For beta and GA we propose to disable all PostFilter plugins in the pod group scheduling cycle in favor of the newly added PodGroupPostFilter extension point. This extension point will be called only once after the whole pod group fails to schedule. 
-It will provide data about the outcome of whole PodGroup scheduling cycle and allow users to define actions that can be taken to make the PodGroup schedulable. Workload Aware Preemption will be one of the implementations of this extension point. As part of the beta promotion we will provide the implementation for other in tree plugin that implements the PostFilter interface (namely the DRA Plugin). We expect owners of out of tree PostFilters to follow with their own implementations.
+For beta and GA we propose to disable all PostFilter plugins in the pod group scheduling cycle in
+favor of the newly added PodGroupPostFilter extension point. This extension point will be called
+only once after the whole pod group fails to schedule. It will provide data about the outcome of
+whole PodGroup scheduling cycle and allow users to define actions that can be taken to make the
+PodGroup schedulable. Workload Aware Preemption will be one of the implementations of this
+extension point. As part of the beta promotion we will provide the implementation for other in
+tree plugin that implements the PostFilter interface (namely the DRA Plugin). We expect owners
+of out of tree PostFilters to follow with their own implementations.
+
+The evaluation of PodGroupPostFilter plugins will reuse the same logic as the PostFilter one. Mainly,
+the plugins will be executed in the same order as they appear in the scheduler configuration,
+and the first plugin that returns a success result, will stop evaluation of any further plugins.
 
 ```go
 // PodGroupPostFilterResult stores information about nominated nodes for a pod group.
 type PodGroupPostFilterResult struct {
-    NominatedNodeNames map[*v1.Pod]*fwk.NominatingInfo
+    NominatingInfos map[*v1.Pod]*fwk.NominatingInfo
 }
 
 // PodGroupPostFilterPlugin is an interface for "PodGroupPostFilter" plugins. These plugins are called
@@ -814,7 +753,7 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
 
 1. Non-uniform priority across CompositePodGroups.
 
-   We anticipate that in the future the `CompositePodGroup` concept will be introduced. We can envision
+   The `CompositePodGroup` concept is also being introduced to Workload API. We can envision
    a case where different `CompositePodGroups` will require to have different preemption priorities.
    To achieve that, we could introduce `PriorityClassName` field also at the `CompositePodGroup` level, with the semantic that lower-level structure overwrites the higher-level one (e.g. priority set for `PodGroup` overwrites the priority
    for `CompositePodGroup`). So the API and semantics proposed in this KEP would allow for achieving
@@ -853,7 +792,7 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
    we make preemption priority mutable.
 
    However, given an ability to achieve both of these in backward compatible way later, we leave
-   those for future extensions.
+   those for future extensions. We expect this improvement to come up in a dedicated, follow up KEP.
 
 1. PodGroupPostFilter extension
    
@@ -944,8 +883,6 @@ For GA we will promote those tests to conformance.
 
 #### GA
 
-- Decision about additional sorting/scoring preemption victims to minimize preemption cost
-- Decision whether we support mutability of Priority for GA
 - E2E test promoted to conformance
 - Performance benchmarks have well defined thresholds and are run as part of the scheduler-perf of sig-scalability-benchmarks
 - All known issues resolved 
@@ -997,8 +934,8 @@ creating the `PodGroup` object.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes, the preemption algorithm changes can be disabled by simply disabling the feature gate
-in kube-scheduler. However, this requires also disabling a Gang Scheduling feature.
+Yes, the preemption algorithm changes can be disabled by simply disabling `GenericWorkload` feature gate
+in kube-scheduler. However, this will also disable a Gang Scheduling feature.
 
 The new API changes and admission can also be disabled by disabling the feature gate in
 kube-apiserver. However keep in mind that it doesn't result in clearing the new fields
@@ -1028,7 +965,7 @@ enablement/disablement tests - the logic will be covered by regular feature test
 
 The API fields related to Workload Aware Preemption are no longer hidden behind a separate
 feature gate and will be promoted with the whole API to beta. There is no need for the
-dedicated enablement/disablement tests at the kube-apiserver registry layer
+dedicated enablement/disablement tests at the kube-apiserver registry layer.
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -1047,6 +984,7 @@ This results in a fallback to the status quo behavior, meaning that pods will be
 - `scheduler_podgroup_preemption_attempts_total{result="error"}`: A sudden spike indicates internal errors or panics within 
 the workload aware preemption logic.
 - `scheduler_podgroup_preemption_attempt_duration_seconds`: A significant P99 latency would indicate that the performance of the new logic is unacceptable.
+- `plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}`: A sudden increase of the latency of default preemption, especially if there is no PodGroup objects in the cluster indicates an issue with the workload aware default preemption.
 
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
@@ -1133,8 +1071,30 @@ Recall that end users cannot usually observe component logs or access metrics.
 -->
 
 - [X] Events
-  - Event Reason: Preempting
-  - The preemption message will have "cluster" set as a node name.
+  - ```json
+    {
+    "kind": "Event",
+    "involvedObject": {
+      "kind": "Pod",
+    },
+    "related": {
+      "kind": "PodGroup",
+    },
+    "reason": "Preempted",
+    "message": "Preempted by podgroup ... on node cluster",
+    "source": {
+      "component": "default-scheduler"
+    },
+    "type": "Normal",
+    "action": "Preempting",
+    "reportingComponent": "default-scheduler"
+    }
+    ```
+- [X] API .status
+  - Object: PodGroup
+  - Condition Name: `PodGroupScheduled`
+  - reason: `Unschedulable`
+  - message: `pod group is waiting for podgroup preemption to complete`
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
@@ -1149,6 +1109,7 @@ feature primarily in terms of non-regression to ensure the workload aware preemp
   when scheduling pods requires preemption of pods grouped in PodGroups (DisruptionMode = All) compared to scheduling an equivalent number of pods in PodGroups that would require preemption of similar number of pods but not grouped in PodGroup.
   This can be measured by the number of Pod binding API calls arriving to the API server
   (`apiserver_request_total{resource="pods", subresource="binding"}`).
+- Default Preemption Performance: There should be no significant regression in the default preemption performance, especially when there are no PodGroups in the cluster. This can be measured by the `plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}` metric.
 
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
@@ -1158,7 +1119,8 @@ feature primarily in terms of non-regression to ensure the workload aware preemp
     - scheduler_podgroup_preemption_attempts_total
     - scheduler_podgroup_preemption_attempt_duration_seconds
     - scheduler_podgroup_preemption_victims
-    - plugin_execution_duration_seconds{extension_point=Reprieval}
+    - plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="Reprieval"}
+    - plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}
   - Components exposing the metric: kube-scheduler
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
@@ -1243,7 +1205,7 @@ Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus f
 - Diagnostics: Scheduler logs at V=6 searching for logs from podgrouppreemption.go file to trace where preemption slows down.
 - Testing: The scheduler performance benchmarks should catch potential issues with a poor performance of the workload aware preemption
 
-1. WorkloadAwarePreemption does not remove low level pods to make a place for the preemptor
+2. WorkloadAwarePreemption does not remove low level pods to make a place for the preemptor
 - Detection: Check Pod Events/Status. Expected reason: a message indicating why preemption failed
 - Metrics: `scheduler_podgroup_preemption_attempts_total{result=error}`
 - Mitigations:
@@ -1255,7 +1217,7 @@ Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus f
 - Testing:
   - Covered by integration tests
 
-1. WorkloadAwarePreemption removes more pods than necessary 
+3. WorkloadAwarePreemption removes more pods than necessary
 
 - Detection: The amount of pods with status `preempted by podgroup X` is higher than expected for a given pod group
 - Mitigations: If intended, delete the PodGroup object and recreate the pods without `schedulingGroup`to disable gang  
@@ -1265,6 +1227,8 @@ Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus f
 - Testing: The scheduler performance benchmarks should catch potential issues with a poor performance of the workload aware preemption
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
+
+<!-- TODO-->
 
 ## Implementation History
 

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -678,11 +678,24 @@ We expect that for Filter plugins that do not enforce inter pod constraints the 
 provide an implementation for all the in-tree Filter plugins. We expect that the owners of out-of-tree plugins will
 follow with the implementation of `Reprieve` for their plugins.
 
-<!-- TODO(argh4k): Add short description of implementation of reprieve for in-tree Filter Plugins -->
+For currently implemented in-tree plugins that implement FilterPlugin interface the Reprieve method will work as follows:
+- NodeName: No-op. Scheduling constraint without inter pod constraints.
+- NodePorts: The Reprieve method will check whether the preemptor pods do not use the same `hostPort` as victim pod. If they do, reprieving victim pod breaks schedulability of the preemptor.
+- NodeAffinity: No-op. Scheduling constraint without inter pod constraints.
+- TaintToleration: No-op. Scheduling constraint without inter pod constraints.
+- NodeResourceFit: The Reprieve method will check whether there is enough space for the victim pod given the current state of the node (with preemptor assumed).
+- NodeUnschedulable: No-op. Scheduling constraint without inter pod constraints. 
+- VolumeBinding:  The reprieve method will check whether reprieving victim will not cause exceed the CSI storage capacity limity for any storage class on a given node.
+- VolumeRestrictions: The Reprieve method will check whether the volume of victim does not conflict with the node local volumes of the preemptor pods. It will also check whether victim is not trying using `ReadWriteOncePod` PVC that is taken by any of the preemptor pod.
+- VolumeZone: No-op. Scheduling constraint between pod's PVs and node labels
+- PodTopologySpread: The reprieve method has to check whether reprieving a victim pod will not cause the skew of topologySpreadConstraint on the preemptor pod. This one can be potentially the hardest one to implement efficiently as it might require iterating over multiple nodes to calculate skew.
+- InterPodAffinity: We need to check whether preemptor does not have hard anti affinity to the victim pod. If so, reprieving victim would break the schedulability of the preemptor.  We also need to check whether reprieving back the victim pod won't violate any topology constraints (preemptor pod cannot be scheduled in a topology with specific pods running and victim is one of those specific pods). 
+- NodeDeclaredFeatures: No-op. Scheduling constraint.
+- NodeVolumeLimits: The Reprieve method will check whether the limits on the maximum volume attachment count per node won't be broken with assumed preemptor and reprieved victim. 
+- DynamicResources: No-op with current implementation. There is no way to simulate de allocation of the DRA devices  in the preemption, so the preemptor pods cannot take over the devices from victim pods.
 
 When trying to reprieve Pods belonging to the PodGroup with `DisruptionMode=All` the preemption logic will be responsible,
 for making sure that either all of Pods can be reprieved or none of them will be reprieved.
-
 
 ### Pod Group Post Filter
 
@@ -1095,6 +1108,11 @@ Recall that end users cannot usually observe component logs or access metrics.
   - Condition Name: `PodGroupScheduled`
   - reason: `Unschedulable`
   - message: `pod group is waiting for podgroup preemption to complete`
+- [X] API .status
+  - Object: Pod
+  - Condition Name: `DisruptionTarget`
+  - reason: `PreemptionByScheduler`
+  - message: `default-scheduler: preempting to accommodate a higher priority podgroup"
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
@@ -1228,7 +1246,23 @@ Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus f
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
-<!-- TODO-->
+If workload aware preemption latency is the problem:
+
+1. Increase Log Verbosity: Set the default scheduler log level to `-v=6` (or `-v=10` for deep tracing) to capture internal scheduling steps.
+2. Examine Scheduler Logs: Filter logs for source file `podgrouppreemption.go` and look for execution duration messages in the preemption evaluation flow.
+3. Identify Expensive Reprieve Plugins: Determine which specific filter plugins are taking too long during victim reprieval. Plugins that maintain complex topological indexing or search trees (such as `InterPodAffinity` or `PodTopologySpread`) may be executing expensive logic repeatedly in their `Reprieve` methods over candidate domains.
+4. Disable Feature: If the regression is critical and impacting cluster health, disable the GenericWorkload feature gate. This will revert the scheduler to the standard pod-by-pod logic, restoring baseline performance (at the cost of losing gang semantics together with workload aware preemption).
+
+If preemptor workloads are stuck and preemption attempts fail:
+
+1. Inspect Preemptor Pod Status and Events:
+   - Run `kubectl describe pod <preemptor-pod>` to inspect scheduler warnings or event logs. Look for errors with message `pod group preemption`.
+   - Check status conditions of the preemptor Pods and their parent `PodGroup`:
+     - Preemptor Pods: Check for `{type: PodScheduled, status: False, reason: Unschedulable}` with a detailed descriptive message.
+     - Preemptor PodGroup: Check for the `PodGroupScheduled` status condition with `reason: Unschedulable` and message (e.g., `pod group is waiting for podgroup preemption to complete`).
+2. Examine Scheduler Logs: Filter logs for source file `podgrouppreemption.go` and look for messages indicating why the preemption attempts are failing.
+3. Disable Feature: Instead of using PodGroup, create pods as separate pods and rely on the default preemption algorithm.
+
 
 ## Implementation History
 

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -22,6 +22,8 @@
   - [Preemption algorithm](#preemption-algorithm)
     - [In place victim reprieval](#in-place-victim-reprieval)
     - [CycleState retention](#cyclestate-retention)
+      - [TopologyAwareScheduling](#topologyawarescheduling)
+    - [CompositePodGroup](#compositepodgroup)
   - [Pod Group Post Filter](#pod-group-post-filter)
   - [Potential future extensions](#potential-future-extensions)
   - [Test Plan](#test-plan)
@@ -154,6 +156,8 @@ and many others) and bring the true value for every Kubernetes user.
   If we decide to change that it will be addressed in a dedicated KEP.
 - Propose any tradeoff between preemption and cluster scale-up.
 - Design workload-level preemption triggered by external schedulers
+- Handling non-uniform priorities across PodGroups/CompositePodGroups
+- Full support for Topology Aware Scheduling. This will be provided in TAS KEP.
 
 ## Proposal
 
@@ -326,7 +330,12 @@ type PodGroupSpec struct {
 ```
 
 Given that preemption unit shouldn't be larger then the scheduling unit, additional validation
-will be added to prevent `All` disruption mode for PodGroups with BasicSchedulingPolicy. 
+will be added to prevent `All` disruption mode for PodGroups with BasicSchedulingPolicy.
+
+The DisruptionMode is modeled as a struct to allow future extensibility, especially with the 
+upcoming CompositePodGroup. This KEP approval does not mean that these plans are approved
+but we are seeing potential future use cases, like custom DisruptionMode with "preempt 
+single units until X, then preempt all" semantics, which require DisrtupionMode to be expandable.
 
 While the `PreemptionMode` might seem the more natural name here, we envision that the same
 concept can be later used in `Eviction` API and other usecases, so we already start with a more
@@ -415,6 +424,7 @@ the possible divergence in the documentation.
 For Beta and GA, we will disallow the divergence between the priority of the `Pod` and the `PodGroup`. 
 This will be done by the scheduler, which will fail scheduling of the `PodGroup`, once it observes such divergence.
 This mechanism will follow a similar mechanism already implemented in scheduler that disallows `PodGroup` with pods having different `spec.schedulerName`.
+We will check only the numerical value of the priority, not the priority class from which the value was derived.
 This information will be visible to the user in the description of the `PodScheduled` `Conditions` in the `Pod.Status` and `PodGroup.Status`:
 
 ```yaml
@@ -650,6 +660,13 @@ However, one can note that actually do not need a full Filter check. Instead of 
 We propose to tenantively call it `Reprieve` with following semantics:
 
 ```go 
+
+type PreemptorPlacement struct {
+  Pod        *v1.Pod
+  Node       NodeInfo
+  CycleState CycleState
+}
+
 // ...
 // FilterPlugin also needs to implement Reprieve method
 // for effective preemption for pod groups.
@@ -677,7 +694,7 @@ type FilterPlugin interface {
     // Once canceled, they should return as soon as possible with
     // an Unschedulable status that includes the
     // `context.Cause(ctx)` error explanation.
-    Reprieve(ctx context.Context, victimPod *v1.Pod, nodeInfo NodeInfo, preemptorPods []*v1.Pod, clusterNodes []NodeInfo) *Status
+    Reprieve(ctx context.Context, victimPod *v1.Pod, nodeInfo NodeInfo, preemptorPods []PreemptorPlacement, clusterNodes []NodeInfo) *Status
 }
 ```
 
@@ -719,13 +736,43 @@ In the Alpha implementation of WAP the whole PodGroupScheduling function is exec
 building a new CycleState for each of the preemptor pods. This assumes that each of the plugin can create a valid
 CycleState based on the current NodeInfoSnapshot which is updated as victim pods are removed and added. This might not be true
 for plugins that use information from external informer and rely on the PreFilterExtension to keep a diff that is applied
-on top of the informer to simulate current state of the world (See [DRA Preemption Proposal](https://github.com/kubernetes/enhancements/issues/5690)). That's why for Beta promotion, we will refactor the PodGroupSchedulingAlgorithm to allow CycleState to be reused across the original scheduling atttempt and attempts in the WAP.
+on top of the informer to simulate current state of the world. See [DRA Preemption Proposal](https://github.com/kubernetes/enhancements/issues/5690)
+and VolumeRestrictionsPlugin.
+
+That's why for Beta promotion, we will refactor the PodGroupSchedulingAlgorithm to allow CycleState to be reused across the original scheduling atttempt and attempts in the WAP.
 
 In the current implementation of PodGroupSchedulingAlgorithm the CycleState for Nth Pod from PodGroup is created with previous (N-1) pods from the same PodGroup assumed. 
 To revert that from the CycleState of Nth Pod, we will need to run PreFilterExtension.RemovePod() for each of the (N-1) pods as part of clean up function that we currently run to remove Nth Pod from the NodeInfoSnapshot.
 
-This is akin to the current implementation of PostFilter, where the CycleState from original scheduling attempt is passed
-to Postfilter method.
+This is akin to the current implementation of PostFilter, where the CycleState from original scheduling attempt is passed to Postfilter method.
+
+For the Reprieve method to work it will require that after an successful attempt of PodGroupScheduling in WAP, for a Nth Pod in PodGroup we will need to add all 
+pods from N+1 till the end of the PodGroup to this pod CycleState. This is to make sure that CycleState of Nth Pod is aware of the assumed presence of the rest 
+of the pods from PodGroup.
+
+This also means that we will not rerun PreFilter plguins in the PodGroupScheduling during WAP. It's also akin to the current implementation of default
+preemption where we only rerun Filter plugins. This information is not exposed right now, so to make thing explicit we will expand the PreFilter plugin
+description to clearly describe how it works with preemption:
+- if any Prefilter returns UnschedulableAndUnresolvable the default preemption / workload aware preemption will not be run. Other PodGroupPostFilter plugins may still run.
+- if any PreFilter returns Unschedulable we run default preemption / workload aware preemption with cycleStates from the initial attempt. PreFilters are NOT rerun in the preemption.
+  Only the PreFilteExtension interface is called to adjust internal state of prefilters based on the victim removal/addition.
+- if a PreFilter returns Skip, the plugin will also be skipped during WAP scheduling simulation and in the Reprieve phase
+- if a PreFilter returns a subset of nodes, this subset of nodes will also be used during preemption scheduling simulation, meaning that even after victim removal we will not search 
+  additional nodes. This is in line with the behavior of not reruning PreFilters in the preemption. 
+
+##### TopologyAwareScheduling
+
+Even though we do not aim to have a full support for TAS as a part of this KEP, it's worth to consider whether this approach will not block or make it hard
+to implement support for WAP in TAS in the future. As the PlacementGeneratePlugins do not depend on the pod cycle states, there is no concern here.
+For the scheduling attempts inside TAS, the PreFilter plugins do not depend on the selected placement (they always use whole cluster nodes), so we should be able to reuse
+the CycleState from the original scheduling attempt.
+
+#### CompositePodGroup
+
+As in TopologyAwareScheduling case we do not aim to have a support for CPG as part of this KEP, but it's alo worth to consider whether this approach will not block WAP for 
+CPGs in the future. This case is very similar to the TopologyAwareScheduling, where in Multi Level Topology Scheduling topolgies will not depend on the pod cycle states and 
+cycle states of pods from all pod groups can be stored and passed to the preemption. 
+
 
 ### Pod Group Post Filter
 
@@ -789,10 +836,12 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
 
 1. Improved preemption algorithm.
 
-   Instead of considering a single placement of a preemptor for a given set of victims, we may
-   consider multiple different placements. This will have much bigger impact once kube-scheduler
-   supports topology-aware scheduling. As a result, we're leaving it as a future extension -
-   the algorithm can always be improved and will result in pretty local code changes.
+   We expect that in the future the algorithm proposed in this KEP can be improved to limit
+   the disruptions it causes. For example, instead of considering a single placement of a
+   preemptor for a given set of victims, we may consider multiple different placements.
+   This will have much bigger impact once kube-scheduler supports topology-aware scheduling.
+   As a result, we're leaving it as a future extension -the algorithm can always be improved
+  and will result in pretty local code changes.
 
 1. Binary search during preemption
 

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -814,6 +814,13 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
    to allow plugins to have more insights into why a given pod group cannot be scheduled. One example of that
    would be an extension similar to the NodeToStatusReader object passed to a PostFilter plugins.
 
+1. Custom Scoring functions
+
+   During the Workload Aware Preemption we remove all potential victims and assume the preemptor. After
+   that we try to reprieve the victims. With a custom scoring functions we could change influence the 
+   placement of the preemptor in order to optimize for the reducing the preemption cost. Such change
+   can be designed and implemented as a dedicated, follow up KEP. 
+
 
 ### Test Plan
 

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -213,7 +213,7 @@ just wasting the resources in the cluster.
 
 #### AI Training Job as preemptor
 
-When scheduling an AI Traning Job, I want preemption to ensure that the
+When scheduling an AI Training Job, I want preemption to ensure that the
 whole Training Job can fit on to a cluster. I want to avoid partial preemptions for single pods
 from my training job if they cannot guarantee that the whole Job will become schedulable.
 
@@ -352,7 +352,9 @@ case rises following questions:
 - what should be the priority of the `PodGroup` when it is considered as a preemption victim.
 
 For the first question the natural answer is that each Pod should become a separate scheduling unit, with the
-priority. With that, the pods from `PodGroup` should also become a separate PreemptionUnits. In that case, one can ask why should we join such pods in a `PodGroup` in the first place. As we do not find an use case for that, we will continue with the assumption that all pods, even heterogenous, within `PodGroup` should have the same priority. 
+priority. With that, the pods from `PodGroup` should also become a separate PreemptionUnits. In that case,
+one can ask why should we join such pods in a `PodGroup` in the first place. As we do not find an use case for
+that, we will continue with the assumption that all pods, even heterogenous, within `PodGroup` should have the same priority. 
 
 Additionally, as described in user stories above, a simple static priority doesn't seem to be enough. Arguably it is
 not even a single priority because a priority used for scheduling can be different than the priority
@@ -606,7 +608,7 @@ with preemption:
           least ones). Tentatively, the function will sort first by their priority, and within a single
           priority prioritizing pod groups over individual pods.
 
-      1.  Temprarily schedule the preemptor on the chosen placement (assuming that all potential victims are removed).
+      1.  Temporarily schedule the preemptor on the chosen placement (assuming that all potential victims are removed).
  
       1.  Perform best-effort reprieval of pod groups and pods violating PodDisruptionBudgets. We achieve it by iterating 
           over potential victims that would violate PodDisruptionBudget to check if these can be placed in the exact 
@@ -624,27 +626,17 @@ with preemption:
           hurt performance we propose to accept this limitation (if needed a better algorithm may be
           proposed as a separate KEP).
 
-      1.  For the remaining potential victims, using binary search across priorities (not across the list
-          of victims) find the minimal priority N for which scheduling the preemptor can be achieved
-          without preempting any victims with priority higher than N. This allows to reduce the potential
-          cascading preemptions later.
-
-      1.  Eliminate all victims from the potential victims list that have priority higher than N.
-
-      1.  Schedule and assume the preemptor (assuming that all remaining potential victims are removed).
-
-      1.  Iterate over the list of potential victims (in the order achieved with sorting above) checking
-          if they can be placed where they are currently running. If so assume it back and remove from
-          potential victims list.
-
       We acknowledge the fact that the above algorithm is not optimal, but (a) is compatible with the
       current pod-based one, (b) is computationally feasible, (c) is simple to reason about. We will
       proceed with it and may consider improvements in a follow-up KEPs in the future.
 
 1. We score scheduling decisions for selected number of the domains/placements and choose the best one. For cluster wide 
-   preemption without TAS there will be only one decision. For multiple placments we will reuse (and generalize) the [preemption scoring functions]. During promotion of [Topology Aware Scheduling] to beta we will consider the exact scoring criteria.
+   preemption without TAS there will be only one decision. For multiple placments we will reuse (and generalize) the [preemption scoring functions]. 
+   During promotion of [Topology Aware Scheduling] to beta we will consider the exact scoring criteria.
 
-We acknowledge that some users might favor more disruptive preemptions if they allow the workload to be placed in a more optimal way, especially when the Topology-Aware Scheduling comes into the picture. This can be addressed by custom scoring criteria for the placements in the future.
+We acknowledge that some users might favor more disruptive preemptions if they allow the workload to be placed in a
+more optimal way, especially when the Topology-Aware Scheduling comes into the picture. This can be addressed by
+custom scoring criteria for the placements in the future.
 
 It's worth noting that as structured, this algorithm addresses all four cases mentioned above that
 we want to support and is compatible with the current pod-based preemption algorithm. This means
@@ -658,9 +650,16 @@ we will be able to achieve in-place replacement with relatively localized change
 
 The algorithm described above states that at one point we need to check whether a victim can be placed back in the place
 they are currently running with preemptor assumed to run on selected nodes. This check will be achieved by running Filter 
-plugins for each of the schedulable preemptor pods on selected nodes with the preemptor pod `CycleState`. We will keep the `CycleState` objects of each of the schedulable preemptor pods from the scheduling algorithm run within WAP and update them as we reprieve victims.
+plugins for each of the schedulable preemptor pods on selected nodes with the preemptor pod `CycleState`.
+We will keep the `CycleState` objects of each of the schedulable preemptor pods from the scheduling algorithm run within
+WAP and update them as we reprieve victims.
 
-The `CycleState` object for Nth pod does not contain information about pods that were scheduled in the pod group cycle after this pod. That's why before running reprieval we will need to update CycleState of preemptor pods with the information about all other pods that were scheduled in pod group cycle after this pod.
+The `CycleState` object for Nth pod does not contain information about pods that were scheduled in the pod group cycle after this pod.
+That's why before running reprieval we will need to update CycleState of preemptor pods with the information about all other pods that
+were scheduled in pod group cycle after this pod. We acknowledge that this operation has $O(N^2)$ complexity where N is the number of pods
+in the pod group, but we believe that the cost of PreFilterExtension.AddPod is small enough to not account for most of the additional time
+complexity introduced by WAP. Reducing this complexity might be one of performance optimization along other described in 
+[Potential future extensions](#potential-future-extensions) section.
 
 > **Note:**
 > DynamicResources, NodeVolumeLimits and VolumeBinding plugins do not work well with preemption right now.
@@ -676,18 +675,24 @@ all pods from rollback list will be removed from cluster representation.
 
 ##### TopologyAwareScheduling
 
-Even though we do not aim to have a full support for TAS as a part of this KEP, it's worth to consider whether this approach will not block or make it hard
-to implement support for WAP in TAS in the future. As we will rerun whole podGroupSchedulingAlgorithm in the WAP, we will as an output get the best placement
-with proposed pods assignments. If we also get the CycleStates from those Pod, we will be able to perform an in-place reprieve as described above.
+Even though we do not aim to have a full support for TAS as a part of this KEP, it's worth to consider whether this 
+approach will not block or make it hard to implement support for WAP in TAS in the future. As we will rerun whole 
+podGroupSchedulingAlgorithm in the WAP, we will as an output get the best placement with proposed pods assignments. 
+If we also get the CycleStates from those Pod, we will be able to perform an in-place reprieve as described above.
 
 #### CompositePodGroup
 
-As in TopologyAwareScheduling case we do not aim to have a support for CPG as part of this KEP, but it's alo worth to consider whether this approach will not block WAP for 
-CPGs in the future. This case is analogous to TopologyAwareScheduling, where whole CPG logic will be hidden within the podGroupSchedulingAlgorithm rerun in the WAP.
+As in TopologyAwareScheduling case we do not aim to have a support for CPG as part of this KEP, but it's also
+worth to consider whether this approach will not block WAP for CPGs in the future. This case is analogous to
+TopologyAwareScheduling, where whole CPG logic will be hidden within the podGroupSchedulingAlgorithm rerun in the WAP.
 
 ### Pod Group Post Filter
 
-As part of minimizing preemptions goal, arguably the most important thing to do is to avoid unnecessary preemptions. However, with the model of preemption when preemption is triggered immediately after the victims are decided and PostFilter is run per Pod in PodGroup, it doesn't achieve this goal. The reason for that is that the proposed placement (nomination) can actually appear to be invalid and not be proceeded with, if the whole PodGroup fails to schedule. In such case we will not even proceed to binding and the preemption will be completely unnecessary disruption.
+As part of minimizing preemptions goal, arguably the most important thing to do is to avoid unnecessary preemptions.
+However, with the model of preemption when preemption is triggered immediately after the victims are decided and
+PostFilter is run per Pod in PodGroup, it doesn't achieve this goal. The reason for that is that the proposed placement
+(nomination) can actually appear to be invalid and not be proceeded with, if the whole PodGroup fails to schedule.
+In such case we will not even proceed to binding and the preemption will be completely unnecessary disruption.
 
 For alpha, to avoid triggering unnecessary preemptions, we disabled the default preemption
 plugin in PostFilter for pods from PodGroup if the workload aware preemption was enabled.
@@ -706,6 +711,10 @@ PodGroup schedulable. Workload Aware Preemption will be one of the implementatio
 extension point. As part of the beta promotion we will provide the implementation for other in
 tree plugin that implements the PostFilter interface (namely the DRA Plugin). We expect owners
 of out of tree PostFilters to follow with their own implementations.
+
+We will introduce additional safety check during the initialization, that will output a warning
+log line when we detect plugins that implement PostFilter interface without implementing
+PodGroupPostFilter interface.
 
 The evaluation of PodGroupPostFilter plugins will reuse the same logic as the PostFilter one. Mainly,
 the plugins will be executed in the same order as they appear in the scheduler configuration,
@@ -752,7 +761,7 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
    preemptor for a given set of victims, we may consider multiple different placements.
    This will have much bigger impact once kube-scheduler supports topology-aware scheduling.
    As a result, we're leaving it as a future extension -the algorithm can always be improved
-  and will result in pretty local code changes.
+   and will result in pretty local code changes.
 
 1. Binary search during preemption
 
@@ -766,9 +775,10 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
 
    The `CompositePodGroup` concept is also being introduced to Workload API. We can envision
    a case where different `CompositePodGroups` will require to have different preemption priorities.
-   To achieve that, we could introduce `PriorityClassName` field also at the `CompositePodGroup` level, with the semantic that lower-level structure overwrites the higher-level one (e.g. priority set for `PodGroup` overwrites the priority
-   for `CompositePodGroup`). So the API and semantics proposed in this KEP would allow for achieving
-   it in backward compatible way.
+   To achieve that, we could introduce `PriorityClassName` field also at the `CompositePodGroup` level,
+   with the semantic that lower-level structure overwrites the higher-level one (e.g. priority set for 
+   `PodGroup` overwrites the priority for `CompositePodGroup`). So the API and semantics proposed in 
+   this KEP would allow for achieving it in backward compatible way.
 
 1. Non-uniform (Composite)PodGroups
 
@@ -882,10 +892,11 @@ For Alpha we implemented integration tests to ensure basic functionalities of wo
   when preempting a single pod would be enough to free up the space for the higher priority
   individual pod.
 
-Those tests are located at [podgrouppreemption_test.go](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/pkg/scheduler/framework/preemption/podgrouppreemption_test.go).
+Those tests are located at
+[podgrouppreemption_test.go](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/pkg/scheduler/framework/preemption/podgrouppreemption_test.go).
 
-For Beta we will expand the set of integration tests to cover the new Reprieval method. Namely, we will
-make sure that we have scenarios that covers the use of all in tree Filter plugins during the workload aware preemption.
+For Beta we will expand the set of integration tests to cover the in-place reprieval logic. Namely, we will
+make sure that we have scenarios that covers the use of all in-tree Filter plugins during the workload aware preemption.
 We also aim to have a parity with all the existing test scenarios for the default preemption.
 
 ##### e2e tests
@@ -893,7 +904,8 @@ We also aim to have a parity with all the existing test scenarios for the defaul
 For alpha, given the new functionality is limited to kube-scheduler change and API extensions,
 we will rely on integration tests described above (as easier and faster to run and debug).
 
-For beta we will add a new e2e test to the sig scheduling tests defined in [test/e2e/scheduling/preemption.go](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/test/e2e/scheduling/preemption.go).
+For beta we will add a new e2e test to the sig scheduling tests defined in
+[test/e2e/scheduling/preemption.go](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/test/e2e/scheduling/preemption.go).
 Those tests will cover the four basics basic functionalities describe in previous section.
 
 For GA we will promote those tests to conformance.
@@ -1008,16 +1020,23 @@ This section must be completed when targeting beta to a release.
 
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-Workloads that do not use the `Workload` and `PodGroup `APIs should not be impacted, since the functionality remains unchanged for them. During a rolling upgrade, if the active scheduler instance has the feature disabled, it will schedule pods using the standard pod-by-pod method, falling back to a default PostFilter methods. A default preemption algorithm will treat all pods as single preemption units, even when they are a part of a PodGroup with `All` Disruption Mode.
+Workloads that do not use the `Workload` and `PodGroup `APIs should not be impacted, since the functionality remains unchanged
+for them. During a rolling upgrade, if the active scheduler instance has the feature disabled, it will schedule pods using the
+standard pod-by-pod method, falling back to a default PostFilter methods. A default preemption algorithm will treat all pods
+as single preemption units, even when they are a part of a PodGroup with `All` Disruption Mode.
 
-This results in a fallback to the status quo behavior, meaning that pods will be still scheduled, but PodGroup-level scheduling constraints and preemption behavior won't be applied.
+This results in a fallback to the status quo behavior, meaning that pods will be still scheduled, but PodGroup-level scheduling
+constraints and preemption behavior won't be applied.
 
 ###### What specific metrics should inform a rollback?
 
-- `scheduler_podgroup_preemption_attempts_total{result="error"}`: A sudden spike indicates internal errors or panics within 
-the workload aware preemption logic.
-- `scheduler_podgroup_preemption_attempt_duration_seconds`: A significant P99 latency would indicate that the performance of the new logic is unacceptable.
-- `plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}`: A sudden increase of the latency of default preemption, especially if there is no PodGroup objects in the cluster indicates an issue with the workload aware default preemption.
+- `scheduler_podgroup_preemption_attempts_total{result="error"}`: A sudden spike indicates internal 
+   errors or panics within the workload aware preemption logic.
+- `scheduler_podgroup_preemption_attempt_duration_seconds`: A significant P99 latency would indicate 
+   that the performance of the new logic is unacceptable.
+- `plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}`: 
+   A sudden increase of the latency of default preemption, especially if there is no PodGroup 
+   objects in the cluster indicates an issue with the workload aware default preemption.
 
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
@@ -1063,7 +1082,8 @@ behavior).
 2. Attempt to create two low priority Pods with `spec.schedulingGroup` set.
 3. The `spec.schedulingGroup` field is dropped by the API server. The pod are created successfully
    but without the `schedulingGroup` reference.
-4. Create a high priority pod with NodeName set to a node of one of the low priority Pods. The pod is scheduled successfully and it preempts one of the low priority Pods.
+4. Create a high priority pod with NodeName set to a node of one of the low priority Pods. The pod is scheduled successfully and it preempts 
+   one of the low priority Pods.
 5. Restart/Upgrade API Server and Scheduler to v1.37 with feature gate enabled.
 6. Create two PodGroup objects: `gang-test-A` and `gang-test-B` (both with `minCount=2` and `PreemptionMode: All` and `Priority: Low`).
 7. Create two low piority pods `test-pod-1` and `test-pod-2` with `spec.schedulingGroup` pointing to `gang-test-A`.
@@ -1091,7 +1111,8 @@ previous answers based on experience in the field.
 
 ###### How can an operator determine if the feature is in use by workloads?
 
-Operators can check the new `scheduler_podgroup_preemption_attempts_total` metric. A value greater than zero indicates that the scheduler is processing Workload Aware Preemption.
+Operators can check the new `scheduler_podgroup_preemption_attempts_total` metric. A value greater than zero indicates that the
+scheduler is processing Workload Aware Preemption.
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -1138,17 +1159,22 @@ Recall that end users cannot usually observe component logs or access metrics.
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
 Since there are no formal SLOs for the kube-scheduler apart from scalability SLOs, we define the objectives for this
-feature primarily in terms of non-regression to ensure the workload aware preemption does not degrade the performance of the workload scheduling which in term would degrade the performance of the standard scheduling loop.
+feature primarily in terms of non-regression to ensure the workload aware preemption does not degrade the performance
+of the workload scheduling which in term would degrade the performance of the standard scheduling loop.
 
-- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s) 
-  when scheduling pods attached to a PodGroup that requires preemption compared to scheduling an equivalent number of individual pods that would also require preemption.
+- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s)
+  when scheduling pods attached to a PodGroup that requires preemption compared to scheduling an equivalent number of
+  individual pods that would also require preemption.
   This can be measured by the number of Pod binding API calls arriving to the API server
   (`apiserver_request_total{resource="pods", subresource="binding"}`).
-- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s) 
-  when scheduling pods requires preemption of pods grouped in PodGroups (DisruptionMode = All) compared to scheduling an equivalent number of pods in PodGroups that would require preemption of similar number of pods but not grouped in PodGroup.
+- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s)
+  when scheduling pods requires preemption of pods grouped in PodGroups (DisruptionMode = All) compared to scheduling
+  an equivalent number of pods in PodGroups that would require preemption of similar number of pods but not grouped in PodGroup.
   This can be measured by the number of Pod binding API calls arriving to the API server
   (`apiserver_request_total{resource="pods", subresource="binding"}`).
-- Default Preemption Performance: There should be no significant regression in the default preemption performance, especially when there are no PodGroups in the cluster. This can be measured by the `plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}` metric.
+- Default Preemption Performance: There should be no significant regression in the default preemption performance,
+  especially when there are no PodGroups in the cluster. This can be measured by the
+  `plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}` metric.
 
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
@@ -1159,7 +1185,6 @@ feature primarily in terms of non-regression to ensure the workload aware preemp
     - scheduler_podgroup_preemption_attempt_duration_seconds
     - scheduler_podgroup_preemption_victims
     - scheduler_podgroup_preemption_reprieved_total
-    - plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="Reprieval"}
     - plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}
   - Components exposing the metric: kube-scheduler
 
@@ -1230,11 +1255,16 @@ details). For now, we leave it here.
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
-The behavior is consistent with the status quo. The removal of the victims selected by the Workload-Aware Preemption uses the same code as the standard preemption. Since the scheduler cannot remove pods or update them, any pod removal attempts that are an outcome of preemption will fail, not making space for the preemptor pods. Preemptor pods will not be marked with the NominatedNodeName. 
+The behavior is consistent with the status quo. The removal of the victims selected by the Workload-Aware Preemption
+uses the same code as the standard preemption. Since the scheduler cannot remove pods or update them, 
+any pod removal attempts that are an outcome of preemption will fail, not making space for the preemptor
+pods. Preemptor pods will not be marked with the NominatedNodeName. 
 
-When the call to delete victim pods fails, the preemptor is moved to active queue (with async preemption) or backoff/unschedulable queue (without async preemption). 
+When the call to delete victim pods fails, the preemptor is moved to active queue (with async preemption) 
+or backoff/unschedulable queue (without async preemption). 
 
-Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus function which implements a retry mechanism and is shared by all occurrences that require updating pod status from scheduler. 
+Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus function which implements 
+a retry mechanism and is shared by all occurrences that require updating pod status from scheduler. 
 
 ###### What are other known failure modes?
 
@@ -1270,10 +1300,16 @@ Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus f
 
 If workload aware preemption latency is the problem:
 
-1. Increase Log Verbosity: Set the default scheduler log level to `-v=6` (or `-v=10` for deep tracing) to capture internal scheduling steps.
-2. Examine Scheduler Logs: Filter logs for source file `podgrouppreemption.go` and look for execution duration messages in the preemption evaluation flow.
-3. Identify Expensive Reprieve Plugins: Determine which specific filter plugins are taking too long during victim reprieval. Plugins that maintain complex topological indexing or search trees (such as `InterPodAffinity` or `PodTopologySpread`) may be executing expensive logic repeatedly in their `Reprieve` methods over candidate domains.
-4. Disable Feature: If the regression is critical and impacting cluster health, disable the GenericWorkload feature gate. This will revert the scheduler to the standard pod-by-pod logic, restoring baseline performance (at the cost of losing gang semantics together with workload aware preemption).
+1. Increase Log Verbosity: Set the default scheduler log level to `-v=6` (or `-v=10` for deep tracing) to capture internal
+   scheduling steps.
+2. Examine Scheduler Logs: Filter logs for source file `podgrouppreemption.go` and look for execution duration messages in
+   the preemption evaluation flow.
+3. Identify Expensive Filter Plugins: Determine which specific filter plugins are taking too long during victim reprieval.
+   Plugins that maintain complex topological indexing or search trees (such as `InterPodAffinity` or `PodTopologySpread`)
+   may be executing expensive logic repeatedly in their `Filter` methods over candidate domains.
+4. Disable Feature: If the regression is critical and impacting cluster health, disable the GenericWorkload feature gate.
+   This will revert the scheduler to the standard pod-by-pod logic, restoring baseline performance (at the cost of losing
+   gang semantics together with workload aware preemption).
 
 If preemptor workloads are stuck and preemption attempts fail:
 
@@ -1281,7 +1317,8 @@ If preemptor workloads are stuck and preemption attempts fail:
    - Run `kubectl describe pod <preemptor-pod>` to inspect scheduler warnings or event logs. Look for errors with message `pod group preemption`.
    - Check status conditions of the preemptor Pods and their parent `PodGroup`:
      - Preemptor Pods: Check for `{type: PodScheduled, status: False, reason: Unschedulable}` with a detailed descriptive message.
-     - Preemptor PodGroup: Check for the `PodGroupScheduled` status condition with `reason: Unschedulable` and message (e.g., `pod group is waiting for podgroup preemption to complete`).
+     - Preemptor PodGroup: Check for the `PodGroupScheduled` status condition with `reason: Unschedulable` and message
+       (e.g., `pod group is waiting for podgroup preemption to complete`).
 2. Examine Scheduler Logs: Filter logs for source file `podgrouppreemption.go` and look for messages indicating why the preemption attempts are failing.
 3. Disable Feature: Instead of using PodGroup, create pods as separate pods and rely on the default preemption algorithm.
 
@@ -1301,7 +1338,8 @@ that it deserves standardizing in core Kubernetes.
 
 ## Alternatives
 
- One alternative considered as a short-term workaround for unnecessary preemption was the introduction of "delayed preemption". The proposed delayed preemption mechanism was structured as follows:
+One alternative considered as a short-term workaround for unnecessary preemption was the introduction of
+"delayed preemption". The proposed delayed preemption mechanism was structured as follows:
 
 1. Modify the `DefaultPreemption` plugin to just compute preemptions, without actuating them.
 
@@ -1334,7 +1372,8 @@ that it deserves standardizing in core Kubernetes.
    In both cases, the scheduling of the whole PodGroup (all its pods) is marked as unschedulable
    and got back to the scheduling queue.
 
-This alternative was dropped as we decided that workload aware preemption is crucial for the Gang Scheduling effort. As we tied those two efforts together, there is no need for additional alternative approach for minimzing disruptions in Gang Scheduling without WAP.
+This alternative was dropped as we decided that workload aware preemption is crucial for the Gang Scheduling effort.
+As we tied those two efforts together, there is no need for additional alternative approach for minimzing disruptions in Gang Scheduling without WAP.
 
 <!--
 What other approaches did you consider, and why did you rule them out? These do

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -11,16 +11,18 @@
   - [High-level approach](#high-level-approach)
   - [User Stories](#user-stories)
     - [Preemption of AI Training job](#preemption-of-ai-training-job)
+    - [AI Training Job as preemptor](#ai-training-job-as-preemptor)
     - [Preemption of Multihost Inference](#preemption-of-multihost-inference)
     - [Preemption of Multihost Inference that can run in a degraded mode](#preemption-of-multihost-inference-that-can-run-in-a-degraded-mode)
     - [Preemption cost](#preemption-cost)
-  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Preemption unit](#preemption-unit)
   - [Pod Group priorities](#pod-group-priorities)
   - [Preemption algorithm](#preemption-algorithm)
-  - [Delayed preemption](#delayed-preemption)
+    - [In place victim reprieval](#in-place-victim-reprieval)
+  - [Pod Group Post Filter](#pod-group-post-filter)
   - [Potential future extensions](#potential-future-extensions)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -75,8 +77,8 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
 - [X] (R) Production readiness review completed
 - [X] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [X] "Implementation History" section is up-to-date for milestone
+- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
@@ -155,8 +157,11 @@ and many others) and bring the true value for every Kubernetes user.
 
 ## Proposal
 
-This KEP heavily depends on [KEP-4671: Gang Scheduling using Workload Object] one. It is building
-on foundations introduced there and assumes the knowledge of the concepts introduces there.
+This KEP is tightly coupled with [KEP-4671: Gang Scheduling using Workload Object] one. It is building
+on foundations introduced there and assumes the knowledge of the concepts introduces there. 
+
+We believe that providing a Gang Scheduling capability without a dedicated preemption mechanism for it
+is of no use for the high performance batch workloads for which this feature is primarily designed.
 
 ### Principles
 
@@ -173,8 +178,8 @@ While cascading preemptions are inevitable in some cases (e.g. if high priority 
 has very strict placement requirements), in general if there are multiple options of scheduling
 a higher priority pod group with preemptions, with some of them being expected to cause cascading
 preemptions and others not, we will try to choose the later. However, due to computational
-cost of searching the potential space, this is not a hard rule, but rather a goal that we will
-try to optimize for.
+cost of searching the potential space, especially in big clusters, this is not a hard rule, but rather
+a goal that we will try to optimize for.
 
 ### High-level approach
 
@@ -192,11 +197,7 @@ pieces of the solution and discuss them in more detail in the following sections
    these can be achieved later in backward-compatible way.
 1. We start with a simple sub-optimal preemption algorithm that is based on the existing
    pod preemption algorithm used by kube-scheduler.
-1. We introduce a mechanism of "delayed preemption" to postpone actuation of preemption
-   decisions until we really know that these are necessary. This is to prevent the situation
-   when preemption is triggered but the pod/workload that triggered it in the end cannot
-   be bound anyway due to inability to schedule the workload as a whole.
-
+  
 The rest of this KEP explains those pieces in more detail.
 
 ### User Stories
@@ -206,6 +207,12 @@ The rest of this KEP explains those pieces in more detail.
 When running an AI Training job, I want to ensure that it will not be partially preempted.
 If at least one my pods is not running, the others are not making progress anyway and are
 just wasting the resources in the cluster.
+
+#### AI Training Job as preemptor
+
+When scheduling an AI Traning Job, I want preemption to ensure that the
+whole Training Job can fit on to a cluster. I want to avoid partial preemptions for single pods
+from my training job if they cannot guarantee that the whole Job will become schedulable.
 
 #### Preemption of Multihost Inference
 
@@ -227,10 +234,12 @@ When a long-running AI Training job, its cost of preemption differs over time an
 on how long ago it checkpointed its state. I want to be able to somehow influence the
 preemption priority of my job based on how much would it really cost me.
 
-This story is treated directionally and will not be addressed at least in Alpha.
+This story is treated directionally and will not be addressed in Alpha and Beta.
 
 
-### Notes/Constraints/Caveats (Optional)
+### Notes/Constraints/Caveats
+
+For alpha we defined a Workload Aware Preemption as a separate feature that can be disabled independently of the Gang Scheduling. We acknowledge that for Beta, releasing the Gang Scheduling without Workload Aware Preemption does not provide enough value for the end users. That's why in Beta we merge those two features and progress them together under single `GenericWorkload` feature gate.
 
 <!--
 What are the caveats to the proposal?
@@ -277,40 +286,54 @@ a single pod}. With that definition both scheduling unit and preemption units ca
 
 In the future, we may want to support usecases when a single scheduling unit consists of multiple
 preemption groups, but we leave that usecase as a future extension (it can be addressed when we
-decide to extend Workload API with PodSubGroup concept - for more details see
-[API Design For Gang and Workload-Aware Scheduling]). However, we never expect preemption unit to
+decide to extend Workload API with CompositePodGroup concept - for more details see
+[API Design For Gang and Workload-Aware Scheduling](https://tiny.cc/hvhs001)). However, we never expect preemption unit to
 be larger than scheduling unit.
 
 Based on that, we will extend the the existing `GangSchedulingPolicy` as following:
 
 ```golang
-// DisruptionMode describes the mode in which a PodGroup can be disrupted (e.g. preempted).
-// +enum
-type DisruptionMode string
+// DisruptionMode defines how individual entities within a group can be disrupted.
+// Exactly one mode can be set.
+//
+// +union
+type DisruptionMode struct {
+	// Single specifies that children can be disrupted independently from each other.
+	//
+	// +optional
+	Single *SingleDisruptionMode 
 
-const (
-  // DisruptionModePod means that individual pods can be disrupted or preempted independently.
-  // It doesn't depend on exact set of Pods currently running in this PodGroup.
-  DisruptionModePod = "Pod"
-  // DisruptionModePodGroup means that the whole PodGroup replica needs to be disrupted or
-  // preempted together.
-  DisruptionModePodGroup = "PodGroup"
-)
+	// All specifies that all children can only be disrupted together.
+	//
+	// +optional
+	All *AllDisruptionMode
+}
 
-type PodGroupSchedulingPolicy struct {
+// SingleDisruptionMode specifies that children can be disrupted independently.
+type SingleDisruptionMode struct {
+	// Intentionally empty now.
+}
+
+// AllDisruptionMode specifies that children can only be disrupted together.
+type AllDisruptionMode struct {
+	// Intentionally empty now.
+}
+
+type PodGroupSpec struct {
     // Existing field(s).
-
+    
     // DisruptionMode defines the mode in which a given PodGroup can be disrupted.
-    // One of Pod, PodGroup.
-    // Defaults to Pod if unset.
-    //
+    // Controllers are expected to fill this field by copying it from a PodGroupTemplate.
+    // One of Single, All. Defaults to Single if unset.
     // This field is immutable.
-    DisruptionMode *DisruptionMode
+    // This field is available only when the GangScheduling feature gate
+    // is enabled.
+    DisruptionMode *DisruptionMode 
 }
 ```
 
 Given that preemption unit shouldn't be larger then the scheduling unit, additional validation
-will be added to prevent `PodGroup` disruption mode for PodGroups with BasicSchedulingPolicy.
+will be added to prevent `All` disruption mode for PodGroups with BasicSchedulingPolicy. 
 
 While the `PreemptionMode` might seem the more natural name here, we envision that the same
 concept can be later used in `Eviction` API and other usecases, so we already start with a more
@@ -319,14 +342,18 @@ generic name to avoid future confusion.
 ### Pod Group priorities
 
 Prioritizing pod groups across each other requires answering the question: "What is pod group priority?".
-Up until now, only individual pods have assigned priority. But nothing prevents individual pods
-forming a `PodGroup` from being heterogeneous and having different priorities.
+Up until now, only individual pods have assigned priority. For homogenous `PodGroup` the priority of a PodGroup
+should be the same priority as the priority of individual pods that form the group.
 
-Intuitively, the priority of a `PodGroup` in such case would be the "minimum of priorities of pods
-that belong to it" - any pod with a priority higher than that can e.g. preempt our pod group. But
-intuition is not enough here.
+We can also think about heterogenous `PodGroup` where individual pods have different priorities. However, that
+case rises following questions:
+- what should be the priority of the `PodGroup` in the scheduling queue. 
+- what should be the priority of the `PodGroup` when it is considered as a preemption victim.
 
-As described in user stories above, a simple static priority doesn't seem to be enough. Arguably it is
+For the first question the natural answer is that each Pod should become a separate scheduling unit, with the
+priority. With that, the pods from `PodGroup` should also become a separate PreemptionUnits. In that case, one can ask why should we join such pods in a `PodGroup` in the first place. As we do not find an use case for that, we will continue with the assumption that all pods, even heterogenous, within `PodGroup` should have the same priority. 
+
+Additionally, as described in user stories above, a simple static priority doesn't seem to be enough. Arguably it is
 not even a single priority because a priority used for scheduling can be different than the priority
 that should be used for preemption. So in the ideal world a workload owner should be able to:
 
@@ -381,7 +408,7 @@ type PodGroupSpec struct {
     // 'priority' field.
     //
     // This field is immutable.
-      PriorityClassName *string
+    PriorityClassName *string
 }
 ```
 
@@ -389,24 +416,24 @@ With that change, when scheduling or preempting a pod that is part of a Pod Grou
 priority defined in the `PodGroup` object will be used (and priority defined in the `Pod`
 itself will be ignored, thus not reflecting the actual pod priority).
 
-We acknowledge that it might be misleading to users. For Alpha, we will simply just
-describe the possible divergence in the documentation.
+We acknowledge that it might be misleading to users. For Alpha, we described
+the possible divergence in the documentation.
 
-For Beta, we will decide if we need additional actions, e.g.:
-- expose the information about divergence in the API by introducing a new `Conditions` field
-  in the `PodGroup.Status` with dedicated condition like `PodsNotMatchingPriority` that will
-  be set by either kube-scheduler or a new workload-controller whenever it observes pods
-  referencing a given `PodGroup` object which priority doesn't match the priority of the
-  PodGroup object.
-- introduce an admission to validate that if a `Pod` is referencing a `PodGroup` object, its
-  `pod.Spec.PriorityClassName` equals to `podGroup.Spec.PriorityClassName`. However, we allow
-  creating pods before the PodGroup object, and there doesn't seem to be an easy way to avoid
-  races.
-- making `pod.Spec.PriorityClassName` and `pod.Spec.Priority` mutable fields and having a new
-  workload controller responsible for reconciling these. However, that could introduce another
-  divergence between the priority of pods and the priority defined in the PodTemplate in true
-  workload object (e.g. Job) which would introduce a similar level of confusion to users.
-However, decision if we need any of these will be made when graduating this feature to Beta.
+For Beta and GA, we will disallow the divergence between the priority of the `Pod` and the `PodGroup`. 
+This will be done by the scheduler, which will fail scheduling of the `PodGroup`, once it observes such divergence.
+This mechanism will follow a similar mechanism already implemented in scheduler that disallows `PodGroup` with pods having different `spec.schedulerName`.
+This information will be visible to the user in the description of the `PodScheduled` `Conditions` in the `Pod.Status`
+
+```yaml
+status:
+  conditions:
+  - type: PodScheduled
+    status: "False"
+    reason: SchedulerError
+    message: 'all pods in a single pod group should match the priority of the pod group, got: 1 and 2'
+```
+
+We might relax this restriction in the future if there is a strong use cases that justify it. 
 
 It's worth mentioning here, that we want to introduce the same defaulting rules for
 `PodGroup.Spec.PriorityClassName` that we have for pods. Namely, if `PriorityClassName` is unset
@@ -417,6 +444,9 @@ nor PodGroup priorities.
 Note that, for workload-aware preemption we will support the `preemptionPolicy` being part
 of requestion `PriorityClass` - namely both currently existing modes: `PreemptLowerPriority`
 and `Never`.
+
+As the `preemptionPolicy` is also a field of the Pod, we will apply the same constraints to this field as we will
+for the priority. Namely, all pods within `PodGroup` will have to share the same `preemptionPolicy`. This will be enforced on the scheduler level.
 
 Given that components operate on integer priorities, we will introduce a corresponding fields
 that reflect priority of a PodGroup (similarly to how it's done in Pod API).
@@ -472,10 +502,9 @@ type PodGroupSpec struct {
 }
 ```
 
-If that appears not being enough, we will similarly extend the `PodSubGroup` API in a follow up.
-In such case, the priority of a pod would be the priority of a smallest unit in the `PodGroup`
-object (PodGroup, PodSubGroup, ...) corresponding to this pod.
-
+If that appears not being enough, we will similarly extend the `CompositePodGroup` API in a follow up.
+In such case, we expect that for any pod, the priority of a pod from the perspective of being a preemption victim
+would be the priority of a smallest unit encompassing it in the `CompositePodGroup` tree.
 
 ### Preemption algorithm
 
@@ -498,9 +527,8 @@ To check if a pod P can be scheduled on a given node with preemption we:
 Once we find enough nodes feasible for preemption and list of victims for them, we score that and
 choose the best options.
 
-The above algorithm achieves our principles, as by eliminating highest priority pods first, it
+The above algorithm achieves our principles, as by reprieving the highest priority pods first, it
 effectively tries to minimize the cascading preemptions later.
-
 
 We want to generalize the same algorithm to the workload case. However, the difference is not only
 moving to the level of `PodGroup`, but also no longer operating at the level of individual nodes.
@@ -521,8 +549,7 @@ with preemption:
 
 1. Split the cluster into mutually-exclusive domains where a preemptor will be put:
    - for pod P, it will always be individual nodes
-   - for pod group G, we will start with just one "whole cluster"; eventually once we will have
-     topology-aware scheduling, we will most probably inject some domain-based split here
+   - for pod group G, we will start with just one "whole cluster"; 
 
 1. For every domain computed above run the following points:
 
@@ -530,101 +557,247 @@ with preemption:
       - all running pod groups with (preemption) priority lower then preemptor priority; note that
         some pods from that pod group may be running outside of currently considered domain D - they
         need to contribute to scoring, but they won't contribute to feasibility of domain D.
-      - all individual pods with priority lower the preemptor priority
+      - all individual pods with priority lower then preemptor priority
 
    1. If removing all potential victims would not make the preemptor schedulable, the preemptor
       is unschedulable with preemption in currently considered domain D.
 
-   1. Sort all the potential victims to reflect their "importance" (from the most important to the
-      least ones). Tentatively, the function will sort first by their priority, and within a single
-      priority prioritizing pod groups over individual pods.
+   1. For the [Topology-Aware Scheduling] "checking whether preemptor becomes schedulable" yields a list 
+      of potential placements. For the alpha support of TAS, we will only assume the best placement. With the
+      progression of TAS to Beta, we might change the algorithm to consider multiple placements.
+      We can also see a future where if the algorithm is performant enough, even for the non TAS case,
+      we will generate multiple potential placements and consider them. 
 
-   1. Perform best-effort reprieval of pod groups and pods violating PodDisruptionBudgets. We achieve
-      it by scheduling and temporarily adding the preemptor to `nodeInfo` structure (assuming that
-      all potential victims are removed), and then iterating over potential victims that would violate
-      PodDisruptionBudget to check if these can be placed in the exact same place they are running now.
-      If they can we simply leave them where they are running now and remove from the potential victims
-      list.
+   1. For each placement computed above run the following points:
 
-      For domain D being a single node (current pod-based preemption), the above algorithm works
-      identically to the current algorithm. For larger domains, different placements of a preemptor
-      are potentially possible and may result in potentially different sets of victims violating
-      PodDisruptionBudgets to remain feasible. This means that the proposed algorithm is not necessarily
-      minimizing the number of victims that would violate their PodDisruptionBudgets.
-      However, optimizing for it would be extremely expensive computationally so to not significantly
-      hurt performance we propose to accept this limitation (if needed a better algorithm may be
-      proposed as a separate KEP).
+      1.  Sort all the potential victims to reflect their "importance" (from the most important to the
+          least ones). Tentatively, the function will sort first by their priority, and within a single
+          priority prioritizing pod groups over individual pods.
 
-   1. For the remaining potential victims, using binary search across priorities (not across the list
-      of victims) find the minimal priority N for which scheduling the preemptor can be achieved
-      without preempting any victims with priority higher than N. This allows to reduce the potential
-      cascading preemptions later.
+      1.  Perform best-effort reprieval of pod groups and pods violating PodDisruptionBudgets. We achieve
+          it by scheduling and temporarily adding the preemptor to `nodeInfo` structure (assuming that
+          all potential victims are removed), and then iterating over potential victims that would violate
+          PodDisruptionBudget to check if these can be placed in the exact same place they are running now.
+          If they can we simply leave them where they are running now and remove from the potential victims
+          list.
 
-   1. Eliminate all victims from the potential victims list that have priority higher than N.
+          For domain D being a single node (current pod-based preemption), the above algorithm works
+          identically to the current algorithm. For larger domains, different placements of a preemptor
+          are potentially possible and may result in potentially different sets of victims violating
+          PodDisruptionBudgets to remain feasible. This means that the proposed algorithm is not necessarily
+          minimizing the number of victims that would violate their PodDisruptionBudgets.
+          However, optimizing for it would be extremely expensive computationally so to not significantly
+          hurt performance we propose to accept this limitation (if needed a better algorithm may be
+          proposed as a separate KEP).
 
-   1. Schedule and assume the preemptor (assuming that all remaining potential victims are removed).
+      1.  For the remaining potential victims, using binary search across priorities (not across the list
+          of victims) find the minimal priority N for which scheduling the preemptor can be achieved
+          without preempting any victims with priority higher than N. This allows to reduce the potential
+          cascading preemptions later.
 
-   1. Iterate over the list of potential victims (in the order achieved with sorting above) checking
-      if they can be placed where they are currently running. If so assume it back and remove from
-      potential victims list.
+      1.  Eliminate all victims from the potential victims list that have priority higher than N.
 
-   We acknowledge the fact that the above algorithm is not optimal, but (a) is compatible with the
-   current pod-based one, (b) is computationally feasible, (c) is simple to reason about. We will
-   proceed with it and may consider improvements in a follow-up KEPs in the future.
+      1.  Schedule and assume the preemptor (assuming that all remaining potential victims are removed).
 
-1. We score scheduling decisions for each of the domains and choose the best one. For Alpha, we will
-   reuse (and generalize) the [preemption scoring functions]. We will reconsider the exact criteria
-   for Beta.
+      1.  Iterate over the list of potential victims (in the order achieved with sorting above) checking
+          if they can be placed where they are currently running. If so assume it back and remove from
+          potential victims list.
+
+      We acknowledge the fact that the above algorithm is not optimal, but (a) is compatible with the
+      current pod-based one, (b) is computationally feasible, (c) is simple to reason about. We will
+      proceed with it and may consider improvements in a follow-up KEPs in the future.
+
+1. We score scheduling decisions for selected number of the domains/placements and choose the best one. For cluster wide 
+   preemption without TAS there will be only one decision. For multiple placments we will reuse (and generalize) the [preemption scoring functions]. During promotion of [Topology Aware Scheduling] to beta we will consider the exact scoring criteria.
+
+We acknowledge that some users might favor more disruptive preemptions if they allow the workload to be placed in a more optimal way, especially when the Topology-Aware Scheduling comes into the picture. This can be addressed by custom scoring criteria for the placements in the future.
 
 It's worth noting that as structured, this algorithm addresses all four cases mentioned above that
 we want to support and is compatible with the current pod-based preemption algorithm. This means
 we will be able to achieve in-place replacement with relatively localized changes.
 
-[preemption scoring functions]: https://github.com/kubernetes/kubernetes/blob/c180d6762d7ac5059d9b50457cafb0d7f4cf74a9/pkg/scheduler/framework/preemption/preemption.go#L702-L714
 
-### Delayed preemption
+[Topology Aware Scheduling]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5732-topology-aware-workload-scheduling
+[preemption scoring functions]: https://github.com/kubernetes/kubernetes/blob/c180d6762d7ac5059d9b50457cafb0d7f4cf74a9/pkg/scheduler/framework/preemption/preemption.go#L702-
 
-As part of minimizing preemptions goal, arguably the most important thing to do is to avoid unnecessary
-preemptions. However, with the current model of preemption when preemption is triggered immediately
-after the victims are decided (in `PostFilter`) doesn't achieve this goal. The reason for that is
-that the proposed placement (nomination) can actually appear to be invalid and not be proceeded with.
-In such case we will not even proceed to binding and the preemption will be completely unnecessary
-disruption.
+#### In place victim reprieval
 
-We're addressing it with what we call `delayed preemption` mechanism described in
-[KEP-4671: Introduce Workload Scheduling Cycle].
+The algorithm described above assumes that we can cheaply check if a potential victim pod can be placed back where they are currently running after preemptor has been `assumed` on the target node. However there is no extension point like this implemented in the scheduler as of right now. During scheduling, the scheduler uses Filter plugins to check whether a pod can run on a given node. This process is heavy and requires to build a `cycleState` object, particularly for plugins that have inter pod constraints such as pod affinity (pod running on node A can fail "Filter" on node B). Running `Filter()` and building a `cycleState` for all of the victims does not seem like a feasible option from performance perspective.
 
-However, there is one point that requires an update. Namely, how can we avoid or minimize subsequent
-preemptions, if the previous scheduling attempt already triggered some preemptions.
-We have the following two cases:
+However, one can note that actually do not need a full Filter check. Instead of checking if the victim pod can be scheduled back on its node, we need to check whether keeping the victim pod on a node will break the schedulability of the preemptor that we assumed. Mainly, this means that we do not have to meet the scheduling constraints for victim pod, and we only care about scheduling constraints of the preemptor pod that could be broken. Such check can be implemented by extending Filter plugins with a new method.
+We propose to tenantively call it `Reprieve` with following semantics for Beta:
 
-   1. If the original nomination is still feasible, we can try finding an alternative placement,
-      but can't trigger a new preemption.
+```go 
+// ReprieveExtension is an interface that is included in Filter plugins that allow specifying
+// reprieve method used by workload aware preemption.
+type ReprieveExtension interface {
+    // Reprieve is called by the workload aware preemption.
+    // All FilterPlugins should return "Success" to declare that
+    // the given victim pod can be placed back on the given node
+    // without breaking the schedulability of the preemptor pod on this node.
+    // If Reprieve does not return "Success", it will return "Unschedulable"
+    // or "Error".
+    //
+    // "Error" aborts preemption.
+    //
+    // For the node being evaluated Filter plugins should look at the passed
+    // nodeInfo reference for this particular node's information instead of
+    // looking it up in the NodeInfoSnapshot because during preemption
+    // the state of the node can be mutated to evaluate the possibility of  preempting 
+    // them to schedule preemptor pods. The same stands for all nodes belonging 
+    // to the cluster, as they might be out of sync with NodeInfoSnapshot.
 
-   1. If the original nomination is no longer feasible (e.g. some higher priority pods were scheduled
-      there in the meantime), we reject the original placement (clear nominations) and start scheduling
-      from scratch.
+    // Plugins are encouraged to check the context for cancellation.
+    // Once canceled, they should return as soon as possible with
+    // an Unschedulable status that includes the
+    // `context.Cause(ctx)` error explanation.
+    Reprieve(ctx context.Context, victimPod *v1.Pod, nodeInfo NodeInfo,  preemptorPods []*v1.Pod clusterNodes []NodeInfo) *Status
+}
 
-The remaining question is why in the second case we can start from scratch and ignore which exact
-preemptions we did instead of trying to first expand the original, now (partially) occupied placement.
-The rationale behind that is that we don't really care which exact preemptions were triggered by
-the workload - what really matters is the current state of the cluster in which we want to minimize
-the cost of additional preemptions. We need to run the preemption algorithm that assumes that all
-triggered preemptions are finished and on top of that minimize the cost of additional preemptions.
-In some cases it may mean expanding the previously freed up space, but it may not always be the case
-(e.g. preempting medium priority small workload to expand the original placement may transitively
-preempt low priority large workload elsewhere, preempting which would be just enough for us).
+// FilterPlugin is an interface for Filter plugins. These plugins are called at the
+// filter extension point for filtering out hosts that cannot run a pod.
+// This concept used to be called 'predicate' in the original scheduler.
+// These plugins should return "Success", "Unschedulable" or "Error" in Status.code.
+// However, the scheduler accepts other valid codes as well.
+// Anything other than "Success" will lead to exclusion of the given host from
+// running the pod. Plugins that implement FilterPlugin should
+// also implement SignPlugin to enable batching optimizations.
+type FilterPlugin interface {
+    Plugin
+    // Filter is called by the scheduling framework.
+    // All FilterPlugins should return "Success" to declare that
+    // the given node fits the pod. If Filter doesn't return "Success",
+    // it will return "Unschedulable", "UnschedulableAndUnresolvable" or "Error".
+    //
+    // "Error" aborts pod scheduling and puts the pod into the backoff queue.
+    //
+    // For the node being evaluated, Filter plugins should look at the passed
+    // nodeInfo reference for this particular node's information (e.g., pods
+    // considered to be running on the node) instead of looking it up in the
+    // NodeInfoSnapshot because we don't guarantee that they will be the same.
+    // For example, during preemption, we may pass a copy of the original
+    // nodeInfo object that has some pods removed from it to evaluate the
+    // possibility of preempting them to schedule the target pod.
+    //
+    // Plugins are encouraged to check the context for cancellation.
+    // Once canceled, they should return as soon as possible with
+    // an UnschedulableAndUnresolvable status that includes the
+    // `context.Cause(ctx)` error explanation. For example, the
+    // context gets canceled when a sufficient number of suitable
+    // nodes have been found and searching for more isn't necessary
+    // anymore.
+    Filter(ctx context.Context, state CycleState, pod *v1.Pod, nodeInfo NodeInfo) *Status 
+    // ReprieveExtension returns a ReprieveExtension interface if the plugin implements one,
+    // or nil if it does not.
+    ReprieveExtension() ReprieveExtension
+}
+```
 
-As a result, the only thing we need is additional scoring function(s) for choosing preemption victims
-(effectively additional sorting criteria for choosing potential victims in the algorithm). With that,
-which is highly desired even for single-step preemption, the subsequent preemption attempt can really
-be done from scratch just in the new cluster state.
+We expect that for Filter plugins that do not enforce inter pod constraints the implementation should be trivial. We will
+provide an implementation for all the in-tree Filter plugins. We expect that the owners of out-of-tree plugins will 
+follow with the implementation of `Reprieve` for their plugins.
 
-However, the additional sorting criteria will be added in Beta.
+For Beta, the workload aware preemption, thus the gang scheduling will be disabled if any of the Filter plugins registered does not support the Reprieve extension.
 
-[KEP-4671: Introduce Workload Scheduling Cycle]: https://github.com/kubernetes/enhancements/pull/5730
+For GA, we state that the Reprieve method is required for an effective workload aware preemption. That's why we will promote the Reprieve extension to become a method of the FilterPlugin interface as follows:
 
-[API Design For Gang and Workload-Aware Scheduling]: https://tiny.cc/hvhs001
+```go
+// FilterPlugin is an interface for Filter plugins. These plugins are called at the
+// filter extension point for filtering out hosts that cannot run a pod.
+// This concept used to be called 'predicate' in the original scheduler.
+// These plugins should return "Success", "Unschedulable" or "Error" in Status.code.
+// However, the scheduler accepts other valid codes as well.
+// Anything other than "Success" will lead to exclusion of the given host from
+// running the pod. Plugins that implement FilterPlugin should
+// also implement SignPlugin to enable batching optimizations.
+type FilterPlugin interface {
+    Plugin
+    // Filter is called by the scheduling framework.
+    // All FilterPlugins should return "Success" to declare that
+    // the given node fits the pod. If Filter doesn't return "Success",
+    // it will return "Unschedulable", "UnschedulableAndUnresolvable" or "Error".
+    //
+    // "Error" aborts pod scheduling and puts the pod into the backoff queue.
+    //
+    // For the node being evaluated, Filter plugins should look at the passed
+    // nodeInfo reference for this particular node's information (e.g., pods
+    // considered to be running on the node) instead of looking it up in the
+    // NodeInfoSnapshot because we don't guarantee that they will be the same.
+    // For example, during preemption, we may pass a copy of the original
+    // nodeInfo object that has some pods removed from it to evaluate the
+    // possibility of preempting them to schedule the target pod. The same stands for
+    // all nodes belonging to the cluster, as they might be out of sync with NodeInfoSnapshot.
+    //
+    // Plugins are encouraged to check the context for cancellation.
+    // Once canceled, they should return as soon as possible with
+    // an UnschedulableAndUnresolvable status that includes the
+    // `context.Cause(ctx)` error explanation. For example, the
+    // context gets canceled when a sufficient number of suitable
+    // nodes have been found and searching for more isn't necessary
+    // anymore.
+    Filter(ctx context.Context, state CycleState, pod *v1.Pod, nodeInfo NodeInfo) *Status
+
+    // Reprieve is called by the preemption.
+    // All FilterPlugins should return "Success" to declare that
+    // the given victim pod can be placed back on the given node
+    // without breaking schedulability of the preemtor pod on this node.
+    // If Reprieve does not return "Success", it will return "Unschedulable"
+    // or "Error".
+    //
+    // "Error" aborts preemption.
+    //
+    // For the node being evaluated Filter plugins should look at the passed
+    // nodeInfo reference for this particular node's information instead of
+    // looking it up in the NodeInfoSnapshot because during preemption
+    // the state of the node can be mutated to evaluate the possibility of  preempting 
+    // them to schedule preemptor pods.
+
+    // Plugins are encouraged to check the context for cancellation.
+    // Once canceled, they should return as soon as possible with
+    // an Unschedulable status that includes the
+    // `context.Cause(ctx)` error explanation.
+    Reprieve(ctx context.Context, victimPod *v1.Pod, nodeInfo NodeInfo, preemptorPods []*v1.Pod, clusterNodes []NodeInfo) *Status
+}
+```
+
+### Pod Group Post Filter
+
+As part of minimizing preemptions goal, arguably the most important thing to do is to avoid unnecessary preemptions. However, with the current model of preemption when preemption is triggered immediately after the victims are decided and PostFilter is run per Pod in PodGroup, it doesn't achieve this goal. The reason for that is that the proposed placement (nomination) can actually appear to be invalid and not be proceeded with, if the whole PodGroup fails to schedule. In such case we will not even proceed to binding and the preemption will be completely unnecessary disruption.
+
+For alpha, to avoid triggering unnecessary preemptions, we disabled the default preemption plugin in PostFilter for pods from PodGroup if the workload aware preemption was enabled.
+
+For beta, we acknowledge that the default preemption is not the only PostFilter plugin out there. Other PostFilter plugins can also perform disruptive actions. In the current model, those plugins works only on the outcome of single pod scheduling cycle, within a PodGroup cycle. With that they do not have a full picture of the pod group scheduling outcome and can perform actions that are either not optimal or in the worst case will not make the PodGroup schedulable anwyay.
+
+For beta and GA we propose to disable all PostFilter plugins in the pod group scheduling cycle in favor of the newly added PodGroupPostFilter extension point. This extension point will be called only once after the whole pod group fails to schedule. 
+It will provide data about the outcome of whole PodGroup scheduling cycle and allow users to define actions that can be taken to make the PodGroup schedulable. Workload Aware Preemption will be one of the implementations of this extension point. As part of the beta promotion we will provide the implementation for other in tree plugin that implements the PostFilter interface (namely the DRA Plugin). We expect owners of out of tree PostFilters to follow with their own implementations.
+
+```go
+// PodGroupPostFilterResult stores information about nominated nodes for a pod group.
+type PodGroupPostFilterResult struct {
+    NominatedNodeNames map[*v1.Pod]*fwk.NominatingInfo
+}
+
+// PodGroupPostFilterPlugin is an interface for "PodGroupPostFilter" plugins. These plugins are called
+// after a PodGroup cannot be scheduled.
+type PodGroupPostFilterPlugin interface {
+    fwk.Plugin
+
+    // PodGroupPostFilter is called by the scheduling framework
+    // when the pod group scheduling cycle failed.
+    //
+    //
+    // A PodGroupPostFilter plugin should return one of the following statuses:
+    // - Unschedulable: the plugin gets executed successfully but the PodGroup cannot be made schedulable.
+    // - Success: the plugin gets executed successfully and the PodGroup can be made schedulable.
+    // - Error: the plugin aborts due to some internal error.
+    //
+    // Informational plugins should be configured ahead of other ones, and always return Unschedulable status.
+    // Optionally, a non-nil PodGroupPostFilterResult may be returned along with a Success status. For example,
+    // a preemption plugin may choose to return nominatedNodeName, so that framework can reuse that to update the
+    // preemptor pod's status.nominatedNodeName field.
+    PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *fwk.Status)
+}
+```
 
 ### Potential future extensions
 
@@ -639,22 +812,21 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
    supports topology-aware scheduling. As a result, we're leaving it as a future extension -
    the algorithm can always be improved and will result in pretty local code changes.
 
-1. Non-uniform priority across PodSubGroups.
+1. Non-uniform priority across CompositePodGroups.
 
-   We anticipate that in the future the `PodSubGroup` concept will be introduced. We can envision
-   a case where different `PodSubGroups` will require to have different priorities.
-   To achieve that, we could introduce `PriorityClassName` field also at the `PodSubGroup` level, with the semantic that lower-level structure
-   overwrites the higher-level one (e.g. priority set for `PodSubGroup` overwrites the priority
-   for `PodGroup`). So the API and semantics proposed in this KEP would allow for achieving
+   We anticipate that in the future the `CompositePodGroup` concept will be introduced. We can envision
+   a case where different `CompositePodGroups` will require to have different preemption priorities.
+   To achieve that, we could introduce `PriorityClassName` field also at the `CompositePodGroup` level, with the semantic that lower-level structure overwrites the higher-level one (e.g. priority set for `PodGroup` overwrites the priority
+   for `CompositePodGroup`). So the API and semantics proposed in this KEP would allow for achieving
    it in backward compatible way.
 
-1. Non-uniform PodGroups
+1. Non-uniform (Composite)PodGroups
 
    In addition to non-uniform priorities, we may expect other non-uniform behaviors. As an
    example consider `LeaderWorkerSet` and a usecase where we allow for preempting individual
    workers (with a given unit working in a degraded mode), but don't allow for preempting a
-   leader. The enum-based `DisruptionMode` allows for introducing more sophisticated policies
-   (e.g. only a subset of `PodSubGroups` can be preempted).
+   leader. The struct based `DisruptionMode` allows for introducing more sophisticated policies
+   (e.g. only a subset of `CompositePodGroups` can be preempted).
 
 1. Dynamic preemption priority
 
@@ -682,6 +854,14 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
 
    However, given an ability to achieve both of these in backward compatible way later, we leave
    those for future extensions.
+
+1. PodGroupPostFilter extension
+   
+   The PodGroupPostFilter interface proposed in this KEP contains the most important 
+   information about PodGroup that failed scheduling cycle. We can extend this interface in the future
+   to allow plugins to have more insights into why a given pod group cannot be scheduled. One example of that
+   would be an extension similar to the NodeToStatusReader object passed to a PostFilter plugins.
+
 
 ### Test Plan
 
@@ -717,24 +897,34 @@ This can be done with:
 - [test name](https://github.com/kubernetes/kubernetes/blob/2334b8469e1983c525c0c6382125710093a25883/test/integration/...): [integration master](https://testgrid.k8s.io/sig-release-master-blocking#integration-master?include-filter-by-regex=MyCoolFeature), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=MyCoolFeature)
 -->
 
-We will create integration test(s) to ensure basic functionalities of workload preemption:
+For Alpha we implemented integration tests to ensure basic functionalities of workload preemption:
 
-- Pods from a single PodGroup with `DisruptionMode=Pod` can be preempted individually by the
+- Pods from a single PodGroup with `DisruptionMode=Single` can be preempted individually by the
   higher priority PodGroup
-- Pods from a single PodGroup with `DisruptionMode=PodGroup` are preempted all together even
+- Pods from a single PodGroup with `DisruptionMode=All` are preempted all together even
   when preempting a single pod would be enough to free up the space for the higher priority
   PodGroup
-- Pods from a single PodGroup with `DisruptionMode=Pod` can be preempted individuallby by the
+- Pods from a single PodGroup with `DisruptionMode=Single` can be preempted individually by the
   higher priority individual pod.
-- Pods from a single PodGroup with `DisruptionMode=PodGroup` are preempted all together even
+- Pods from a single PodGroup with `DisruptionMode=All` are preempted all together even
   when preempting a single pod would be enough to free up the space for the higher priority
   individual pod.
 
+Those tests are located at [podgrouppreemption_test.go](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/pkg/scheduler/framework/preemption/podgrouppreemption_test.go).
+
+For Beta we will expand the set of integration tests to cover the new Reprieval method. Namely, we will
+make sure that we have scenarios that covers the use of all in tree Filter plugins during the workload aware preemption.
+We also aim to have a parity with all the existing test scenarios for the default preemption.
+
 ##### e2e tests
 
-Given the new functionality is limited to kube-scheduler change and API extensions,
+For alpha, given the new functionality is limited to kube-scheduler change and API extensions,
 we will rely on integration tests described above (as easier and faster to run and debug).
 
+For beta we will add a new e2e test to the sig scheduling tests defined in [test/e2e/scheduling/preemption.go](https://github.com/kubernetes/kubernetes/blob/e136f39334a72b7d35069a97d373ccaa0211dcae/test/e2e/scheduling/preemption.go).
+Those tests will cover the four basics basic functionalities describe in previous section.
+
+For GA we will promote those tests to conformance.
 
 ### Graduation Criteria
 
@@ -754,7 +944,11 @@ we will rely on integration tests described above (as easier and faster to run a
 
 #### GA
 
-- TBD in for Beta release
+- Decision about additional sorting/scoring preemption victims to minimize preemption cost
+- Decision whether we support mutability of Priority for GA
+- E2E test promoted to conformance
+- Performance benchmarks have well defined thresholds and are run as part of the scheduler-perf of sig-scalability-benchmarks
+- All known issues resolved 
 
 
 ### Upgrade / Downgrade Strategy
@@ -785,19 +979,12 @@ is not relevant for it.
 ###### How can this feature be enabled / disabled in a live cluster?
 
 - [X] Feature gate (also fill in values in `kep.yaml`)
-  - Feature gate name: WorkloadAwarePreemption
+  - Feature gate name: GenericWorkload
   - Components depending on the feature gate: kube-apiserver, kube-scheduler
-- [ ] Other
-  - Describe the mechanism:
-  - Will enabling / disabling the feature require downtime of the control
-    plane?
-  - Will enabling / disabling the feature require downtime or reprovisioning
-    of a node?
 
-Note that this feature depends on the Workload API and gang-scheduling, so in addition
-to the `WorkloadAwarePreemption` feature gate, the `GenericWorkload` and `GangScheduling`
-feature gates also need to be enable. It is represented by adding dependency on those
-in the feature-gate framework.
+Note that for Alpha this feature was using `WorkloadAwarePreemption` feature gate.
+For Beta and GA we decided to merge it together with the `GenericWorkload` feature gate,
+with the rationale provided in the rest of the KEP. 
 
 ###### Does enabling the feature change any default behavior?
 
@@ -806,12 +993,12 @@ modified version of the algorithm. Thus the exact set of victims may slightly di
 
 The bigger changes in preemption victims may appear when pod groups start using `PodGroup`
 disruption mode, however that requires an explicit opt-in from the user (or controller)
-creating the Workload object.
+creating the `PodGroup` object.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
 Yes, the preemption algorithm changes can be disabled by simply disabling the feature gate
-in kube-scheduler.
+in kube-scheduler. However, this requires also disabling a Gang Scheduling feature.
 
 The new API changes and admission can also be disabled by disabling the feature gate in
 kube-apiserver. However keep in mind that it doesn't result in clearing the new fields
@@ -839,8 +1026,9 @@ https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05
 The scheduler algorithm changes are purely in-memory and doesn't require any dedicated
 enablement/disablement tests - the logic will be covered by regular feature tests.
 
-For the newly introduced API fields, dedicated enablement/disablement tests at the
-kube-apiserver registry layer will be added in Alpha.
+The API fields related to Workload Aware Preemption are no longer hidden behind a separate
+feature gate and will be promoted with the whole API to beta. There is no need for the
+dedicated enablement/disablement tests at the kube-apiserver registry layer
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -850,36 +1038,75 @@ This section must be completed when targeting beta to a release.
 
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-<!--
-Try to be as paranoid as possible - e.g., what if some components will restart
-mid-rollout?
+Workloads that do not use the `Workload` and `PodGroup `APIs should not be impacted, since the functionality remains unchanged for them. During a rolling upgrade, if the active scheduler instance has the feature disabled, it will schedule pods using the standard pod-by-pod method, falling back to a default PostFilter methods. A default preemption algorithm will treat all pods as single preemption units, even when they are a part of a PodGroup with `All` Disruption Mode.
 
-Be sure to consider highly-available clusters, where, for example,
-feature flags will be enabled on some API servers and not others during the
-rollout. Similarly, consider large clusters and how enablement/disablement
-will rollout across nodes.
--->
+This results in a fallback to the status quo behavior, meaning that pods will be still scheduled, but PodGroup-level scheduling constraints and preemption behavior won't be applied.
 
 ###### What specific metrics should inform a rollback?
 
-<!--
-What signals should users be paying attention to when the feature is young
-that might indicate a serious problem?
--->
+- `scheduler_podgroup_preemption_attempts_total{result="error"}`: A sudden spike indicates internal errors or panics within 
+the workload aware preemption logic.
+- `scheduler_podgroup_preemption_attempt_duration_seconds`: A significant P99 latency would indicate that the performance of the new logic is unacceptable.
+
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
-<!--
-Describe manual testing that was done and the outcomes.
-Longer term, we may want to require automated upgrade/rollback tests, but we
-are missing a bunch of machinery and tooling and can't do that now.
--->
+We'll perform manual testing of the upgrade -> downgrade -> upgrade path using the following sequences to
+verify workload aware preemption where Pod Group is either preemptor or a victim:
+
+For the Pod Group is a preemptor case we will use the following sequence:
+
+1. Start a local Kubernetes v1.36 cluster with `GenericWorkload` feature gate disabled (default 
+behavior).
+2. Fill the cluster with low priority idle pods so there is no room for new pods.
+3. Attempt to create a Pod with `spec.schedulingGroup` set.
+4. The `spec.schedulingGroup` field is dropped by the API server. The pod is created successfully
+   but without the `schedulingGroup` reference, resulting in immediate standard scheduling (one-by-one).
+5. Restart/Upgrade API Server and Scheduler to v1.37 with feature gate enabled.
+6. Create two PodGroup objects: `gang-test-A` and `gang-test-B` (both with `minCount=2`).
+6. Create a Pod `test-pod-1` with `spec.schedulingGroup` pointing to `gang-test-A`.
+7. The Pod stays in `Pending` state (waiting for the gang). Verify that
+   `scheduler_pending_entities{type="podgroup", queue="gated"}` metric is incremented.
+8. Create a Pod `test-pod-2` pointing to the same pod group.
+9. Both pods are scheduled successfully in the same cycle (Gang Scheduling with Workload Aware Preemption works).
+10. Verify that `scheduler_podgroup_preemption_attempts_total` metric is incremented.
+10. Downgrade API Server and Scheduler to v1.36 with feature gate disabled.
+11. Create `test-pod-3` pointing to `gang-test-B`. Note: We use a pod group created in step 5 because creating new
+    PodGroup objects is disabled.
+12. The pod is scheduled immediately (PodGroup logic is ignored because the schedulingGroup field is dropped by
+    the v1.36 API server). If Gang Scheduling were active, this pod would hang pending waiting for a second member.
+13. Verify that `preemption_attempts_total` was increased and the `scheduler_podgroup_preemption_attempts_total` metric
+    did not increase.
+13. Upgrade API Server and Scheduler back to v1.37 with feature gate enabled.
+14. Create `test-pod-4` and `test-pod-5` pointing to `gang-test-B`; verifying that Gang Scheduling functionality is
+    restored (these pods wait for `minCount=2` before scheduling).
+15. Verify that the `scheduler_podgroup_preemption_attempts_total` metric was increased and `preemption_attempts_total`
+    was not increased.
+
+For the Pod Group is a victim case we will use the following sequence:
+
+This sequence assumes that the pods and nodes are define in a way that ensures that only one pod can fit onto a node.
+
+1. Start a local Kubernetes v1.36 cluster with `GenericWorkload` feature gate disabled (default 
+behavior).
+2. Attempt to create two low priority Pods with `spec.schedulingGroup` set.
+3. The `spec.schedulingGroup` field is dropped by the API server. The pod are created successfully
+   but without the `schedulingGroup` reference.
+4. Create a high priority pod with NodeName set to a node of one of the low priority Pods. The pod is scheduled successfully and it preempts one of the low priority Pods.
+5. Restart/Upgrade API Server and Scheduler to v1.37 with feature gate enabled.
+6. Create two PodGroup objects: `gang-test-A` and `gang-test-B` (both with `minCount=2` and `PreemptionMode: All` and `Priority: Low`).
+7. Create two low piority pods `test-pod-1` and `test-pod-2` with `spec.schedulingGroup` pointing to `gang-test-A`.
+8. Create a high priority pod that with NodeName set to a node name of `test-pod-1`. Verify that preemption preempted both `test-pod-1` and -`test-pod-2`. 
+9. Downgrade API Server and Scheduler to v1.36 with feature gate disabled.
+10. Create `test-pod-3` and `test-pod-4`  pointing to `gang-test-B`. Note: We use a pod group created in step 6 because creating new PodGroup objects is disabled.
+11. Create a high priority pod that with NodeName set to a node name of `test-pod-3`. Verify that preemption preempted only `test-pod-3` and not `test-pod-4`. 
+12. Upgrade API Server and Scheduler back to v1.37 with feature gate enabled.
+13. Create low priority pods `test-pod-5` and `test-pod-6` pointing to `gang-test-B`.
+14. Create a high priority pod that with NodeName set to a node name of `test-pod-5`. Verify that preemption preempted `test-pod-5` and `test-pod-6`. 
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
-<!--
-Even if applying deprecation policies, they may still surprise some users.
--->
+No.
 
 ### Monitoring Requirements
 
@@ -892,11 +1119,7 @@ previous answers based on experience in the field.
 
 ###### How can an operator determine if the feature is in use by workloads?
 
-<!--
-Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
-checking if there are objects with field X set) may be a last resort. Avoid
-logs or events for this purpose.
--->
+Operators can check the new `scheduler_podgroup_preemption_attempts_total` metric. A value greater than zero indicates that the scheduler is processing Workload Aware Preemption.
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -909,50 +1132,38 @@ and operation of this feature.
 Recall that end users cannot usually observe component logs or access metrics.
 -->
 
-- [ ] Events
-  - Event Reason: 
-- [ ] API .status
-  - Condition name: 
-  - Other field: 
-- [ ] Other (treat as last resort)
-  - Details:
+- [X] Events
+  - Event Reason: Preempting
+  - The preemption message will have "cluster" set as a node name.
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
-<!--
-This is your opportunity to define what "normal" quality of service looks like
-for a feature.
+Since there are no formal SLOs for the kube-scheduler apart from scalability SLOs, we define the objectives for this
+feature primarily in terms of non-regression to ensure the workload aware preemption does not degrade the performance of the workload scheduling which in term would degrade the performance of the standard scheduling loop.
 
-It's impossible to provide comprehensive guidance, but at the very
-high level (needs more precise definitions) those may be things like:
-  - per-day percentage of API calls finishing with 5XX errors <= 1%
-  - 99% percentile over day of absolute value from (job creation time minus expected
-    job creation time) for cron job <= 10%
-  - 99.9% of /health requests per day finish with 200 code
+- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s) 
+  when scheduling pods attached to a PodGroup that requires preemption compared to scheduling an equivalent number of individual pods that would also require preemption.
+  This can be measured by the number of Pod binding API calls arriving to the API server
+  (`apiserver_request_total{resource="pods", subresource="binding"}`).
+- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s) 
+  when scheduling pods requires preemption of pods grouped in PodGroups (DisruptionMode = All) compared to scheduling an equivalent number of pods in PodGroups that would require preemption of similar number of pods but not grouped in PodGroup.
+  This can be measured by the number of Pod binding API calls arriving to the API server
+  (`apiserver_request_total{resource="pods", subresource="binding"}`).
 
-These goals will help you determine what you need to measure (SLIs) in the next
-question.
--->
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
-<!--
-Pick one more of these and delete the rest.
--->
-
-- [ ] Metrics
-  - Metric name:
-  - [Optional] Aggregation method:
-  - Components exposing the metric:
-- [ ] Other (treat as last resort)
-  - Details:
+- [X] Metrics
+  - Metric name: 
+    - scheduler_podgroup_preemption_attempts_total
+    - scheduler_podgroup_preemption_attempt_duration_seconds
+    - scheduler_podgroup_preemption_victims
+    - plugin_execution_duration_seconds{extension_point=Reprieval}
+  - Components exposing the metric: kube-scheduler
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-<!--
-Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
-implementation difficulties, etc.).
--->
+No. 
 
 ### Dependencies
 
@@ -962,20 +1173,7 @@ This section must be completed when targeting beta to a release.
 
 ###### Does this feature depend on any specific services running in the cluster?
 
-<!--
-Think about both cluster-level services (e.g. metrics-server) as well
-as node-level agents (e.g. specific version of CRI). Focus on external or
-optional services that are needed. For example, if this feature depends on
-a cloud provider API, or upon an external software-defined storage or network
-control plane.
-
-For each of these, fill in the following—thinking about running existing user workloads
-and creating new ones, as well as about cluster-level services (e.g. DNS):
-  - [Dependency name]
-    - Usage description:
-      - Impact of its outage on the feature:
-      - Impact of its degraded performance or high-error rates on the feature:
--->
+No dependencies other than the components where the feature is implemented (kube-apiserver and kube-scheduler).
 
 ### Scalability
 
@@ -1030,43 +1228,93 @@ details). For now, we leave it here.
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
+The behavior is consistent with the status quo. The removal of the victims selected by the Workload-Aware Preemption uses the same code as the standard preemption. Since the scheduler cannot remove pods or update them, any pod removal attempts that are an outcome of preemption will fail, not making space for the preemptor pods. Preemptor pods will not be marked with the NominatedNodeName. 
+
+When the call to delete victim pods fails, the preemptor is moved to active queue (with async preemption) or backoff/unschedulable queue (without async preemption). 
+
+Calls to update NominatedNodeNames for preemptor pods are using PatchPodStatus function which implements a retry mechanism and is shared by all occurrences that require updating pod status from scheduler. 
+
 ###### What are other known failure modes?
 
-<!--
-For each of them, fill in the following information by copying the below template:
-  - [Failure mode brief description]
-    - Detection: How can it be detected via metrics? Stated another way:
-      how can an operator troubleshoot without logging into a master or worker node?
-    - Mitigations: What can be done to stop the bleeding, especially for already
-      running user workloads?
-    - Diagnostics: What are the useful log messages and their required logging
-      levels that could help debug the issue?
-      Not required until feature graduated to beta.
-    - Testing: Are there any tests for failure mode? If not, describe why.
--->
+1. WorkloadAwarePreemption takes too long halting scheduling loop
+- Detection: High values for metric: `scheduler_podgroup_preemption_attempt_duration_seconds`
+- Mitigations: If intended, delete the PodGroup object and recreate the pods without `schedulingGroup`
+  to disable gang scheduling and workload aware preemption (fallback to best-effort scheduling and default preemption) if acceptable.
+- Diagnostics: Scheduler logs at V=6 searching for logs from podgrouppreemption.go file to trace where preemption slows down.
+- Testing: The scheduler performance benchmarks should catch potential issues with a poor performance of the workload aware preemption
+
+1. WorkloadAwarePreemption does not remove low level pods to make a place for the preemptor
+- Detection: Check Pod Events/Status. Expected reason: a message indicating why preemption failed
+- Metrics: `scheduler_podgroup_preemption_attempts_total{result=error}`
+- Mitigations:
+  - Scale up the cluster (add nodes) or delete other real-workloads to free up space.
+  - If intended, delete the PodGroup object and recreate the pods without `schedulingGroup`
+    to disable gang scheduling (fallback to best-effort scheduling) if acceptable.
+- Diagnostics:
+  - Scheduler logs at V=6 searching f or logs from podgrouppreemption.go file to see detailed reasons why the workload aware preemption failed.
+- Testing:
+  - Covered by integration tests
+
+1. WorkloadAwarePreemption removes more pods than necessary 
+
+- Detection: The amount of pods with status `preempted by podgroup X` is higher than expected for a given pod group
+- Mitigations: If intended, delete the PodGroup object and recreate the pods without `schedulingGroup`to disable gang  
+  scheduling and workload aware preemption (fallback to best-effort scheduling and default preemption) if acceptable.
+- Diagnostics: Search for log line (V6) `Pods are potential preemption victims on domain`. This line is outputted after
+  each failed victim reprieval.
+- Testing: The scheduler performance benchmarks should catch potential issues with a poor performance of the workload aware preemption
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
 ## Implementation History
 
-<!--
-Major milestones in the lifecycle of a KEP should be tracked in this section.
-Major milestones might include:
-- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
-- the `Proposal` section being merged, signaling agreement on a proposed design
-- the date implementation started
-- the first Kubernetes release where an initial version of the KEP was available
-- the version of Kubernetes where the KEP graduated to general availability
-- when the KEP was retired or superseded
--->
+2025-11: Initial KEP-5710 proposal.
+2026-02: KEP-5710 created for WAP alpha release.
+2026-02: KEP-5710 updated to sync with decoupling of PodGroup/Workload API.
+2026-05: KEP updated to promote to beta in v1.37.
 
 ## Drawbacks
 
-<!--
-Why should this KEP _not_ be implemented?
--->
+There are already multiple implementations of Gang Scheduling with Gang Preemption in
+the kubernetes ecosystem. However, we believe that workload awarness is critical enough
+that it deserves standardizing in core Kubernetes.
 
 ## Alternatives
+
+ One alternative considered as a short-term workaround for unnecessary preemption was the introduction of "delayed preemption". The proposed delayed preemption mechanism was structured as follows:
+
+1. Modify the `DefaultPreemption` plugin to just compute preemptions, without actuating them.
+
+2. Extend the `PostFilterResult` to include a set of victims (in addition to the existing
+   `NominationInfo`). This will allows to clearly decouple the computation from actuation.
+
+3. For individual pods (not being part of a workload), adjust the scheduling framework
+   implementation of `schedulingCycle` to actuate preemptions of returned victims if calling
+   `PostFilter` plugins resulted in finding a feasible placement.
+
+4. For pods being part of a workload, rely on the Workload Scheduling Cycle.
+   There are two subcases here:
+
+   1. In the legacy case (without workload-aware preemption), `PostFilter` is called individually for
+      every pod from a PodGroup. However, the victims computed for already the already processed
+      pods may affect placement decisions for the next pods.
+      To accommodate for that, if a set of victims was returned from a `PostFilter` in addition
+      to keeping them for further actuation, they are additionally stored in `CycleState`.
+      More precisely, the `CycleState` stores a new entry containing a map from
+      a `nodeName` to a list of victims that were already chosen.
+      With that, the `DefaultPreemption` plugin is extended to remove all already chosen
+      victims from a given node before processing that node.
+
+   2. In the target case (with workload-aware preemption), there is no longer a need to process
+      pods individually, so the additional mutations of `CycleState` are not needed.
+
+5. In both above cases, an additional step is introduced to the scheduling algorithm at the
+   end. If a feasible placement for the PodGroup is found, all the victims are taken and their
+   preemption is actuated. If a feasible placement was not found, the victims are dropped.
+   In both cases, the scheduling of the whole PodGroup (all its pods) is marked as unschedulable
+   and got back to the scheduling queue.
+
+This alternative was dropped as we decided that workload aware preemption is crucial for the Gang Scheduling effort. As we tied those two efforts together, there is no need for additional alternative approach for minimzing disruptions in Gang Scheduling without WAP.
 
 <!--
 What other approaches did you consider, and why did you rule them out? These do
@@ -1076,8 +1324,4 @@ information to express the idea and why it was not acceptable.
 
 ## Infrastructure Needed (Optional)
 
-<!--
-Use this section if you need things from the project/SIG. Examples include a
-new subproject, repos requested, or GitHub details. Listing these here allows a
-SIG to get the process for these resources started right away.
--->
+N/A

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -21,7 +21,6 @@
   - [Pod Group priorities](#pod-group-priorities)
   - [Preemption algorithm](#preemption-algorithm)
     - [In place victim reprieval](#in-place-victim-reprieval)
-    - [CycleState retention](#cyclestate-retention)
       - [TopologyAwareScheduling](#topologyawarescheduling)
     - [CompositePodGroup](#compositepodgroup)
   - [Pod Group Post Filter](#pod-group-post-filter)
@@ -657,75 +656,17 @@ we will be able to achieve in-place replacement with relatively localized change
 
 #### In place victim reprieval
 
-The algorithm described above assumes that we can cheaply check if a potential victim pod can be placed back where they are currently running after preemptor has been `assumed` on the target node. However there is no extension point like this implemented in the scheduler as of right now. During scheduling, the scheduler uses Filter plugins to check whether a pod can run on a given node. This process is heavy and requires to build a `cycleState` object, particularly for plugins that have inter pod constraints such as pod affinity (pod running on node A can fail "Filter" on node B). Running `Filter()` and building a `cycleState` for all of the victims does not seem like a feasible option from performance perspective.
+The algorithm described above states that at one point we need to check whether a victim can be placed back in the place
+they are currently running with preemptor assumed to run on selected nodes. This check will be achieved by running Filter 
+plugins for each of the schedulable preemptor pods on selected nodes with the preemptor pod `CycleState`. We will keep the `CycleState` objects of each of the schedulable preemptor pods from the scheduling algorithm run within WAP and update them as we reprieve victims.
 
-However, one can note that actually do not need a full Filter check. Instead of checking if the victim pod can be scheduled back on its node, we need to check whether keeping the victim pod on a node will break the schedulability of the preemptor that we assumed. Mainly, this means that we do not have to meet the scheduling constraints for victim pod, and we only care about scheduling constraints of the preemptor pod that could be broken. Such check can be implemented by extending Filter plugins with a new method.
-We propose to tenantively call it `Reprieve` with following semantics:
-
-```go 
-
-type PreemptorPlacement struct {
-  Pod        *v1.Pod
-  Node       NodeInfo
-  CycleState CycleState
-}
-
-// ...
-// FilterPlugin also needs to implement Reprieve method
-// for effective preemption for pod groups.
-type FilterPlugin interface {
-    Plugin
-
-    Filter(ctx context.Context, state CycleState, pod *v1.Pod, nodeInfo NodeInfo) *Status
-
-    // Reprieve is called by the preemption.
-    // All FilterPlugins should return "Success" to declare that
-    // the given victim pod can be placed back on the given node
-    // without breaking schedulability of the preemtor pod on this node.
-    // If Reprieve does not return "Success", it will return "Unschedulable"
-    // or "Error".
-    //
-    // "Error" aborts preemption.
-    //
-    // For the node being evaluated Filter plugins should look at the passed
-    // nodeInfo reference for this particular node's information instead of
-    // looking it up in the NodeInfoSnapshot because during preemption
-    // the state of the node can be mutated to evaluate the possibility of  preempting 
-    // them to schedule preemptor pods.
-
-    // Plugins are encouraged to check the context for cancellation.
-    // Once canceled, they should return as soon as possible with
-    // an Unschedulable status that includes the
-    // `context.Cause(ctx)` error explanation.
-    Reprieve(ctx context.Context, victimPod *v1.Pod, nodeInfo NodeInfo, preemptorPods []PreemptorPlacement, clusterNodes []NodeInfo) *Status
-}
-```
-
-We expect that for Filter plugins that do not enforce inter pod constraints the implementation should be trivial. We will
-provide an implementation for all the in-tree Filter plugins. We expect that the owners of out-of-tree plugins will
-follow with the implementation of `Reprieve` for their plugins.
-
-For currently implemented in-tree plugins that implement FilterPlugin interface the Reprieve method will work as follows:
-- NodeName: No-op. Scheduling constraint without inter pod constraints.
-- NodePorts: The Reprieve method will check whether the preemptor pods do not use the same `hostPort` as victim pod. If they do, reprieving victim pod breaks schedulability of the preemptor.
-- NodeAffinity: No-op. Scheduling constraint without inter pod constraints.
-- TaintToleration: No-op. Scheduling constraint without inter pod constraints.
-- NodeResourceFit: The Reprieve method will check whether there is enough space for the victim pod given the current state of the node (with preemptor assumed).
-- NodeUnschedulable: No-op. Scheduling constraint without inter pod constraints. 
-- VolumeBinding:  No-op with the current implementation. No change in NodeInfoSnapshot can change the csiStorageCapacityLister output, thus allow preemptor to schedule in a way that breaks CSI storage capacity limity.
-- VolumeRestrictions: The Reprieve method will check whether the volume of victim does not conflict with the node local volumes of the preemptor pods. It will also check whether victim is not trying using `ReadWriteOncePod` PVC that is taken by any of the preemptor pod.
-- VolumeZone: No-op. Scheduling constraint between pod's PVs and node labels
-- PodTopologySpread: The reprieve method has to check whether reprieving a victim pod will not cause the skew of topologySpreadConstraint on the preemptor pod. This one can be potentially the hardest one to implement efficiently as it might require iterating over multiple nodes to calculate skew.
-- InterPodAffinity: We need to check whether preemptor does not have hard anti affinity to the victim pod. If so, reprieving victim would break the schedulability of the preemptor.  We also need to check whether reprieving back the victim pod won't violate any topology constraints (preemptor pod cannot be scheduled in a topology with specific pods running and victim is one of those specific pods). 
-- NodeDeclaredFeatures: No-op. Scheduling constraint.
-- NodeVolumeLimits: No-op with the current implementation. No change in NodeInfoSnapshot can change the csiManager output, thus allow preemptor to schedule in a way that breaks node volume limits.
-- DynamicResources: No-op with current implementation. There is no way to simulate de allocation of the DRA devices in the preemption, so the preemptor pods cannot take over the devices from victim pods.
+The `CycleState` object for Nth pod does not contain information about pods that were scheduled in the pod group cycle after this pod. That's why before running reprieval we will need to update CycleState of preemptor pods with the information about all other pods that were scheduled in pod group cycle after this pod.
 
 > **Note:**
 > DynamicResources, NodeVolumeLimits and VolumeBinding plugins do not work well with preemption right now.
 > They do not support PreFilterExtension interface and they work on a data provided by informer based
 > managers which does not reflect changes in NodeInfo snapshot. As a result they produce false negatives.
-> We do not expect to improve on this when introducing WAP and reprieval method.
+> We do not expect to improve on this when introducing WAP.
 
 When trying to reprieve Pods belonging to the PodGroup with `DisruptionMode=All` the preemption logic will be responsible,
 for making sure that either all of Pods can be reprieved or none of them will be reprieved. This will be achieved 
@@ -733,49 +674,16 @@ by reprieving all pods from PodGroup one by one. After each victim is reprieved,
 of the cluster and kept in a list of pods to rollback. If any of the pods from PodGroup fails the Reprieve call
 all pods from rollback list will be removed from cluster representation.
 
-#### CycleState retention
-
-In the Alpha implementation of WAP the whole PodGroupScheduling function is executed for each victim "reprieval". It includes 
-building a new CycleState for each of the preemptor pods. This assumes that each of the plugin can create a valid
-CycleState based on the current NodeInfoSnapshot which is updated as victim pods are removed and added. This might not be true
-for plugins that use information from external informer and rely on the PreFilterExtension to keep a diff that is applied
-on top of the informer to simulate current state of the world. See [DRA Preemption Proposal](https://github.com/kubernetes/enhancements/issues/5690)
-and VolumeRestrictionsPlugin.
-
-That's why for Beta promotion, we will refactor the PodGroupSchedulingAlgorithm to allow CycleState to be reused across the original scheduling atttempt and attempts in the WAP.
-
-In the current implementation of PodGroupSchedulingAlgorithm the CycleState for Nth Pod from PodGroup is created with previous (N-1) pods from the same PodGroup assumed. 
-To revert that from the CycleState of Nth Pod, we will need to run PreFilterExtension.RemovePod() for each of the (N-1) pods as part of clean up function that we currently run to remove Nth Pod from the NodeInfoSnapshot.
-
-This is akin to the current implementation of PostFilter, where the CycleState from original scheduling attempt is passed to Postfilter method.
-
-For the Reprieve method to work it will require that after an successful attempt of PodGroupScheduling in WAP, for a Nth Pod in PodGroup we will need to add all 
-pods from N+1 till the end of the PodGroup to this pod CycleState. This is to make sure that CycleState of Nth Pod is aware of the assumed presence of the rest 
-of the pods from PodGroup.
-
-This also means that we will not rerun PreFilter plguins in the PodGroupScheduling during WAP. It's also akin to the current implementation of default
-preemption where we only rerun Filter plugins. This information is not exposed right now, so to make thing explicit we will expand the PreFilter plugin
-description to clearly describe how it works with preemption:
-- if any Prefilter returns UnschedulableAndUnresolvable the default preemption / workload aware preemption will not be run. Other PodGroupPostFilter plugins may still run.
-- if any PreFilter returns Unschedulable we run default preemption / workload aware preemption with cycleStates from the initial attempt. PreFilters are NOT rerun in the preemption.
-  Only the PreFilteExtension interface is called to adjust internal state of prefilters based on the victim removal/addition.
-- if a PreFilter returns Skip, the plugin will also be skipped during WAP scheduling simulation and in the Reprieve phase
-- if a PreFilter returns a subset of nodes, this subset of nodes will also be used during preemption scheduling simulation, meaning that even after victim removal we will not search 
-  additional nodes. This is in line with the behavior of not reruning PreFilters in the preemption. 
-
 ##### TopologyAwareScheduling
 
 Even though we do not aim to have a full support for TAS as a part of this KEP, it's worth to consider whether this approach will not block or make it hard
-to implement support for WAP in TAS in the future. As the PlacementGeneratePlugins do not depend on the pod cycle states, there is no concern here.
-For the scheduling attempts inside TAS, the PreFilter plugins do not depend on the selected placement (they always use whole cluster nodes), so we should be able to reuse
-the CycleState from the original scheduling attempt.
+to implement support for WAP in TAS in the future. As we will rerun whole podGroupSchedulingAlgorithm in the WAP, we will as an output get the best placement
+with proposed pods assignments. If we also get the CycleStates from those Pod, we will be able to perform an in-place reprieve as described above.
 
 #### CompositePodGroup
 
 As in TopologyAwareScheduling case we do not aim to have a support for CPG as part of this KEP, but it's alo worth to consider whether this approach will not block WAP for 
-CPGs in the future. This case is very similar to the TopologyAwareScheduling, where in Multi Level Topology Scheduling topolgies will not depend on the pod cycle states and 
-cycle states of pods from all pod groups can be stored and passed to the preemption. 
-
+CPGs in the future. This case is analogous to TopologyAwareScheduling, where whole CPG logic will be hidden within the podGroupSchedulingAlgorithm rerun in the WAP.
 
 ### Pod Group Post Filter
 
@@ -827,7 +735,7 @@ type PodGroupPostFilterPlugin interface {
     // Optionally, a non-nil PodGroupPostFilterResult may be returned along with a Success status. For example,
     // a preemption plugin may choose to return nominatedNodeName, so that framework can reuse that to update the
     // preemptor pod's status.nominatedNodeName field.
-    PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *fwk.Status)
+    PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, podGroupCycleState *framework.CycleState, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *fwk.Status)
 }
 ```
 
@@ -910,6 +818,21 @@ for any of those and proceeding with any of these will require dedicated KEP(s) 
    that we try to reprieve the victims. With a custom scoring functions we could change influence the 
    placement of the preemptor in order to optimize for the reducing the preemption cost. Such change
    can be designed and implemented as a dedicated, follow up KEP. 
+
+1. Specific in place reprieval method
+
+   The in place reprieval proposed in this KEP works by reusing the Filter plugins on preemptor pods.
+   However, this can lead to superflous checks especially for scheduling constraints of preemptor pods
+   that cannot be influenced by "reprieval" of victim. We can see a future, where for the improved performance
+   we will introduce a new method that will allow us to perform a more focused in place reprieval check.
+   
+1. Other in place reprieval improvements
+
+   We can also improve the in place reprieval proposed in this KEP by adding a special check that would allow
+   plugins to decide whether a given pod contains any inter pod constraints. If the Pod does not have any
+   such constraints, we would know that it's safe to reprieve all victims on the nodes that were not selected
+   for the preemptor pods. This can provide a significant performance gain in large scale clusters for 
+   workloads without inter pod constraints.
 
 
 ### Test Plan

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -668,12 +668,9 @@ plugins for each of the schedulable preemptor pods on selected nodes with the pr
 We will keep the `CycleState` objects of each of the schedulable preemptor pods from the scheduling algorithm run within
 WAP and update them as we reprieve victims.
 
-The `CycleState` object for Nth pod does not contain information about pods that were scheduled in the pod group cycle after this pod.
-That's why before running reprieval we will need to update CycleState of preemptor pods with the information about all other pods that
-were scheduled in pod group cycle after this pod. We acknowledge that this operation has $O(N^2)$ complexity where N is the number of pods
-in the pod group, but we believe that the cost of PreFilterExtension.AddPod is small enough to not account for most of the additional time
-complexity introduced by WAP. Reducing this complexity might be one of performance optimization along other described in 
-[Potential future extensions](#potential-future-extensions) section.
+We will make sure that the Filter plugins in the WAP will mimic the behavior of Filter plugins from the scheduling cycle.
+Mainly it means that when running Filter plugins for Nth Pod in the PodGroup, the CycleState/NodeInfo should not contain
+information about further pods from the Pod Group.
 
 > **Note:**
 > DynamicResources, NodeVolumeLimits and VolumeBinding plugins do not work well with preemption right now.

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -156,7 +156,7 @@ and many others) and bring the true value for every Kubernetes user.
   If we decide to change that it will be addressed in a dedicated KEP.
 - Propose any tradeoff between preemption and cluster scale-up.
 - Design workload-level preemption triggered by external schedulers
-- Handling non-uniform priorities across PodGroups/CompositePodGroups
+- Handling non-uniform priorities across PodGroups
 - Full support for Topology Aware Scheduling. This will be provided in TAS KEP.
 
 ## Proposal
@@ -286,7 +286,7 @@ a single pod}. With that definition both scheduling unit and preemption units ca
 In the future, we may want to support usecases when a single scheduling unit consists of multiple
 preemption groups, but we leave that usecase as a future extension (it can be addressed when we
 decide to extend Workload API with CompositePodGroup concept - for more details see
-[API Design For Gang and Workload-Aware Scheduling](https://tiny.cc/hvhs001)). However, we never expect preemption unit to
+[CompositePodGroup API](https://github.com/kubernetes/enhancements/issues/6012)). However, we never expect preemption unit to
 be larger than scheduling unit.
 
 Based on that, we will extend the the existing `GangSchedulingPolicy` as following:
@@ -364,9 +364,12 @@ that should be used for preemption. So in the ideal world a workload owner shoul
 - mutate preemption priority during the whole lifecycle of the workload to reflect the importance
   of that workload at a given moment
 
-However, while we believe that all of these are eventually needed, we start simpler by:
-- starting with just a single priority for scheduling and preemption.
-- starting with static preemption priority (mutability brings additional complexity that is
+However, while we expect the need for separate mutable priorities, we leave it as a possible further 
+extension out of the scope of this KEP.
+
+In this KEP we introduce:
+- a single priority for scheduling and preemption.
+- static preemption priority (mutability brings additional complexity that is
   purely additive and thus should be added in a follow-up KEP)
 
 In [KEP-4671: Gang Scheduling using Workload Object] we already decided that PodGroup is the scheduling
@@ -1232,6 +1235,7 @@ feature primarily in terms of non-regression to ensure the workload aware preemp
     - scheduler_podgroup_preemption_attempts_total
     - scheduler_podgroup_preemption_attempt_duration_seconds
     - scheduler_podgroup_preemption_victims
+    - scheduler_podgroup_preemption_reprieved_total
     - plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="Reprieval"}
     - plugin_execution_duration_seconds{plugin="DefaultPreemption", extension_point="PostFilter"}
   - Components exposing the metric: kube-scheduler

--- a/keps/sig-scheduling/5710-workload-aware-preemption/README.md
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/README.md
@@ -460,8 +460,9 @@ Note that, for workload-aware preemption we will support the `preemptionPolicy` 
 of requestion `PriorityClass` - namely both currently existing modes: `PreemptLowerPriority`
 and `Never`.
 
-As the `preemptionPolicy` is also a field of the Pod, we will apply the same constraints to this field as we will
-for the priority. Namely, all pods within `PodGroup` will have to share the same `preemptionPolicy`. This will be enforced on the scheduler level.
+As the `preemptionPolicy` is also a field of the Pod, we will apply the same constraints as
+for the priority. Namely, all pods within `PodGroup` will have to share the same `preemptionPolicy`. 
+This will be enforced on the scheduler level.
 
 Given that components operate on integer priorities, we will introduce a corresponding fields
 that reflect priority of a PodGroup (similarly to how it's done in Pod API).
@@ -540,7 +541,7 @@ To check if a pod P can be scheduled on a given node with preemption we:
    and working down until the set of remaining victims still keeps the node feasible.
 
 Once we find enough nodes feasible for preemption and list of victims for them, we score that and
-choose the best options.
+choose the best option.
 
 The above algorithm achieves our principles, as by reprieving the highest priority pods first, it
 effectively tries to minimize the cascading preemptions later.
@@ -578,10 +579,13 @@ with preemption:
       is unschedulable with preemption in currently considered domain D.
 
    1. For the [Topology-Aware Scheduling] "checking whether preemptor becomes schedulable" yields a list 
-      of potential placements. For the alpha support of TAS, we will only assume the best placement. With the
-      progression of TAS to Beta, we might change the algorithm to consider multiple placements.
+      of potential placements. For the alpha support of TAS, we will only assume the best placement (based on
+      TAS Placement Scoring plugins). With the progression of TAS to Beta, we might change the algorithm to 
+      consider top N placements and adjust their scores based on the amount of preemption victims each placement yields,
+      and only after that selecting the best one.
       We can also see a future where if the algorithm is performant enough, even for the non TAS case,
-      we will generate multiple potential placements and consider them. 
+      we will generate multiple potential placements and consider them, to select a placement that yields 
+      the lowest amount of disruptions. 
 
    1. For each placement computed above run the following points:
 
@@ -590,9 +594,9 @@ with preemption:
           priority prioritizing pod groups over individual pods.
 
       1.  Perform best-effort reprieval of pod groups and pods violating PodDisruptionBudgets. We achieve
-          it by scheduling and temporarily adding the preemptor to `nodeInfo` structure (assuming that
-          all potential victims are removed), and then iterating over potential victims that would violate
-          PodDisruptionBudget to check if these can be placed in the exact same place they are running now.
+          it by temporarily scheduling the preemptor (assuming that all potential victims are removed),
+          and then iterating over potential victims that would violate PodDisruptionBudget to check if these
+          can be placed in the exact same place they are running now.
           If they can we simply leave them where they are running now and remove from the potential victims
           list.
 

--- a/keps/sig-scheduling/5710-workload-aware-preemption/kep.yaml
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/kep.yaml
@@ -15,7 +15,7 @@ approvers:
 
 see-also:
   - "/keps/sig-scheduling/4671-gang-scheduling"
-  - "/keps/sig-scheduling/5732-topology-aware-workload-preemption"
+  - "/keps/sig-scheduling/5732-topology-aware-workload-scheduling"
 
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
@@ -40,6 +40,7 @@ feature-gates:
     components:
       - kube-apiserver
       - kube-scheduler
+      - kube-controller-manager
 disable-supported: true
 
 # The following PRR answers are required at beta release

--- a/keps/sig-scheduling/5710-workload-aware-preemption/kep.yaml
+++ b/keps/sig-scheduling/5710-workload-aware-preemption/kep.yaml
@@ -2,6 +2,7 @@ title: Workload-aware preemption
 kep-number: 5710
 authors:
   - "@wojtek-t"
+  - "@argh4k"
 owning-sig: sig-scheduling
 participating-sigs:
 status: implementable
@@ -14,16 +15,17 @@ approvers:
 
 see-also:
   - "/keps/sig-scheduling/4671-gang-scheduling"
+  - "/keps/sig-scheduling/5732-topology-aware-workload-preemption"
 
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -34,7 +36,7 @@ milestone:
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
-  - name: WorkloadAwarePreemption
+  - name: GenericWorkload
     components:
       - kube-apiserver
       - kube-scheduler
@@ -42,3 +44,6 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
+  - scheduler_podgroup_preemption_attempts_total
+  - scheduler_podgroup_preemption_attempt_duration_seconds
+  - scheduler_podgroup_preemption_victims


### PR DESCRIPTION
- One-line PR description: Update KEP-5710 for beta in v1.37

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5710

<!-- other comments or additional information -->
- Other comments: 
  - Apart from Beta graduation itself this update:
    - Eliminates delayed preemption completely
    - Removes Workload Aware preemption specific feature gate and ties the effort with GangScheduling behind GenericWorkload feature gate
    - Describes in details the proposed "in place reprieval" 
    - Describes in details PodGroupPostFilter extension point