### PR TITLE
Add note to notify SRC when KEP-5707 becomes default

### DIFF
--- a/keps/sig-network/5707-deprecate-service-externalips/README.md
+++ b/keps/sig-network/5707-deprecate-service-externalips/README.md
@@ -119,6 +119,7 @@ Tentative version: 1.36
 
 - Switch the `AllowServiceExternalIPs` feature gate to false
 - Create e2e test ensuring that externalIPs is no longer used by kube-proxy
+- Notify the Security Response Committee to update CVE-2020-8554 indicating that it now has a fix available.
 
 Clusters administrators can enable the feature gate if needed to restore the externalIPs functionality
 

--- a/keps/sig-network/5707-deprecate-service-externalips/README.md
+++ b/keps/sig-network/5707-deprecate-service-externalips/README.md
@@ -119,7 +119,7 @@ Tentative version: 1.36
 
 - Switch the `AllowServiceExternalIPs` feature gate to false
 - Create e2e test ensuring that externalIPs is no longer used by kube-proxy
-- Notify the Security Response Committee to update CVE-2020-8554 indicating that it now has a fix available.
+- Update the CVE record to indicate that CVE-2020-8554 has been fixed
 
 Clusters administrators can enable the feature gate if needed to restore the externalIPs functionality
 

--- a/keps/sig-network/5707-deprecate-service-externalips/kep.yaml
+++ b/keps/sig-network/5707-deprecate-service-externalips/kep.yaml
@@ -3,7 +3,7 @@ kep-number: 5707
 authors:
   - "@adrianmoisey"
 owning-sig: sig-network
-participating-sigs: []
+participating-sigs: [committee-security-response]
 status: implementable
 creation-date: 2026-02-02
 reviewers:


### PR DESCRIPTION
- One-line PR description: Add note to notify SRC when KEP-5707 becomes default

- Issue link: https://github.com/kubernetes/enhancements/issues/5707

- Other comments: When this KEP defaults to on, users' clusters will no longer be vulnerable to CVE-2020-8554 unless they specifically choose to re-enable support. At that point I consider the CVE to be fixed, and we should update the published CVE record to indicate that fact. Putting a little to-do note in here seems the best way to make sure we all remember to do so at the appropriate time.