### PR TITLE
KEP-5966: default EtcdRangeStream on in Beta

### DIFF
--- a/keps/sig-etcd/5966-etcd-range-stream/README.md
+++ b/keps/sig-etcd/5966-etcd-range-stream/README.md
@@ -291,9 +291,8 @@ limit. The `storage.Interface` is unchanged.
 
 #### Beta
 
-- Feature implemented behind the `EtcdRangeStream` feature gate, default off
-  initially. May flip to default on within Beta if testing data and
-  API Machinery leads agree there is sufficient signal of stability.
+- Feature implemented behind the `EtcdRangeStream` feature gate, default on
+  in Beta.
 - Watch cache initialization routes through `RangeStream` with
   automatic `Unimplemented` fallback for older etcd.
 - Feature is covered with unit, integration, and e2e tests.


### PR DESCRIPTION
API Machinery Link: https://docs.google.com/document/d/1x9RNaaysyO0gXHIr1y50QFbiL1x8OWnk2v3XnrdkT5Y/edit?disco=AAAB7_stwB0

Skew section coverage: https://github.com/kubernetes/enhancements/tree/master/keps/sig-etcd/5966-etcd-range-stream#version-skew-strategy

Confirming with David if KEP and proposed design has sufficient coverage for Beta on by default. 

/cc @jpbetz @serathius 
/assign @deads2k 