### PR TITLE
KEP-5237: add route corrections metric and adjust graduation criteria

### DIFF
--- a/keps/prod-readiness/sig-cloud-provider/5237.yaml
+++ b/keps/prod-readiness/sig-cloud-provider/5237.yaml
@@ -1,3 +1,5 @@
 kep-number: 5237
 alpha:
   approver: "@deads2k"
+beta:
+  approver: "@deads2k"

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/README.md
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/README.md
@@ -145,8 +145,6 @@ This is mitigated by:
 
 We use a similar concept as already implemented in the node and service controller. Through node informers we register event handlers for the add, delete and update node events, where updates are filtered by certain criteria. To introduce the feature we establish a new feature gate called `CloudControllerManagerWatchBasedRoutesReconciliation`.
 
-Additionally, we introduce a new non-gated metric `route_controller_route_sync_total`, which tracks the number of route reconciliations. This metric can be used for A/B testing to evaluate the impact of watch based route reconciliation.
-
 #### Full reconcile
 
 The current route controller always does a “full reconcile”, looking at all routes inside the configured `ClusterCIDR` and all nodes and then taking action to create/update/delete any routes to match the expectation.
@@ -169,6 +167,13 @@ Two fields are relevant for determining whether a reconcile should occur:
 
 1. `Node.Status.Addresses` maps to the `TargetNodeAddresses` field in the `Route` struct. It determines where packets for a given IP range should be sent. Changes to this field must trigger a reconcile.
 2. `Node.Spec.PodCIDRs` contains the IP ranges assigned to the node. These CIDRs are used as the destination in the created routes. Changes to this field must trigger a reconcile.
+
+#### Metrics
+
+Two new metrics are introduced:
+
+1. `route_controller_route_sync_total` (non-gated): tracks the total number of route reconciliations. Useful for A/B testing the impact of watch-based route reconciliation.
+2. `route_controller_route_corrections_total` (gated): tracks how often routes required adjustment after a periodic reconcile. This signals whether our node update filters are accurate or need revision.
 
 ### Test Plan
 

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/README.md
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/README.md
@@ -202,7 +202,8 @@ Two new metrics are introduced:
 
 #### Beta
 
-- Multiple infrastructure provider have enabled the feature flag, and we are confident that the field selectors are correct.
+- A non-gated metric (`route_controller_route_sync_total`) is available to A/B test the feature's impact on the number of route reconciliations.
+- A gated metric is available to track the number of route corrections made during periodic reconciles.
 
 #### GA
 

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/README.md
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/README.md
@@ -19,6 +19,7 @@
     - [Periodic reconcile](#periodic-reconcile)
     - [Workqueue singleton](#workqueue-singleton)
     - [Node update filters](#node-update-filters)
+    - [Metrics](#metrics)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
@@ -18,7 +18,7 @@ replaces: []
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
@@ -10,7 +10,9 @@ creation-date: 2025-05-08
 reviewers:
   - "@elmiko"
   - "@JoelSpeed"
-approvers: []
+approvers:
+  - "@elmiko"
+  - "@JoelSpeed"
 
 see-also: []
 replaces: []

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
@@ -28,7 +28,7 @@ latest-milestone: "v1.37"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.35"
-  beta: "v1.38"
+  beta: "v1.37"
   stable: "v1.39"
 
 # The following PRR answers are required at alpha release

--- a/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
+++ b/keps/sig-cloud-provider/5237-watch-based-route-controller-reconciliation/kep.yaml
@@ -23,13 +23,13 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.35"
-  beta: "v1.37"
-  stable: "v1.38"
+  beta: "v1.38"
+  stable: "v1.39"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
@@ -41,3 +41,4 @@ feature-gates:
 # The following PRR answers are required at beta release
 metrics:
   - route_controller_route_sync_total
+  - route_controller_route_corrections_total


### PR DESCRIPTION
- One-line PR description: Adds a new gated metric `route_controller_route_corrections_total` to measure how often periodic reconciles correct routes (signal for filter accuracy), and adjusts graduation criteria for milestone beta.

- Issue link: https://github.com/kubernetes/enhancements/issues/5237