### PR TITLE
KEP-5732: Update Topology-aware workload scheduling for beta in v1.37

### DIFF
--- a/keps/prod-readiness/sig-scheduling/5732.yaml
+++ b/keps/prod-readiness/sig-scheduling/5732.yaml
@@ -1,3 +1,5 @@
 kep-number: 5732
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -556,6 +556,9 @@ Topology Aware Scheduling With Basic Policy:
 
 Those tests are located at [tas_test.go‎](https://github.com/kubernetes/kubernetes/blob/eb01d62d2676cfe009382cadd5d65c2ad654998d/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go‎).
 
+Apart from those integration tests with promoting to beta performance tests
+for basic scenario of Topology Aware Scheduling With Gang Policy will be added.
+
 #### e2e tests
 
 - End-to-End Workload Scheduling: Submit a Workload with TopologyConstraint

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -557,7 +557,9 @@ Topology Aware Scheduling With Basic Policy:
 Those tests are located at [tas_test.go‎](https://github.com/kubernetes/kubernetes/blob/eb01d62d2676cfe009382cadd5d65c2ad654998d/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go‎).
 
 Apart from those integration tests with promoting to beta performance tests
-for basic scenario of Topology Aware Scheduling With Gang Policy will be added.
+for basic scenario of Topology Aware Scheduling With Gang Policy have been
+added. Those tests are located at [tas_test.go]
+(https://github.com/kubernetes/kubernetes/tree/42d9ed9c47706cb04457410e387e07889203b888/test/integration/scheduler_perf/tas).
 
 #### e2e tests
 

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -256,7 +256,7 @@ type TopologyConstraint struct {
     // All pods within the PodGroup must be colocated within the same domain instance.
     // Different PodGroups can land on different domain instances even if they derive from the same PodGroupTemplate.
     // Examples: "topology.kubernetes.io/rack"
-    Level string
+    Key string
 }
 ```
 
@@ -413,7 +413,7 @@ The algorithm proceeds in three main phases for a given PodGroup.
 **TopologyPlacementGenerator (New)** Implements `PlacementGeneratePlugin`. Generates
 Placements based on distinct values of the designated node label (TAS).
 
-**NodeResourcesFit (Existsing)** Implements `PlacementScorePlugin`. Scores
+**NodeResourcesFit (Existing)** Implements `PlacementScorePlugin`. Scores
 Placements to maximize utilization (tightest fit) and minimize fragmentation.
 
 **PodGroupPodsCount (New)** Implements `PlacementScorePlugin`. Scores
@@ -565,7 +565,7 @@ Those tests are located at [tas_test.go‎](https://github.com/kubernetes/kubern
 
 - Scalability tests on large clusters with high placement counts.
 - Comprehensive e2e testing.
-- Cluster autoscaling compomnents are aware of workload topology constraints.
+- Cluster autoscaling components are aware of workload topology constraints.
 
 #### GA
 
@@ -723,7 +723,7 @@ are actively using the feature.
 
 - [X] API .status
   - Object: PodGroup
-  - Condition Name: `PodGroupScheduled`
+  - Condition Name: `PodGroupInitiallyScheduled`
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -9,7 +9,6 @@
 - [Proposal](#proposal)
   - [User Stories (Optional)](#user-stories-optional)
     - [Story 1: AI Training in a Single Rack](#story-1-ai-training-in-a-single-rack)
-    - [Story 2: Workload using Interconnected DRA Devices](#story-2-workload-using-interconnected-dra-devices)
   - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
@@ -23,7 +22,7 @@
     - [Phase 3: Placement Scoring and Selection](#phase-3-placement-scoring-and-selection)
   - [Scheduler Plugins](#scheduler-plugins)
   - [Beta Extensions](#beta-extensions)
-  - [Potential Future Extensions](#potential-future-extensions)
+  - [Future Extensions](#future-extensions)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
     - [Unit tests](#unit-tests)
@@ -32,6 +31,7 @@
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha](#alpha)
     - [Beta](#beta)
+    - [GA](#ga)
   - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
   - [Version Skew Strategy](#version-skew-strategy)
 - [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
@@ -64,9 +64,9 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
 - [X] (R) Production readiness review completed
 - [X] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [X] "Implementation History" section is up-to-date for milestone
+- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [X] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
 **Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
@@ -89,15 +89,15 @@ lifecycle introduced in KEP-4671, rather than fundamentally altering the schedul
 loop itself. It extends this foundation by enabling the evaluation of scheduling
 options within specific "Placements" (subsets of the cluster). These Placements
 represent candidate domains (sets of
-nodes or DRA resources) where the entire workload is theoretically feasible. The
+nodes) where the entire workload is theoretically feasible. The
 scheduler then simulates the placement of the full group of pods within these
 domains, utilizing existing filtering and scoring logic to ensure high-fidelity
 decisions before committing resources.
 
 This design introduces specific extensions to the Kubernetes Workload API to
-support `TopologyConstraints` and `DRAConstraints`, defines new interfaces
-within the Scheduling Framework (`PlacementGeneratorPlugin`, `PlacementStatePlugin`,
-`PlacementScorerPlugin`), and details the algorithmic flow required to schedule Pod
+support `TopologyConstraints`, defines new interfaces
+within the Scheduling Framework (`PlacementGeneratePlugin`,
+`PlacementScorePlugin`), and details the algorithmic flow required to schedule Pod
 Groups while maintaining compatibility with the scheduler's existing ecosystem.
 
 ## Motivation
@@ -110,11 +110,10 @@ primarily establishes the API structure. For workloads sensitive to inter-pod
 communication, simply grouping pods is insufficient; their physical placement
 within the cluster's network topology is a decisive factor in their performance.
 
-In this KEP, we propose an algorithm for topology-aware and DRA-aware scheduling
+In this KEP, we propose an algorithm for topology-aware scheduling
 that operates directly within the Kubernetes kube-scheduler. The core objective
 is to ensure that pods belonging to a Workload are co-located within optimal
-topological domains - such as specific racks or blocks - or are bound to shared
-Dynamic Resource Allocation (DRA) devices that require cohesive management.
+topological domains - such as specific racks or blocks that require cohesive management.
 Without this level of precision, workloads may be fragmented across disparate
 network domains, drastically degrading performance and wasting the potential of
 expensive hardware.
@@ -130,7 +129,7 @@ Topology-aware scheduling is not a new concept and is currently addressed by
 external admission control systems like Kueue or alternative schedulers like
 Volcano. However, relying on external admission controllers decouples the
 topology decision from the scheduler's core logic, while alternative schedulers
-introduce operational complexity. We believe that embedding topology and DRA
+introduce operational complexity. We believe that embedding topology
 awareness deeply into the kube-scheduler is critical enough to warrant
 standardization. This integration allows the algorithm to leverage the full
 fidelity of the scheduler's existing pod-level filtering and scoring plugins,
@@ -139,14 +138,13 @@ need for external dependencies.
 
 ### Goals
 
-- To enhance kube-scheduler to be able to perform topology-aware and DRA-aware
+- To enhance kube-scheduler to be able to perform topology-aware
   scheduling for multi-pod workloads, as defined by the Workload API
   ([KEP-4671](https://kep.k8s.io/4671)).
 - To optimize the placement of distributed workloads by co-locating pods based
-  on network topology and DRA resource availability.
+  on network topology.
 - To introduce new extension points and phases within the Kubernetes scheduler
-  framework to support the concept of "Placements" (candidate sets of nodes
-  and DRA resources).
+  framework to support the concept of "Placements" (candidate sets of nodes).
 - To define the required changes to the Workload API (KEP-4671) to support
   Topology scheduling constraints.
 - To leverage the scheduler's existing pod-level filtering and scoring logic
@@ -157,8 +155,8 @@ need for external dependencies.
 ### Non-Goals
 
 - To define the required changes to the Workload API (KEP-4671) to support
-  ResourceClaims for DRA-aware workload scheduling. These changes will be
-  proposed in a separate KEP:
+  ResourceClaims for DRA-aware workload scheduling and their scheduling.
+  These changes have been proposed in a separate KEP:
   [KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729)
 - To replace the functionality of external workload queueing and admission
   control systems like Kueue. This proposal focuses on the in-scheduler
@@ -168,11 +166,10 @@ need for external dependencies.
 - To handle all aspects of the workload lifecycle management beyond
   scheduling.
 - To implement Workload-level preemption logic.
-- To integrate with cluster autoscaling mechanisms in this phase.
-- To support complex multi-PodSet dependency resolution with backtracking or
+- To support complex multi pod dependency resolution with backtracking or
   parallel processing in the initial version.
 - To automatically discover network topology; the mechanisms rely on topology
-  information being present (e.g., via node labels or DRA ResourceSlices).
+  information being present (e.g., via node labels).
 
 ## Proposal
 
@@ -180,18 +177,16 @@ This proposal introduces an API to define constraints on a PodGroup (a
 collection of pods within a Workload) requiring it to be scheduled onto a
 specific subset of nodes or resources.
 
-We support two fundamental types of constraints:
+We support one type of constraints:
 
 1. **Topology Constraint (Node Label Co-location)**: Ensures all pods in a
    PodGroup are placed onto nodes sharing a common topological characteristic
    (e.g., same rack), defined by a specific node label.
 
-2. **DRA Constraint (Shared Dynamic Resource Allocation)**: Ensures all pods in a
-   PodGroup bind to a single DRA claim fulfilled from a single, shared,
-   co-located resource (e.g., interconnected network interfaces or
-   accelerators).
-
-The scheduler is extended to interpret these new PodGroup level scheduling constraints and similarly to scheduling pods on nodes (available scheduling options), find a "Placement" for this PodGroup among the feasible options (subsets of nodes and DRA resources) that satisfies them.
+The scheduler is extended to interpret these new PodGroup level scheduling constraints
+and similarly to scheduling pods on nodes (available scheduling options), find
+a "Placement" for this PodGroup among the feasible options (subsets of nodes)
+that satisfies them.
 
 ### User Stories (Optional)
 
@@ -203,14 +198,6 @@ need to be located in the same server rack to minimize latency. I define a
 label. The scheduler identifies a rack with sufficient capacity and schedules
 all pods there at once.
 
-#### Story 2: Workload using Interconnected DRA Devices
-
-As a cluster administrator, I want to schedule a workload that requires a set of
-specialized accelerators that are physically interconnected. I use a
-`DRAConstraint` targeting a specific `ResourceClaimTemplate`. The scheduler
-finds a set of DRA resources (ResourceSlice) that are co-located and binds the
-workload's pods to them.
-
 ### Notes/Constraints/Caveats (Optional)
 
 ### Risks and Mitigations
@@ -218,15 +205,14 @@ workload's pods to them.
 - **Scheduling Latency:** Evaluating multiple placements involves running
   filter/score plugins multiple times (multiple attempts to schedule a PodGroup considering all topology options).
 
-  - **Mitigation:** Implement pre-filtering optimizations to reject infeasible
-    placements early based on aggregate resource availability.
+  - **Mitigation:** Implement early placement rejection optimization to stop
+    feasibility checks for placements which cannot fit gang scheduled PodGroups.
 
 - **Complexity of Pod Group Scheduling:** Scheduling heterogeneous Pod Groups
   can be complex.
 
-  - **Mitigation:** The initial version supports sequential processing of pods
-    within a PodGroup, avoiding complex backtracking or parallel processing
-    in the alpha release.
+  - **Mitigation:** We support only sequential processing of pods
+    within a PodGroup, avoiding complex backtracking or parallel processing.
 
 ## Design Details
 
@@ -241,8 +227,8 @@ scheduling constraints. An optional `ScheduleConstraints` field is added to the
 type PodGroupTemplate struct {
     // Existing fields go here
 
-    // SchedulingConstraints defines group-level scheduling requirements,
-    // including topology.
+    // SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate.
+    // This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
     SchedulingConstraints *PodGroupSchedulingConstraints
 }
 
@@ -250,34 +236,36 @@ type PodGroupTemplate struct {
 type PodGroupSpec struct {
     // Existing fields go here
 
-    // SchedulingConstraints defines group-level scheduling requirements,
-    // including topology.
+    // SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroup.
+    // Controllers are expected to fill this field by copying it from a PodGroupTemplate.
+    // This field is immutable.
+    // This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
     SchedulingConstraints *PodGroupSchedulingConstraints
 }
 
-// PodGroupSchedulingConstraints holds the scheduling constraints for the PodGroup.
+// PodGroupSchedulingConstraints defines scheduling constraints (e.g. topology) for a PodGroup.
 type PodGroupSchedulingConstraints struct {
-    // TopologyConstraints specifies desired topological placements for all pods
-    // within this PodGroup.
+    // Topology defines the topology constraints for the pod group.
+    // Currently only a single topology constraint can be specified. This may change in the future.
     TopologyConstraints []TopologyConstraint
 }
 
-// TopologyConstraint describes a desired topological colocation for all pods in the PodGroup.
+// TopologyConstraint defines a topology constraint for a PodGroup.
 type TopologyConstraint struct {
-    // Level specifies the key of the node label representing the topology domain.
+    // Key specifies the key of the node label representing the topology domain.
     // All pods within the PodGroup must be colocated within the same domain instance.
-    // Different replicas of the PodGroup can land on different domain instances.
+    // Different PodGroups can land on different domain instances even if they derive from the same PodGroupTemplate.
     // Examples: "topology.kubernetes.io/rack"
     Level string
 }
 ```
 
 The Workload API changes for DRA-aware scheduling, including the definition of
-DRA constraints, are out of scope for the alpha version of this KEP. These changes
+DRA constraints and their scheduling, are out of scope of this KEP. These changes
 will be defined in a separate KEP: 
 [KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729).
 
-Note: For the initial alpha scope, only a single TopologyConstraint will be
+Note: For this KEP scope, only a single TopologyConstraint will be
 supported.
 
 ### Scheduling Framework Extensions
@@ -288,125 +276,78 @@ Placement represents a candidate domain (nodes and resources) for a PodGroup.
 #### 1. Data Structures
 
 ```go
-// PodGroupInfo holds information about a specific PodGroup within a Workload.
-// This struct is designed to be extensible with more fields in the future.
-type PodGroupInfo struct {
-    // SchedulingGroup is a reference to the parent PodGroup object.
-    SchedulingGroup *corev1.PodSchedulingGroup
-
-    // PodSets is a list of PodSet objects within this PodGroup.
-    PodSets []*PodSetInfo
-
-    // -- Add other fields below for future extensions --
-}
-
-// PodSetInfo holds information about a specific PodSet within a PodGroup,
-// primarily the list of Pods.
-// Pods within a PodSet must be homogeneous (using the sementic defined in KEP-5598).
-// This struct is designed to be extensible with more fields in the future.
-type PodSetInfo struct {
-    // Pods is a list of Pod objects belonging to this PodSet.
-    Pods []*corev1.Pod
-
-    // -- Add other fields below for future extensions --
-}
-
-// Placement represents a candidate domain for scheduling a PodGroup.
-// It defines a set of nodes and/or proposed Dynamic Resource Allocation (DRA)
-// resource bindings necessary to satisfy the PodGroup's requirements within that domain.
-// Placement is valid only in the context of a given PodGroup for a single cycle of
-// workload scheduling.
+// Placement determines the resources to be considered when scheduling a pod group.
+// Pod group scheduling cycle can check multiple placements and select the one that results
+// in the best pod assignments.
 type Placement struct {
-    // NodeSelector specifies the node constraints for this Placement.
-    // For Topology this is derived from topology labels (e.g., all nodes with label
-    // 'topology-rack: rack-1').
-    // For DRA, this selector would be constructed based on nodeSelector from
-    // DRA's AllocationResult from DRAAllocations.
-    // All pods within the PodGroup, when being evaluated against this Placement,
-    // are restricted to the nodes matching this NodeSelector.
-    NodeSelector *corev1.NodeSelector
+    // Name uniquely identifies the placement.
+    // This is used for diagnostics and debugability.
+    // The choice of the name is up to the PlacementGeneratePlugin.
+    Name string
 
-    // DRAAllocations details the proposed DRA resource assignments for
-    // the ResourceClaims made by the PodGroup. This field is primarily used
-    // by DRA-aware plugins.
-    DRAAllocations []DraClaimAllocation
-}
-
-// DraClaimAllocation maps a specific ResourceClaim name to a set of proposed
-// device allocations. These allocations are tentative and used by the scheduler's
-// AssumePlacement phase to simulate resource commitment.
-type DraClaimAllocation struct {
-    // ResourceClaimName is the name of the ResourceClaim within the PodGroup's
-    // context that these allocations are intended to satisfy.
-    ResourceClaimName string
-
-    // Allocation contains DRA AllocationResult structures, specifying devices
-    // from ResourceSlices that are proposed to fulfill the ResourceClaim.
-    // The scheduler will use this information in AssumePlacement to temporarily
-    // consider these devices as allocated.
-    Allocation dra.AllocationResult
+    // Nodes specifies the nodes that are valid for this placement.
+    // Scheduler will try to schedule the pod group using only those nodes.
+    Nodes []NodeInfo
 }
 ```
 
 #### 2. New Plugin Interfaces
 
-**PlacementGeneratorPlugin:** Generates candidate placements based on constraints.
+**PlacementGeneratePlugin:** Generates candidate placements based on constraints.
 
 ```go
-// PlacementGeneratorPlugin is an interface for plugins that generate candidate Placements.
-// Plugins implementing PlacementGeneratorPlugin interface should also implement
-// EnqueueExtensions interface.
-type PlacementGeneratorPlugin interface {
-    Name() string
+// GeneratePlacementsResult represents the result of the PlacementGeneratePlugin.
+type GeneratePlacementsResult struct {
+    // Placements is the set of placements that the plugin wants to partition the resources into.
+    // The partitions can overlap.
+    //
+    // To represent no valid partitions, set the array to nil or empty.
+    Placements []*Placement
+}
 
-    // GeneratePlacements generates a list of potential Placements for the given PodGroup.
-    // Each Placement represents a candidate set of resources (e.g., nodes matching a selector)
-    // and potential DRA allocations where the PodGroup might be scheduled.
-    GeneratePlacements(ctx context.Context, state *framework.CycleState, podGroup *PodGroupInfo, parentPlacements []*Placement) ([]*Placement, *framework.Status)
+// PlacementGeneratePlugin is an interface for plugins that generate candidate Placements.
+type PlacementGeneratePlugin interface {
+    Plugin
+
+    // GeneratePlacements generates a list of potential Placements for the given PodGroup within the parent placement.
+    // Each Placement represents a candidate set of resources, e.g., nodes matching a selector.
+    GeneratePlacements(ctx context.Context, state PodGroupCycleState, podGroup PodGroupInfo, parentPlacement *Placement) (*GeneratePlacementsResult, *Status)
 }
 ```
 
-**PlacementStatePlugin:** Manages state changes (simulating binding) during
-feasibility checks.
+**PlacementScorePlugin:** Scores feasible placements to select the best one.
 
 ```go
-// PlacementStatePlugin is an interface for plugins that manage state changes
-// when a Placement is being considered.
-type PlacementStatePlugin interface {
-    Name() string
+// PlacementScore stores result of a placement score plugin to be later used for normalization.
+type PlacementScore struct {
+    // Placement is the placement for which the score was computed
+    Placement *Placement
 
-    // AssumePlacement temporarily configures the scheduling context to evaluate the feasibility
-    // of the given Placement for the PodGroup.
-    AssumePlacement(ctx context.Context, state *framework.CycleState, podGroup *PodGroupInfo, placement *Placement) *framework.Status
-
-    // RevertPlacement reverts the temporary scheduling context changes made by AssumePlacement.
-    // This should be called after the evaluation of a Placement is complete to restore
-    // the scheduler's state and allow other Placements to be considered.
-    RevertPlacement(ctx context.Context, state *framework.CycleState, podGroup *PodGroupInfo, placement *Placement) *framework.Status
-}
-```
-
-**PlacementScorerPlugin:** Scores feasible placements to select the best one.
-
-```go
-// PodGroupAssignment represents the assignment of pods to nodes within a PodGroup for a specific Placement.
-type PodGroupAssignment struct {
-    // PodToNodeMap maps a Pod name (string) to a Node name (string).
-    PodToNodeMap map[string]string
+    // Score is the score for a given placement, which is used to rank the placements and pick the best one.
+    Score int64
 }
 
-// PlacementScorerPlugin is an interface for plugins that score feasible Placements.
-type PlacementScorerPlugin interface {
-    Name() string
+// PlacementScoreExtensions is an interface for PlacementScore extended functionality.
+type PlacementScoreExtensions interface {
+  	// NormalizePlacementScore is called for all placement scores produced by the same plugin's "ScorePlacement"
+  	// method. A successful run of NormalizePlacementScore will update the scores list and return
+  	// a success status.
+  	NormalizePlacementScore(ctx context.Context, state PodGroupCycleState, podGroup PodGroupInfo, placementScores []PlacementScore) *Status
+}
 
-    // ScorePlacement calculates a score for a given Placement. This function is called in Phase 3
-    // (Placement Scoring and Selection) only for Placements that have been deemed feasible
-    // for all pods in the PodGroup during Phase 2. The PodGroupAssignment indicates the
-    // node assigned to each pod within this Placement. The returned score is a float64,
-    // with higher scores generally indicating more preferable Placements.
-    // Plugins can implement various scoring strategies, such as bin packing to minimize
-    // resource fragmentation.
-    ScorePlacement(ctx context.Context, state *framework.CycleState, podGroup *PodGroupInfo, placement *Placement, podsAssignment *PodGroupAssignment) (float64, *framework.Status)
+// PlacementScorePlugin is an interface for plugins that score feasible Placements.
+type PlacementScorePlugin interface {
+    Plugin
+
+    // ScorePlacement calculates a score for a given Placement.
+    // This function is called only for Placements that have been deemed feasible for the sufficient number of pods in the PodGroup scheduling cycle.
+    // The PodGroupAssignments indicates the node assigned to each pod within this Placement.
+    // The returned score is a int64 with higher scores generally indicating more preferable Placements.
+    // Plugins can implement various scoring strategies, such as bin packing to minimize resource fragmentation.
+    ScorePlacement(ctx context.Context, state PodGroupCycleState, podGroup PodGroupInfo, placement *PodGroupAssignments) (int64, *Status)
+
+    // PlacementScoreExtensions returns a PlacementScoreExtensions interface if it implements one, or nil if does not.
+    PlacementScoreExtensions() PlacementScoreExtensions
 }
 ```
 
@@ -418,13 +359,14 @@ The algorithm proceeds in three main phases for a given PodGroup.
 
 - **Input:** PodGroupInfo.
 
-- **Action:** Iterate over distinct values of the topology label (TAS) or
-  available Devices (DRA).
+- **Action:** Iterate over distinct values of the topology label (TAS).
 
 - **Output:** A list of Placement objects.
 
-- Placement generation is executed after PreFilter giving PlacementGeneratorPlugins
-  a chance to get the list of nodes in the cluster.
+- Placement generation is provided with a parent placement which
+  includes all nodes in the cluster giving a plugin 
+  a chance to get the list of nodes which should be considered when
+  generating placements.
 
 - Example: If the label is rack, placements are generated for rack-1, rack-2,
   etc.
@@ -433,17 +375,9 @@ The algorithm proceeds in three main phases for a given PodGroup.
 
 - **Action:** For each generated Placement:
 
-  1. Call `AssumePlacement` (binds context to the specific node selector/DRA
-     resources).
+  1. Run default workload scheduling algorithm with the given set of nodes.
 
-  2. Run default workload scheduling algorithm with the given context.
-
-  3. If all pods fit, the Placement is marked Feasible.
-
-  4. Call `RevertPlacement`.
-
-- **Potential Optimization:** Pre-filtering can check aggregate resources
-  requested by PodGroup Pods before running the full simulation.
+  2. If all required pods fit, the Placement is marked Feasible.
 
 - **Basic Scheduling Policy Handling:** The current algorithm may exhibit
   inconsistent behavior when used with the PodGroup Basic Scheduling Policy.
@@ -469,44 +403,65 @@ The algorithm proceeds in three main phases for a given PodGroup.
 
 ### Scheduler Plugins
 
-**TopologyPlacementPlugin (New)** Implements `PlacementGeneratorPlugin`. Generates
+**TopologyPlacementGenerator (New)** Implements `PlacementGeneratePlugin`. Generates
 Placements based on distinct values of the designated node label (TAS).
 
-**PlacementBinPackingPlugin (New)** Implements `PlacementScorerPlugin`. Scores
+**NodeResourcesFit (Existsing)** Implements `PlacementScorePlugin`. Scores
 Placements to maximize utilization (tightest fit) and minimize fragmentation.
 
-**PlacementPodCountScorerPlugin (New)** Implements `PlacementScorerPlugin`. Scores
+**PodGroupPodsCount (New)** Implements `PlacementScorePlugin`. Scores
 Placements based on the number of pods fiting into each Placement.
-
-**DRATestPlugin (New)** Implements `PlacementGeneratorPlugin` and `PlacementStatePlugin`
-and is used only for testing the algorithm's support for DRA-aware scheduling.
-
-- **Generator:** Returns Placements derived from available Devices satisfying
-  claims shared by all Pods within a PodGroup.
-
-- **State:** Temporarily assigns AllocationResults to Devices during the
-  Assume phase.
 
 ### Beta Extensions
 
-The beta version of this KEP will introduce full support for DRA-aware workload
-scheduling. This enhancement will enable the scheduler to consider DRA claims
-defined by users when making placement decisions, ensuring that workloads are
-placed on nodes that can satisfy their resource requirements. This will be
-achieved by using the API to be defined in 
-[KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729).
+In the beta release, the following features and performance optimizations have been
+introduced to improve the throughput, efficiency, and flexibility of Topology-Aware
+Scheduling:
 
-The implementation will build upon the extension points introduced in the
-alpha version of this feature and the `DRATestPlugin` implementation.
-Specifically, the `DRAPlugin` will be enhanced to generate placements based
-on the ResourceClaim objects associated with the PodGroup. The plugin will
-interact with the DRA framework to ensure that the selected placement can
-satisfy the resource requirements of the workload, as expressed in its
-ResourceClaim.
+1. Multiple PlacementGeneratePlugins
+   
+   The beta version supports defining multiple PlacementGeneratePlugins. When multiple
+   such plugins are configured, the scheduler framework runs them independently. It then
+   merges their results by calculating non-empty intersections of the placements returned
+   by the different plugins, allowing the system to easily handle complex placement
+   requirements.
 
-### Potential Future Extensions
+2. Early Rejection of Placements
 
-The following features are out of scope for this KEP but are considered for
+  To optimize the scheduling cycle, the scheduler will abort placement evaluation early
+  if there are not enough remaining pods to satisfy a PodGroup's minCount. Previously,
+  all pods were evaluated, which missed an opportunity for optimization. This capability
+  is implemented via a new "pseudo extension point" called PlacementFeasiblePlugin
+  (similar to PodGroupPostFilter) to break out of the pod group scheduling cycle.
+
+3. Limit on the Number of Checked Placements
+
+  To ensure high pod throughput, especially in large clusters, the beta version
+  introduces a limit on the number of scored placements, similar to how the scheduler
+  limits the number of scored nodes in non-TAS scenarios. This limit is controlled via
+  a new scheduler parameter PercentageOfPlacementsToScore.
+
+  By default, an adaptive limit will be applied based on the total number of nodes to
+  evaluate across all generated placements. The limit interpolates from 100% for very
+  small clusters to 10% for clusters with 5000 nodes, with a hard lower bound of 5%.
+  
+  This strategy ensures predictable, robust throughput of topology-aware scheduling.
+
+### Future Extensions
+
+[KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729)
+introduced support for PodGroup-level ResourceClaims. In its alpha version,
+KEP-5729 does not include specialized scheduling logic for these PodGroup-level
+claims. As a future enhancement, the scheduler should evaluate user-defined
+DRA claims during placement decisions to ensure workloads are assigned to nodes
+capable of satisfying their collective resource requirements. This logic will
+build upon the extension points introduced in this KEP. Specifically,
+the DRAPlugin will be enhanced to generate placements based on the ResourceClaim
+objects associated with a PodGroup. The plugin will interact directly with
+the DRA framework to verify that the selected placement can fulfill the workload's
+resource demands, as defined by its ResourceClaim.
+
+The following features are out of scope for this KEP but will be implemented in
 future separate KEPs improving and extending the proposed functionality:
 
 1. **Prioritized Placement Scheduling:** Allowing a set of preferred placements
@@ -524,53 +479,69 @@ future separate KEPs improving and extending the proposed functionality:
    PodGroups (replicas) by scheduling the maximum feasible number of replicas
    within a single placement pass.
 
-5. **Explicit Topology Definition:** Using a Custom Resource (NodeTopology) to
+5. **Explicit Topology Definition:** Using a dedicated resource (NodeTopology) to
    define and alias topology levels, removing the need for users to know exact
    node label keys and opening additional optimization and validation options.
 
-6. **Feasible Placements Limit:** Adding an option to provide a limit on the
-   number of feasible Placements which need to be found before moving to
-   Phase 3: Placement Scoring and Selection.
-
 ### Test Plan
 
-[ ] I/we understand the owners of the involved components may require updates to
+[X] I/we understand the owners of the involved components may require updates to
 existing tests to make this code solid enough prior to committing the changes
 necessary to implement this enhancement.
 
 #### Prerequisite testing updates
 
+N/A
+
 #### Unit tests
 
-- PlacementGeneratorPlugin: Test generation of placements for various topology
-  labels and DRA ResourceSlices.
-
-- PlacementStatePlugin: Verify AssumePlacement and RevertPlacement correctly modify
-  and restore the CycleState.
+- PlacementGeneratePlugin: Test generation of placements for various topology
+  labels.
+  
+- PlacementScorePlugin: Test scoring of placements.
 
 - Algorithm Logic: Test the sequential processing of Placements and the
   selection logic based on scores.
 
-- DRA Integration: specific tests for DRATestPlugin plugin.
-
 #### Integration tests
 
-- Topology Awareness: Verify that pods with TopologyConstraint are correctly
-  co-located on nodes sharing the label.
+For Alpha we implemented integration tests to ensure basic functionalities of
+to
 
-- DRA Awareness: Verify that pods with shared ResourceClaims are bound to shared
-  Devices.
+Topology Aware Scheduling With Gang Policy:
 
-- Infeasibility: Verify that Workloads remain pending if no Placement
-  satisfies the constraints.
+- Resource Availability: Schedules successfully if space permits, or remains
+  pending if resources are insufficient or consumed by existing pods.
+
+- Scoring & Placement: Places pods based on the highest score or allocation
+  percentage using default scoring algorithms.
+
+- Multiple Gangs: Handles consecutive scheduling across the same/different
+  racks, varying topology keys, and capacity bottlenecks.
+
+- Edge Cases: Verifies behavior when minCount is less than the total pod
+  count, and when preemption is required to free up resources.
+
+Topology Aware Scheduling With Basic Policy:
+
+- Standard Placement: Schedules entire podgroups on appropriate racks, leveraging
+  placement scores and allocation percentages (even with pre-existing pods).
+
+- Capacity Constraints: Skips or partially schedules pods when a single rack or
+  the entire cluster lacks the required resources.
+
+- Multiple PodGroups: Manages consecutive scheduling across various racks,
+  zones, and restrictive cluster capacities.
+
+- Dynamic Updates: Successfully resumes scheduling pending pods once blocked
+  resources become available again.
+
+Those tests are located at [tas_test.go‎](https://github.com/kubernetes/kubernetes/blob/eb01d62d2676cfe009382cadd5d65c2ad654998d/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go‎).
 
 #### e2e tests
 
 - End-to-End Workload Scheduling: Submit a Workload with TopologyConstraint
   (e.g., Rack) and verify all pods land on the same rack.
-
-- DRA Co-location: Submit a Workload requiring shared DRA devices and verify
-  correct allocation and placement.
 
 ### Graduation Criteria
 
@@ -583,11 +554,14 @@ necessary to implement this enhancement.
 
 #### Beta
 
-- Support for "Potential Future Extensions" (Prioritized placement, etc.)
-  evaluated.
 - Scalability tests on large clusters with high placement counts.
 - Comprehensive e2e testing.
-- Cluster autoscaling compomnents are aware of workload topology constraints. 
+- Cluster autoscaling compomnents are aware of workload topology constraints.
+
+#### GA
+
+- All issues and gaps identified as feedback during beta are resolved.
+- Promote the e2e API tests to conformance.
 
 ### Upgrade / Downgrade Strategy
 
@@ -599,15 +573,15 @@ workload scheduling:
 
 - they can enable scheduling plugins implementing new Scheduling Framework
   interfaces in kube-scheduler config
-- they can start using the new API to create Workload objects with
+- they can start using the new API to create PodGroup objects with
   `schedulingConstraints` field
-- scheduler will use enabled plugins to generate placements for Workload and
+- scheduler will use enabled plugins to generate placements for PodGroup and
   check their feasibility
 
 When user downgrades the cluster to the version that no longer supports
 topology-aware workload scheduling:
 
-- the `schedulingConstraints` field can no longer be set on the Workloads
+- the `schedulingConstraints` field can no longer be set on the PodGroups
   (the already set fields continue to be set though)
 - scheduler will revert to the original behavior of scheduling pods belonging
   to a gang, without considering different potential placements.
@@ -669,119 +643,99 @@ The scheduler algorithm changes are purely in-memory and doesn't require any ded
 enablement/disablement tests - the logic will be covered by regular feature tests.
 
 For the newly introduced API fields, dedicated enablement/disablement tests at the
-kube-apiserver registry layer will be added in Alpha.
+kube-apiserver registry layer will be added.
 
 ### Rollout, Upgrade and Rollback Planning
 
-<!--
-This section must be completed when targeting beta to a release.
--->
-
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-<!--
-Try to be as paranoid as possible - e.g., what if some components will restart
-mid-rollout?
+Workloads that do not use the PodGroup APIs should not be impacted, since the
+functionality remains unchanged for them. During a rolling upgrade, if the
+active scheduler instance has the feature disabled, it will schedule pods using the
+standard non-TAS method, falling back to a default workload scheduling algorithm.
 
-Be sure to consider highly-available clusters, where, for example,
-feature flags will be enabled on some API servers and not others during the
-rollout. Similarly, consider large clusters and how enablement/disablement
-will rollout across nodes.
--->
+This results in a fallback to the status quo behavior, meaning that pods will be
+still scheduled, but PodGroup-level toplogy scheduling constraints won't be applied.
 
 ###### What specific metrics should inform a rollback?
 
-<!--
-What signals should users be paying attention to when the feature is young
-that might indicate a serious problem?
--->
+- `scheduler_schedule_attempts_total{result="error"}`: A sudden spike indicates internal
+  errors or panics within the scheduling loop, possibly caused by the TAS logic.
+- `process_start_time_seconds`: Frequent resets of this metric indicate that the scheduler
+  process is crashing and restarting (crash loop).
+- `scheduler_podgroup_scheduling_duration_seconds`: A significant regression in P99 latency for
+  pod groups would indicate that the overhead of the new logic is unacceptable.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
-<!--
-Describe manual testing that was done and the outcomes.
-Longer term, we may want to require automated upgrade/rollback tests, but we
-are missing a bunch of machinery and tooling and can't do that now.
--->
+We'll perform manual testing of the upgrade -> downgrade -> upgrade path using the following sequence:
+
+1. Start a local Kubernetes v1.36 cluster with `TopologyAwareWorkloadScheduling` feature
+   gate disabled and `GenericWorkload` feature gate enabled (default behavior).
+2. Attempt to create a PodGroup object with `spec.schedulingConstraints.topologyConstraints[0].level`
+   set to `kubernetes.io/hostname`.
+3. The `spec.schedulingConstraints` field is dropped by the API server. The PodGroup is created
+   successfully but without the `spec.schedulingConstraints` reference.
+4. Restart/Upgrade API Server and Scheduler to v1.37 with feature gates enabled.
+5. Create five PodGroup objects: `tas-test-A` to `tas-test-E` all with `minCount`
+   set to 2 and `spec.schedulingConstraints.topologyConstraints[0].level` set to `kubernetes.io/hostname`.
+6. Create `test-pod-1` and `test-pod-2` Pods with `spec.schedulingGroup` pointing to `tas-test-A`
+   and node affinities pointing to two different nodes.
+7. The Pod stays in `Pending` state (waiting for the TAS scheduling). Verify that
+   `scheduler_pending_entities{type="podgroup", queue="gated"}` metric is incremented.
+8. Create `test-pod-3` and `test-pod-4` Pods with `spec.schedulingGroup` pointing to `tas-test-B`
+   and node affinities pointing to the same node.
+9. Both pods are scheduled successfully (TAS works). 
+10. Downgrade API Server and Scheduler to v1.36 with feature gates disabled.
+11. Create `test-pod-5` and `test-pod-6` Pods with `spec.schedulingGroup` pointing to `tas-test-C`
+    and node affinities pointing to two different nodes. Note: We use a pod group created in step 5
+    because creating new PodGroup objects with schedulingConstraints is disabled.
+13. The pods are scheduled succesfully (schedulingConstraints logic is ignored because the schedulingGroup
+    field is dropped by the v1.36 API server).
+15. Upgrade API Server and Scheduler back to v1.37 with feature gates enabled.
+16. Repeat steps 6 to 9 with `tas-test-D` and `tas-test-E`.
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
-<!--
-Even if applying deprecation policies, they may still surprise some users.
--->
+No.
 
 ### Monitoring Requirements
 
-<!--
-This section must be completed when targeting beta to a release.
-
-For GA, this section is required: approvers should be able to confirm the
-previous answers based on experience in the field.
--->
-
 ###### How can an operator determine if the feature is in use by workloads?
 
-<!--
-Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
-checking if there are objects with field X set) may be a last resort. Avoid
-logs or events for this purpose.
--->
+Operators can check the new `plugin_execution_duration_seconds{plugin="TopologyPlacementGenerator", extension_point="GeneratePlacements"}`
+metric. A value greater than zero indicates that the scheduler is using TAS .
+
+Alternatively, checking for the existence of `PodGroup` via `kubectl get podgroups`,
+and checking the `PodGroup.spec.spec.schedulingConstraints` field confirms that users
+are actively using the feature.
 
 ###### How can someone using this feature know that it is working for their instance?
 
-<!--
-For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
-for each individual pod.
-Pick one more of these and delete the rest.
-Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
-and operation of this feature.
-Recall that end users cannot usually observe component logs or access metrics.
--->
-
-- [ ] Events
-  - Event Reason:
-- [ ] API .status
-  - Condition name:
-  - Other field:
-- [ ] Other (treat as last resort)
-  - Details:
+- [X] API .status
+  - Object: PodGroup
+  - Condition Name: `PodGroupScheduled`
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
-<!--
-This is your opportunity to define what "normal" quality of service looks like
-for a feature.
-
-It's impossible to provide comprehensive guidance, but at the very
-high level (needs more precise definitions) those may be things like:
-  - per-day percentage of API calls finishing with 5XX errors <= 1%
-  - 99% percentile over day of absolute value from (job creation time minus expected
-    job creation time) for cron job <= 10%
-  - 99.9% of /health requests per day finish with 200 code
-
-These goals will help you determine what you need to measure (SLIs) in the next
-question.
--->
+Since there are no formal SLOs for the kube-scheduler apart from scalability SLOs, we define the objectives for this
+feature primarily in terms of non-regression to ensure the toplogy aware scheduling does not degrade the performance
+of the standard scheduling loop.
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
-<!--
-Pick one more of these and delete the rest.
--->
+- Scheduling Throughput: There should be no significant regression in the system-wide scheduling throughput (pods/s) 
+  when scheduling PodGroup using TAS compared to scheduling an equivalent number of individual pods.
+  This can be measured by the number of Pod binding API calls arriving to the API server
+  (`apiserver_request_total{resource="pods", subresource="binding"}`).
 
-- [ ] Metrics
-  - Metric name:
-  - [Optional] Aggregation method:
-  - Components exposing the metric:
-- [ ] Other (treat as last resort)
-  - Details:
+- Scheduling Latency: There should be no significant regression in pod scheduling latency 
+  (`scheduler_pod_scheduling_duration_seconds`) for both TAS and non-TAS pods compared to the baseline
+  (behavior with the feature disabled).
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-<!--
-Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
-implementation difficulties, etc.).
--->
+No.
 
 ### Dependencies
 
@@ -791,20 +745,8 @@ This section must be completed when targeting beta to a release.
 
 ###### Does this feature depend on any specific services running in the cluster?
 
-<!--
-Think about both cluster-level services (e.g. metrics-server) as well
-as node-level agents (e.g. specific version of CRI). Focus on external or
-optional services that are needed. For example, if this feature depends on
-a cloud provider API, or upon an external software-defined storage or network
-control plane.
-
-For each of these, fill in the following—thinking about running existing user workloads
-and creating new ones, as well as about cluster-level services (e.g. DNS):
-  - [Dependency name]
-    - Usage description:
-      - Impact of its outage on the feature:
-      - Impact of its degraded performance or high-error rates on the feature:
--->
+No dependencies other than the components where the feature is implemented
+(kube-apiserver and kube-scheduler).
 
 ### Scalability
 
@@ -861,35 +803,42 @@ details). For now, we leave it here.
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
+The behavior is consistent with the status quo. Since the scheduler cannot bind pods or update statuses without the
+API server, any in-flight TAS scheduling will eventually fail at the binding/update stage. These attempts will be
+retried with standard exponential backoff once connectivity is restored.
+
 ###### What are other known failure modes?
 
-<!--
-For each of them, fill in the following information by copying the below template:
-  - [Failure mode brief description]
-    - Detection: How can it be detected via metrics? Stated another way:
-      how can an operator troubleshoot without logging into a master or worker node?
-    - Mitigations: What can be done to stop the bleeding, especially for already
-      running user workloads?
-    - Diagnostics: What are the useful log messages and their required logging
-      levels that could help debug the issue?
-      Not required until feature graduated to beta.
-    - Testing: Are there any tests for failure mode? If not, describe why.
--->
+- Pods Pending Indefinitely - Gang cannot fit (Resource Constraints)
+  - Detection: Check Pod Events/Status. Expected reason: a message indicating that minCount pods could not be
+    scheduled.
+  - Metrics: `scheduler_podgroup_schedule_attempts_total` with result unschedulable.
+  - Mitigations:
+    - Scale up the cluster (add nodes) or delete other real-workloads to free up space.
+    - If intended, recreate the PodGroup object without `schedulingConstraints`
+      to disable TAS scheduling (fallback to best-effort scheduling) if acceptable.
+  - Diagnostics:
+    - Scheduler logs at V=4 searching for "podgroup" to see detailed reasons why the placement failed.
+  - Testing:
+    - Covered by integration tests submitting unschedulable PodGroups.
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
 
+1. Analyze Latency Metrics: Check `scheduler_podgroup_scheduling_attempt_duration_seconds` and 
+   `scheduler_podgroup_scheduling_algorithm_duration_seconds`. High values here indicate that the Toplogy Aware
+   Schedling logic itself is computationally expensive and causing the regression.
+3. Inspect Logs: Enable scheduler logging at `-v=6` (or `-v=10` for deep tracing) to trace the execution time of
+   individual Workload Scheduling Cycles and identify if specific PodGroups which are blocking the queue. 
+4. Disable Feature: If the regression is critical and impacting cluster health, disable the
+   WorkloadTopologyAwareScheudling feature gate. This will revert the scheduler to the standard Workload Scheduling
+   logic, restoring baseline performance (at the cost of losing topology semantics).
+
 ## Implementation History
 
-<!--
-Major milestones in the lifecycle of a KEP should be tracked in this section.
-Major milestones might include:
-- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
-- the `Proposal` section being merged, signaling agreement on a proposed design
-- the date implementation started
-- the first Kubernetes release where an initial version of the KEP was available
-- the version of Kubernetes where the KEP graduated to general availability
-- when the KEP was retired or superseded
--->
+- 2025-12: Initial KEP-5732 proposal.
+- 2026-02: KEP-5732 created for TAS alpha release.
+- 2026-02: KEP-5732 updated to sync with decoupling of PodGroup/Workload API.
+- 2026-05: KEP updated to promote to beta in v1.37.
 
 ## Drawbacks
 
@@ -930,8 +879,4 @@ Users can run a secondary scheduler like Volcano or Yunikorn.
 
 ## Infrastructure Needed (Optional)
 
-<!--
-Use this section if you need things from the project/SIG. Examples include a
-new subproject, repos requested, or GitHub details. Listing these here allows a
-SIG to get the process for these resources started right away.
--->
+N/A

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -809,16 +809,16 @@ retried with standard exponential backoff once connectivity is restored.
 
 ###### What are other known failure modes?
 
-- Pods Pending Indefinitely - Gang cannot fit (Resource Constraints)
+- Pods Pending Indefinitely - PodGroup cannot fit in any Placement (Resource Constraints)
   - Detection: Check Pod Events/Status. Expected reason: a message indicating that minCount pods could not be
     scheduled.
   - Metrics: `scheduler_podgroup_schedule_attempts_total` with result unschedulable.
   - Mitigations:
     - Scale up the cluster (add nodes) or delete other real-workloads to free up space.
     - If intended, recreate the PodGroup object without `schedulingConstraints`
-      to disable TAS scheduling (fallback to best-effort scheduling) if acceptable.
+      to disable TAS scheduling (fallback to default workload scheduling) if acceptable.
   - Diagnostics:
-    - Scheduler logs at V=4 searching for "podgroup" to see detailed reasons why the placement failed.
+    - Scheduler logs at v=4 searching for "podgroup" to see detailed reasons why the placement failed.
   - Testing:
     - Covered by integration tests submitting unschedulable PodGroups.
 
@@ -830,7 +830,7 @@ retried with standard exponential backoff once connectivity is restored.
 3. Inspect Logs: Enable scheduler logging at `-v=6` (or `-v=10` for deep tracing) to trace the execution time of
    individual Workload Scheduling Cycles and identify if specific PodGroups which are blocking the queue. 
 4. Disable Feature: If the regression is critical and impacting cluster health, disable the
-   WorkloadTopologyAwareScheudling feature gate. This will revert the scheduler to the standard Workload Scheduling
+   TopologyAwareWorkloadScheudling feature gate. This will revert the scheduler to the standard Workload Scheduling
    logic, restoring baseline performance (at the cost of losing topology semantics).
 
 ## Implementation History

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -690,7 +690,7 @@ We'll perform manual testing of the upgrade -> downgrade -> upgrade path using t
 11. Create `test-pod-5` and `test-pod-6` Pods with `spec.schedulingGroup` pointing to `tas-test-C`
     and node affinities pointing to two different nodes. Note: We use a pod group created in step 5
     because creating new PodGroup objects with schedulingConstraints is disabled.
-13. The pods are scheduled succesfully (schedulingConstraints logic is ignored because the schedulingGroup
+13. The pods are scheduled successfully (schedulingConstraints logic is ignored because the schedulingGroup
     field is dropped by the v1.36 API server).
 15. Upgrade API Server and Scheduler back to v1.37 with feature gates enabled.
 16. Repeat steps 6 to 9 with `tas-test-D` and `tas-test-E`.

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -694,6 +694,9 @@ standard non-TAS method, falling back to a default workload scheduling algorithm
 
 This results in a fallback to the status quo behavior, meaning that pods will be
 still scheduled, but PodGroup-level toplogy scheduling constraints won't be applied.
+If the feature gate is subsequently enabled, existing pods belonging to this
+PodGroup will continue to run, but the scheduler may be unable to place any
+new pods within the same PodGroup due to the newly enforced topology constraints.
 
 ###### What specific metrics should inform a rollback?
 

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -689,7 +689,7 @@ still scheduled, but PodGroup-level toplogy scheduling constraints won't be appl
 We'll perform manual testing of the upgrade -> downgrade -> upgrade path using the following sequence:
 
 1. Start a local Kubernetes v1.36 cluster with `TopologyAwareWorkloadScheduling` feature
-   gate disabled and `GenericWorkload` feature gate enabled (default behavior).
+   gate disabled and `GenericWorkload` feature gate enabled.
 2. Attempt to create a PodGroup object with `spec.schedulingConstraints.topologyConstraints[0].level`
    set to `kubernetes.io/hostname`.
 3. The `spec.schedulingConstraints` field is dropped by the API server. The PodGroup is created

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -247,7 +247,7 @@ type PodGroupSpec struct {
 type PodGroupSchedulingConstraints struct {
     // Topology defines the topology constraints for the pod group.
     // Currently only a single topology constraint can be specified. This may change in the future.
-    TopologyConstraints []TopologyConstraint
+    Topology []TopologyConstraint
 }
 
 // TopologyConstraint defines a topology constraint for a PodGroup.
@@ -377,7 +377,9 @@ The algorithm proceeds in three main phases for a given PodGroup.
 
   1. Run default workload scheduling algorithm with the given set of nodes.
 
-  2. If all required pods fit, the Placement is marked Feasible.
+  2. If all required pods (at least `minCount` pods for Gang scheudling policy
+     and at least one pod for Basic scheduling policy) fit, the Placement
+     is marked Feasible.
 
 - **Basic Scheduling Policy Handling:** The current algorithm may exhibit
   inconsistent behavior when used with the PodGroup Basic Scheduling Policy.
@@ -433,6 +435,8 @@ Scheduling:
   all pods were evaluated, which missed an opportunity for optimization. This capability
   is implemented via a new "pseudo extension point" called PlacementFeasiblePlugin
   (similar to PodGroupPostFilter) to break out of the pod group scheduling cycle.
+  
+  More details on this optimization can be found in [KEP-4671: Workload API](https://kep.k8s.io/4671).
 
 3. Limit on the Number of Checked Placements
 

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -368,6 +368,11 @@ The algorithm proceeds in three main phases for a given PodGroup.
   a chance to get the list of nodes which should be considered when
   generating placements.
 
+- If some pods belonging to the PodGroup have already been scheduled,
+  the placement generation process should filter its output to strictly
+  return only those Placements that include all the nodes where
+  the already scheduled pods are currently running.
+
 - Example: If the label is rack, placements are generated for rack-1, rack-2,
   etc.
 

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -377,7 +377,7 @@ The algorithm proceeds in three main phases for a given PodGroup.
 
   1. Run default workload scheduling algorithm with the given set of nodes.
 
-  2. If all required pods (at least `minCount` pods for Gang scheudling policy
+  2. If all required pods (at least `minCount` pods for Gang scheduling policy
      and at least one pod for Basic scheduling policy) fit, the Placement
      is marked Feasible.
 
@@ -625,7 +625,7 @@ kube-scheduler instance being a leader).
 ###### Does enabling the feature change any default behavior?
 
 No - even with a feature enabled scheduler by default will use existing scheduling
-algorithm to scheudle worklaods. Only when workload will have an explicit topology
+algorithm to schedule workloads. Only when workload will have an explicit topology
 constraint set an alternative algorithm will be used.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
@@ -778,7 +778,7 @@ latency / Pod Startup SLO may potentially increase especially for large clusters
 fine grained topology constraints.
 
 We will measure the exact impact using performance benchmarks and scalability tests and
-update the section based on the results. The complexity of scheuduling of a single worklaod
+update the section based on the results. The complexity of scheduling of a single worklaod
 is O(#pods * #nodes), which is comparable to the algorithm not using topology constraints,
 so the benchmarks are primarily to validate the potential inefficiencies of the implementation.
 
@@ -834,7 +834,7 @@ retried with standard exponential backoff once connectivity is restored.
 3. Inspect Logs: Enable scheduler logging at `-v=6` (or `-v=10` for deep tracing) to trace the execution time of
    individual Workload Scheduling Cycles and identify if specific PodGroups which are blocking the queue. 
 4. Disable Feature: If the regression is critical and impacting cluster health, disable the
-   TopologyAwareWorkloadScheudling feature gate. This will revert the scheduler to the standard Workload Scheduling
+   TopologyAwareWorkloadScheduling feature gate. This will revert the scheduler to the standard Workload Scheduling
    logic, restoring baseline performance (at the cost of losing topology semantics).
 
 ## Implementation History

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -80,7 +80,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 ## Summary
 
 This KEP describes the architectural design and implementation details for
-integrating a Topology-Aware and DRA-Aware workload scheduling algorithm into
+integrating a Topology-Aware workload scheduling algorithm into
 the Kubernetes kube-scheduler to address the complex placement requirements of
 modern, high-performance distributed applications.
 
@@ -344,7 +344,7 @@ type PlacementScorePlugin interface {
     // The PodGroupAssignments indicates the node assigned to each pod within this Placement.
     // The returned score is a int64 with higher scores generally indicating more preferable Placements.
     // Plugins can implement various scoring strategies, such as bin packing to minimize resource fragmentation.
-    ScorePlacement(ctx context.Context, state PodGroupCycleState, podGroup PodGroupInfo, placement *PodGroupAssignments) (int64, *Status)
+    ScorePlacement(ctx context.Context, state PlacementCycleState, podGroup PodGroupInfo, placement *PodGroupAssignments) (int64, *Status)
 
     // PlacementScoreExtensions returns a PlacementScoreExtensions interface if it implements one, or nil if does not.
     PlacementScoreExtensions() PlacementScoreExtensions

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -465,6 +465,15 @@ Scheduling:
   arbitrarily land elsewhere, preventing the scheduler from undoing work performed
   in previous nominating cycles.
 
+5. Integration with Workload Aware Preemption
+
+  To ensure parity with a default pod group scheduling cycle, the TAS is now integrated
+  with [Workload Aware Preemption](https://kep.k8s.io/5710). In the WAP, after potential
+  victims are removed, the scheduler will run a podGroupSchedulingAlgorithm with TAS which
+  might potentially generate new placements. The best placement will be selected and the WAP
+  logic will try to reprieve as many victims as possible while assuming that preemptors pods
+  are assigned to the selected placement.
+
 ### Future Extensions
 
 [KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729)

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -456,6 +456,15 @@ Scheduling:
   
   This strategy ensures predictable, robust throughput of topology-aware scheduling.
 
+4. Respecting NominatedNodeName in Placement Selection
+
+  To align with standard pod-by-pod scheduling behavior, the TAS algorithm now
+  supports a pod's NominatedNodeName (NNN). When selecting placements, the scheduler
+  prioritizes evaluating placements containing the previously nominated nodes first.
+  This ensures that a workload whose pods were nominated to specific nodes does not
+  arbitrarily land elsewhere, preventing the scheduler from undoing work performed
+  in previous nominating cycles.
+
 ### Future Extensions
 
 [KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729)

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -532,9 +532,6 @@ N/A
 
 #### Integration tests
 
-For Alpha we implemented integration tests to ensure basic functionalities of
-to
-
 Topology Aware Scheduling With Gang Policy:
 
 - Resource Availability: Schedules successfully if space permits, or remains
@@ -628,6 +625,13 @@ kube-apiserver) may not handle those. Thus, users should not set those fields
 before confirming all control-plane instances were upgraded to the version
 supporting those.
 
+If SchedulingConstraints are set on a PodGroup that is scheduled before the
+TopologyAwareWorkloadScheduling feature gate is enabled on kube-scheduler,
+the pods within that group might be scheduled across different topology domains.
+If the feature gate is subsequently enabled, existing pods belonging to this
+PodGroup will continue to run, but the scheduler may be unable to place any
+new pods within the same PodGroup due to the newly enforced topology constraints.
+
 For the topology-aware workload scheduling itself, this is purely kube-scheduler
 in-memory feature, so the skew doesn't matter (as there is always only a single
 kube-scheduler instance being a leader).
@@ -674,8 +678,10 @@ The feature starts working again.
 The scheduler algorithm changes are purely in-memory and doesn't require any dedicated
 enablement/disablement tests - the logic will be covered by regular feature tests.
 
-For the newly introduced API fields, dedicated enablement/disablement tests at the
-kube-apiserver registry layer will be added.
+The feature has unit tests that verifies enablement and disablement of the
+`schedulingConstraints` field at the kube-apiserver registry layer:
+- Workload API: https://github.com/kubernetes/kubernetes/blob/de391ca4a4dfe6288287088a8f8ea8bc2352d5b8/pkg/registry/scheduling/workload/strategy_test.go#L83
+- PodGroup API: https://github.com/kubernetes/kubernetes/blob/de391ca4a4dfe6288287088a8f8ea8bc2352d5b8/pkg/registry/scheduling/podgroup/strategy_test.go#L125.
 
 ### Rollout, Upgrade and Rollback Planning
 
@@ -702,13 +708,13 @@ still scheduled, but PodGroup-level toplogy scheduling constraints won't be appl
 
 We'll perform manual testing of the upgrade -> downgrade -> upgrade path using the following sequence:
 
-1. Start a local Kubernetes v1.36 cluster with `TopologyAwareWorkloadScheduling` feature
+1. Start a local Kubernetes v1.37 cluster with `TopologyAwareWorkloadScheduling` feature
    gate disabled and `GenericWorkload` feature gate enabled.
 2. Attempt to create a PodGroup object with `spec.schedulingConstraints.topologyConstraints[0].level`
    set to `kubernetes.io/hostname`.
 3. The `spec.schedulingConstraints` field is dropped by the API server. The PodGroup is created
    successfully but without the `spec.schedulingConstraints` reference.
-4. Restart/Upgrade API Server and Scheduler to v1.37 with feature gates enabled.
+4. Restart API Server and Scheduler with `TopologyAwareWorkloadScheduling` feature gate enabled.
 5. Create five PodGroup objects: `tas-test-A` to `tas-test-E` all with `minCount`
    set to 2 and `spec.schedulingConstraints.topologyConstraints[0].level` set to `kubernetes.io/hostname`.
 6. Create `test-pod-1` and `test-pod-2` Pods with `spec.schedulingGroup` pointing to `tas-test-A`
@@ -718,13 +724,13 @@ We'll perform manual testing of the upgrade -> downgrade -> upgrade path using t
 8. Create `test-pod-3` and `test-pod-4` Pods with `spec.schedulingGroup` pointing to `tas-test-B`
    and node affinities pointing to the same node.
 9. Both pods are scheduled successfully (TAS works). 
-10. Downgrade API Server and Scheduler to v1.36 with feature gates disabled.
+10. Restart API Server and Scheduler with `TopologyAwareWorkloadScheduling` feature gate disabled.
 11. Create `test-pod-5` and `test-pod-6` Pods with `spec.schedulingGroup` pointing to `tas-test-C`
     and node affinities pointing to two different nodes. Note: We use a pod group created in step 5
     because creating new PodGroup objects with schedulingConstraints is disabled.
 13. The pods are scheduled successfully (schedulingConstraints logic is ignored because the schedulingGroup
     field is dropped by the v1.36 API server).
-15. Upgrade API Server and Scheduler back to v1.37 with feature gates enabled.
+15. Restart API Server and Scheduler with `TopologyAwareWorkloadScheduling` feature gate enabled.
 16. Repeat steps 6 to 9 with `tas-test-D` and `tas-test-E`.
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
@@ -739,14 +745,18 @@ Operators can check the new `plugin_execution_duration_seconds{plugin="TopologyP
 metric. A value greater than zero indicates that the scheduler is using TAS .
 
 Alternatively, checking for the existence of `PodGroup` via `kubectl get podgroups`,
-and checking the `PodGroup.spec.spec.schedulingConstraints` field confirms that users
+and checking the `PodGroup.spec.schedulingConstraints` field confirms that users
 are actively using the feature.
 
 ###### How can someone using this feature know that it is working for their instance?
 
 - [X] API .status
   - Object: PodGroup
+  - `spec.schedulingConstrains` field is not empty.
   - Condition Name: `PodGroupInitiallyScheduled`
+- [X] Metrics
+  - Metric: `scheduler_placement_total`
+  - Value is greater then 0.
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
@@ -767,7 +777,16 @@ of the standard scheduling loop.
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-No.
+The beta version of this feature introduces three new metrics to track pod group scheduling behavior:
+
+- `scheduler_placement_total` — counter tracking the total number of candidate placements generated
+  during pod group scheduling.
+- `scheduler_placement_evaluations_total` — counter tracking the total number of evaluated candidate
+  placements, partitioned by the result label (`feasible`/`infeasible`).
+- `scheduler_placement_evaluation_duration_seconds` — histogram measuring the latency (in seconds) of
+  evaluating an individual candidate placement, partitioned by the result label (`feasible`/`infeasible`).
+
+No additional metrics have been identified as necessary for this phase.
 
 ### Dependencies
 

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/kep.yaml
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/kep.yaml
@@ -46,6 +46,6 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - scheduler_placement_count
-  - scheduler_placement_schedule_attempts_total
-  - scheduler_placement_scheduling_attempt_duration_seconds
+  - scheduler_placement_total
+  - scheduler_placement_evaluations_total
+  - scheduler_placement_evaluation_duration_seconds

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/kep.yaml
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/kep.yaml
@@ -17,16 +17,17 @@ approvers:
 
 see-also:
   - "/keps/sig-scheduling/4671-gang-scheduling"
+  - "/keps/sig-scheduling/5719-workload-aware-preemption"
 
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -45,3 +46,6 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
+  - scheduler_placement_count
+  - scheduler_placement_schedule_attempts_total
+  - scheduler_placement_scheduling_attempt_duration_seconds


### PR DESCRIPTION
<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Update KEP-5732: Topology-aware workload scheduling for beta in v1.37

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5732

<!-- other comments or additional information -->
- Other comments:
  - Apart from beta graduation itself, this KEP proposes:
    - Adding support for defining  multiple PlacementGeneratePlugins
    - Implementation of two performance improvements for TAS
    - Moving DRA support implementation to [KEP-5729: DRA: ResourceClaim Support for Workloads](https://kep.k8s.io/5729)