### PR TITLE
KEP-1710: Promote SELinux mount to GA

### DIFF
--- a/keps/prod-readiness/sig-storage/1710.yaml
+++ b/keps/prod-readiness/sig-storage/1710.yaml
@@ -10,5 +10,6 @@ beta:
   # @deads2k for SELinuxChangePolicy beta 1.33
 stable:
   approver: "@deads2k"
-  # @deads2k for SELinuxMount GA in 1.36
+  # @deads2k for SELinuxMountReadWriteOncePod in 1.36
   # @deads2k for SELinuxChangePolicy GA 1.36
+  # @deads2k for SELinuxMount GA in 1.37

--- a/keps/sig-storage/1710-selinux-relabeling/README.md
+++ b/keps/sig-storage/1710-selinux-relabeling/README.md
@@ -80,10 +80,10 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [x] (R) Graduation criteria is in place
   - [x] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
 - [x] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
+- [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
 - [x] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [x] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 ## Summary
 
@@ -96,12 +96,11 @@ The enhancement describes situations when such option can/cannot be used, why it
 This KEP is split into three phases:
 1. ReadWriteOncePod volumes are mounted with `-o context` by default.
    All other volumes are recursively relabeled by the container runtime.
-   With feature gate `SELinuxMountReadWriteOncePod`, beta + on by default in v1.28.
+   With feature gate `SELinuxMountReadWriteOncePod`, GA in v1.36.
 2. Same as 1., but we provide metrics that show what Pods will break when *all* volumes are mounted with `-o context` and provide a proactive opt-out by setting `SELinuxChangePolicy: Recursive` in PodSpec.
-   With feature gate `SELinuxChangePolicy`.
-   Alpha in 1.32.
+   With feature gate `SELinuxChangePolicy`, GA in v1.36.
 3. All volumes are mounted with `-o context` by default, users can opt-out by setting `SELinuxChangePolicy: Recursive` in PodSpec.
-   With feature gate `SELinuxMount`, alpha without opt-out since 1.30, adding the opt-out field as alpha in 1.32.
+   With feature gate `SELinuxMount`, GA in v1.37.
 
 Initially, we thought we could do 2. without opt-out, but we found that it may break valid use cases.
 
@@ -550,6 +549,11 @@ Phase 3:
   * Or just generic "volume XYZ is already mounted with a different SELinux label" when A and B are in different namespaces, so users cannot peek into other namespaces.
 * SELinuxController, if enabled, will send events to Pods that may not start if they land on the same node.
 
+As of 2026-05-25, telemetry numbers from OpenShift show:
+* ~1.2% of the clusters with Kubernetes 1.32 and newer have `volume_manager_selinux_volume_context_mismatch_warnings_total > 0`. It is higher than in Phase 2, because more old clusters with old workloads upgraded to 1.32 and newer.
+* ~0.4% of the clusters with Kubernetes 1.33 and newer have any SELinux warning controller warnings. Admins of those clusters need to evaluate the warnings and fix their Pods before Kubernetes upgrade to a version where `SELinuxMount` is GA.
+We consider these numbers good enough to consider Phase 3 successful and proceed with GA.
+
 ## Design Details
 
 ### Required kubelet changes
@@ -717,11 +721,13 @@ All these e2e tests use only CSI volumes. All in-tree volume types that support 
   * Users can update their clusters safely, there is no breaking change yet.
     Users willing to test `SELinuxMount` must enable it explicitly.
   * This phase allows production clusters to check what Pods (Deployments, StatefulSets) need update and fix them before the breaking part (`SELinuxMount`) is enabled by default in the next phase.
+  * Done in 1.36.
 * GA of Phase 3 (`SELinuxMount` is GA and locked to default):
   * At least 1 release after `SELinuxChangePolicy` is GA to give cluster admins enough time to apply `SELinuxChangePolicy` to their Pods.
   * Telemetry numbers from OpenShift show that <2% of clusters would need to change any of their Pods (i.e. most clusters already applied opt-out).
   * This is the phase that may break existing applications during cluster upgrade.
     Users that use SELinux should carefully evaluate the metrics emitted by kubelet and SELinuxWarningController and fix their workloads before upgrade to this version.
+  * Done in 1.37.
 
 ### Upgrade / Downgrade Strategy
 
@@ -759,11 +765,9 @@ _This section must be completed when targeting alpha to a release._
 
 * **How can this feature be enabled / disabled in a live cluster?**
   - [X] Feature gate (also fill in values in `kep.yaml`)
-    - Feature gate name: `SELinuxMountReadWriteOncePod` (beta in 1.28)
-    - Feature gate name: `SELinuxChangePolicy` (alpha in 1.30, proposing beta in 1.33)
-      - To enable `SELinuxChangePolicy` feature gate, `SELinuxMountReadWriteOncePod` **must** be enabled too.
-    - Feature gate name: `SELinuxMount` (alpha in 1.30, proposing beta in 1.33)
-      - To enable `SELinuxMount` feature gate, `SELinuxMountReadWriteOncePod` and `SELinuxChangePolicy` **must** be enabled too.
+    - Feature gate name: `SELinuxMountReadWriteOncePod` (beta in 1.28, GA in 1.36)
+    - Feature gate name: `SELinuxChangePolicy` (alpha in 1.32, beta in 1.33, GA in 1.36)
+    - Feature gate name: `SELinuxMount` (alpha in 1.30, beta in 1.33, GA in 1.37)
     - Components depending on the feature gate: apiserver (API validation only), kubelet
   - [ ] Other
     - Describe the mechanism:
@@ -1056,9 +1060,10 @@ _This section must be completed when targeting beta graduation to a release._
   * Test on non-Fedora based Linux distribution (e.g. Debian) with SELinux enabled.
 * 1.36: Graduate `SELinuxMountReadWriteOncePoc` and `SELinuxChangePolicy` to GA.
   * Keep `SELinuxMount` beta / disabled by default.
-  * Publish a blog or similar documentation that upgrade from 1.36 to 1.37 may introduce breaking changes on clusters with SELinux enabled and cluster admins are advised to check metrics and events.
+  * [Blog post about breaking changes](https://kubernetes.io/blog/2026/04/22/breaking-changes-in-selinux-volume-labeling/) published to warn cluster admins that upgrade from 1.36 to 1.37 may introduce breaking changes on clusters with SELinux enabled.
   * This is based on favorable telemetry data reported by OpenShift on 2026-01-13, see [Risks and Mitigations](#risks-and-mitigations).
-* Optimistic plan: 1.37 GA of everything.
+* 1.37: Graduate `SELinuxMount` to GA.
+  * All three feature gates (`SELinuxMountReadWriteOncePod`, `SELinuxChangePolicy`, `SELinuxMount`) are GA and locked to default.
 
 ## Drawbacks [optional]
 

--- a/keps/sig-storage/1710-selinux-relabeling/kep.yaml
+++ b/keps/sig-storage/1710-selinux-relabeling/kep.yaml
@@ -5,7 +5,7 @@ authors:
 owning-sig: sig-storage
 participating-sigs:
   - sig-node
-status: implementable
+status: implemented
 creation-date: 2020-02-18
 reviewers:
   - "@msau42"
@@ -18,8 +18,8 @@ approvers:
   - "@saad-ali"
 see-also:
   - /keps/sig-storage/695-skip-permission-change/README.md
-stage: beta  # SELinuxMount feature gate, all the others will be stable.
-latest-milestone: "v1.36"
+stage: stable
+latest-milestone: "v1.37"
 milestone:
   alpha: "v1.24"  # SELinuxMountReadWriteOncePod
   beta: "v1.27"   # SELinuxMountReadWriteOncePod
@@ -31,7 +31,7 @@ milestone:
   # stable: "v1.36"   # SELinuxChangePolicy
   #
   # beta: "v1.33"   # SELinuxMount (disabled by default)
-  # plan: stable: "v1.37"   # SELinuxMount (enabled by default)
+  # stable: "v1.37"   # SELinuxMount
 feature-gates:
   - name: SELinuxMountReadWriteOncePod
     components:


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Graduate SELinuxMount to GA

<!-- link to the k/enhancements issue -->
- Issue link: #1710

<!-- other comments or additional information -->
- Other comments:

Just graduate the feature gate to GA, update history and mark everything as implemented.  All PRR section should have been in place from previous releases.

**PRR**
I'm fixing the PRR yaml to reflect the actual state:
* In 1.36, we had SELinuxMountChangePolicy + SELinuxMountReadWriteOncePod GA
* In 1.37 we want SELinuxMount GA

Sorry about that.