### PR TITLE
KEP-5541: Update PersistentVolumeClaimUnusedSinceTime KEP for beta in 1.37

### DIFF
--- a/keps/prod-readiness/sig-storage/5541.yaml
+++ b/keps/prod-readiness/sig-storage/5541.yaml
@@ -1,3 +1,5 @@
 kep-number: 5541
 alpha:
   approver: "@kannon92"
+beta:
+  approver: "@kannon92"

--- a/keps/sig-storage/5541-pvc-last-used-time-status-field/README.md
+++ b/keps/sig-storage/5541-pvc-last-used-time-status-field/README.md
@@ -44,7 +44,7 @@ Items marked with (R) are required _prior to targeting to a milestone / release_
 - [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
-  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [x] e2e Tests for all Beta API Operations (endpoints)
   - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [x] (R) Graduation criteria is in place
@@ -61,10 +61,11 @@ Items marked with (R) are required _prior to targeting to a milestone / release_
 
 ## Summary
 
-This KEP proposes adding a new `UnusedSince` status field on a `PersistentVolumeClaim`
-to determine when a PVC was last used by a Pod. This enables cluster
+This KEP proposes adding a new `Unused` condition on `PersistentVolumeClaimStatus`
+to determine whether a PVC is currently in use by a Pod. This enables cluster
 administrators to identify unused PVCs and implement cleanup policies for
-storage that is no longer in use.
+storage that is no longer in use. The `lastTransitionTime` of the condition
+indicates when the PVC last changed between used and unused states.
 
 ## Motivation
 
@@ -79,8 +80,8 @@ this the ideal place to track usage.
 
 ### Goals
 
-- Add an `UnusedSince` timestamp field to `PersistentVolumeClaimStatus`
-- Update this field with a timestamp when a PVC is last used by a Pod
+- Add an `Unused` condition type to `PersistentVolumeClaim` status conditions
+- Set the condition to reflect whether the PVC is currently in use by any non-terminal Pod
 
 ### Non-Goals
 
@@ -90,12 +91,19 @@ this the ideal place to track usage.
 
 ## Proposal
 
-Add a new field `UnusedSince` of type `metav1.Time` to the `PersistentVolumeClaimStatus`
-struct. This field will be updated by the PVC protection controller (in kube-controller-manager)
-when the PVC transitions from being in use to not being in use.
+Add a new condition type `Unused` to the `PersistentVolumeClaim` status conditions.
+This condition is managed by the PVC protection controller (in kube-controller-manager)
+and reflects whether the PVC is currently referenced by any non-terminal Pod.
 
-The definition of a PVC not being in use is when the last Pod referencing it has
-been deleted or reached a terminal state.
+When the last Pod referencing a PVC is deleted or reaches a terminal state, the
+condition is set to `Status=True` with `Reason="NoPodsUsingPVC"` and
+`Message="No pods are currently referencing this PVC"`. When a new Pod starts
+referencing the PVC, the condition is set to `Status=False` with
+`Reason="PodUsingPVC"` and `Message="A pod is currently referencing this PVC"`.
+
+The `lastTransitionTime` of the condition indicates when the PVC last changed
+between used and unused states, providing the equivalent of an "unused since"
+timestamp.
 
 ### User Stories (Optional)
 
@@ -109,82 +117,89 @@ reduce storage costs.
 
 Notes:
 
-- Definition of 'last used': For the purposes of this KEP, a PVC is considered
-   'last used' when the last Pod referencing it has been deleted/terminated. Since
-   multiple Pods can share the same PVC, it's important to update the last used
-   status when the last Pod referencing it goes down.
-- Granularity: The timestamp represents the last time the PVC was referenced
-   by a Pod, not continuous usage tracking. A PVC re-mounted by a long-running Pod
-   will clear the timestamp to `nil`. If `UnusedSince` is not-nil, that'd mean the
-   PVC is not in use. If it is `nil`, it'd either mean it's currently in use, or
-   that it has never completed a usage cycle.
+- Definition of 'unused': A PVC is considered unused when no non-terminal Pod
+   references it. The `Unused` condition reflects this state:
+   - `Unused` condition with `Status=True` means the PVC is not referenced by
+     any non-terminal Pod.
+   - `Unused` condition with `Status=False` means at least one non-terminal Pod
+     references the PVC.
+   - No `Unused` condition present means the feature was recently enabled and no
+     transition has been observed yet, or the PVC has not yet gone through a
+     usage cycle.
+- Granularity: The `lastTransitionTime` on the condition indicates when the
+   PVC last changed between used and unused states. A PVC referenced by a
+   long-running Pod will have the condition set to `Status=False`. When that
+   Pod terminates, the condition transitions to `Status=True` and
+   `lastTransitionTime` is updated accordingly.
 
 ### Risks and Mitigations
 
 One risk is API server churn on KCM startup. When the feature is enabled (which
 leads to KCM restarts), the PVC protection controller will try to re-process all
-PVCs (one PVC at a time, from the queue) to ensure the timestamps are accurate,
+PVCs (one PVC at a time, from the queue) to ensure the conditions are accurate,
 including any changes that were missed while offline.
 
 In some clusters with many PVCs, this may cause the controller being throttled,
-which may lead to slight delays in updating the timestamp values on the PVCs (which
+which may lead to slight delays in updating the condition on PVCs (which
 is another risk too - see last point). This is an expected behavior for now and should
 be documented to convey the risks to the users.
 
-Another risk/point of confusion is when the feature is disabled, existing `UnusedSince`
-values remain in etcd, but are no longer updated, potentially becoming misleading. A
-similar mitigation approach could be adopted - to document about the fact that
-disabling the feature freezes existing values, and that administrators should not rely
-on the field while the feature is disabled.
+Another risk/point of confusion is when the feature is disabled, existing `Unused`
+condition values remain in etcd, but are no longer updated, potentially becoming
+misleading. A similar mitigation approach could be adopted - to document about the
+fact that disabling the feature freezes existing condition values, and that
+administrators should not rely on the condition while the feature is disabled.
 
-One more risk is that the timestamp value may not be entirely accurate. The `UnusedSince`
-timestamp represents when the controller observed no Pods referencing the PVC. It does
-not represent when the volume was actually unmounted at the infrastructure level and
-became actually unused (which could be delay of seconds or minutes). The only component
-that knows the longest time known to Kubernetes since volume was not used by a Pod is
-the kubelet, when it does the last unmount - but we'd not like our kubelet to update PVCs.
-The reported unused duration may be shorter than actual, but should never be longer.
+One more risk is that the condition transition time may not be entirely accurate.
+The `lastTransitionTime` on the `Unused` condition represents when the controller
+observed no Pods referencing the PVC. It does not represent when the volume was
+actually unmounted at the infrastructure level and became actually unused (which
+could be delay of seconds or minutes). The only component that knows the longest
+time known to Kubernetes since volume was not used by a Pod is the kubelet, when
+it does the last unmount - but we'd not like our kubelet to update PVCs. The
+reported unused duration may be shorter than actual, but should never be longer.
 Mitigation approach here would be to document this information clearly.
 
 ## Design Details
 
 Changes required for this KEP:
 
-1. Add a new field to `PersistentVolumeClaimStatus` in `core/v1` to track the timestamp:
+1. Add a new condition type constant to PVC condition types in `core/v1`:
 
    ```go
-   type PersistentVolumeClaimStatus struct {
-     // existing fields...
-
-     // UnusedSince is the timestamp that represents when the PVC last transitioned
-     // to not being in use. When the PVC is currently in use, this field is nil.
-     // It is updated when the last Pod referencing this PVC is deleted or reaches a
-     // terminal state, and cleared when a new Pod starts referencing the PVC.
-     // +optional
-     UnusedSince *metav1.Time `json:"unusedSince,omitempty" protobuf:"bytes,10,opt,name=UnusedSince"`
-   }
+   // In staging/src/k8s.io/api/core/v1/types.go
+   PersistentVolumeClaimUnused PersistentVolumeClaimConditionType = "Unused"
    ```
 
-1. Update the timestamp whenever the PVC transitions to not being in use anymore.
+   The condition uses the following states:
+
+   | Status | Reason | Message |
+   | :--- | :--- | :--- |
+   | `True` | `NoPodsUsingPVC` | `No pods are currently referencing this PVC` |
+   | `False` | `PodUsingPVC` | `A pod is currently referencing this PVC` |
+
+1. In the PVC protection controller, add logic to set/update the `Unused` condition:
 
    - The PVC Protection controller already watches Pod events and checks when a
       PVC transitions from "in use" to "not in use".
-   - The implementation can extend this existing logic:
+   - The implementation extends this existing logic:
       - When a Pod is deleted, the controller enqueues all the affected PVCs
       - During sync, the controller checks if the PVC is still in use by a Pod
       - Existing behavior: If it's not in use, and the `deletionTimestamp` is set,
          it proceeds with finalizer removal. If `deletionTimestamp` is not set, it returns early.
       - New behavior: When it determines a PVC is not in use, and the `deletionTimestamp`
-         is not set (not queued for deletion), it should update the `status.UnusedSince`
-         timestamp to the current timestamp. (Note: If `deletionTimestamp` is set, we skip
-         updating `UnusedSince` since the PVC is being deleted and the timestamp
-         would serve no purpose)
+         is not set (not queued for deletion), it sets the `Unused` condition to
+         `Status=True`. (Note: If `deletionTimestamp` is set, we skip updating the
+         condition since the PVC is being deleted and the condition would serve no purpose.)
          Conversely, when the PVC transitions from not in use to in use (i.e., a Pod starts
-         referencing it) the controller should clear `UnusedSince` to `nil`. This ensures
-         the field doesn't reflect stale values when it's currently in use.
+         referencing it) the controller sets the `Unused` condition to `Status=False`.
+   - The controller uses two separate check functions: `podUsesPVCForDeletion`
+      (existing, for finalizer logic) and `podUsesPVCForUnusedSince` (new, considers
+      unscheduled pods too).
 
-1. Add a Feature Gate named `PersistentVolumeClaimUnusedSinceTime` that is disabled by default in alpha.
-   The timestamp field exists but is not populated unless gate is enabled.
+1. Add a Feature Gate named `PersistentVolumeClaimUnusedSinceTime` that is disabled
+   by default in alpha and enabled by default in beta. The condition is not managed
+   unless the gate is enabled.
 
 Note (definition of in use): A PVC is considered to be in use if a Pod references
 it in `pod.spec.volumes` and that Pod is not in a terminal state (succeeded/failed).
@@ -201,35 +216,25 @@ to implement this enhancement.
 
 The following packages will be modified and require test coverage:
 
-- `pkg/controller/volume/pvcprotection`: tests for `UnusedSince` being set when
-the last Pod referencing a PVC terminates, and not set when other Pods still
-reference the PVC.
+- `pkg/controller/volume/pvcprotection`: tests for the `Unused` condition being
+set to `Status=True` when the last Pod referencing a PVC terminates, and set to
+`Status=False` when a Pod references the PVC.
 
-- `pkg/controller/volume/pvcprotection`: `2026-01-18` - `74.1%`
+- [`pkg/controller/volume/pvcprotection`](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go): `2026-01-18` - `74.1%`
 
 ##### Integration tests
 
-Integration tests can be added to verify the core controller logic:
-
-- `UnusedSince` set when last Pod referencing PVC terminates
-- `UnusedSince` set to `nil` when other Pods still reference the PVC
-- Feature gate enable/disable behavior
-
-Note: Integration and e2e tests would be pretty identical for this feature.
+Integration and e2e tests would be pretty identical for this feature.
 We can possibly skip this using the reasoning that e2e tests would provide
-more value and might help catch more bugs. \[TBD\]
-
-- [test name](https://github.com/kubernetes/kubernetes/blob/2334b8469e1983c525c0c6382125710093a25883/test/integration/...): [integration master](https://testgrid.k8s.io/sig-release-master-blocking#integration-master?include-filter-by-regex=MyCoolFeature), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=MyCoolFeature)
+more value.
 
 ##### e2e tests
 
-e2e tests will be added to verify the feature works in a real cluster environment.
+e2e tests will be added to verify the feature works in a real cluster environment:
 
-- `UnusedSince` set when last Pod referencing PVC terminates
-- `UnusedSince` set to `nil` when other Pods still reference the PVC
+- `Unused` condition set to `Status=True` when last Pod referencing PVC terminates
+- `Unused` condition set to `Status=False` when a Pod references the PVC
 - Feature gate enable/disable behavior
-
-- [test name](https://github.com/kubernetes/kubernetes/blob/2334b8469e1983c525c0c6382125710093a25883/test/e2e/...): [SIG ...](https://testgrid.k8s.io/sig-...?include-filter-by-regex=MyCoolFeature), [triage search](https://storage.googleapis.com/k8s-triage/index.html?test=MyCoolFeature)
 
 ### Graduation Criteria
 
@@ -237,33 +242,40 @@ e2e tests will be added to verify the feature works in a real cluster environmen
 
 - Feature implemented successfully behind a feature gate
 - Unit tests added to test out feature enablement/disablement, and passing
-- Initial e2e tests completed and enabled
 
 #### Beta
 
-TBD
+- Feature implemented and stable in alpha for one release
+- Initial e2e tests completed and enabled
+- Comprehensive unit test coverage
+- E2E tests added and passing
+- PRR completed and approved
 
 #### GA
 
-TBD
+- Feature enabled by default for at least one release (beta)
+- No major bugs reported
+- Conformance tests if applicable
 
 ### Upgrade / Downgrade Strategy
 
 Upgrading and downgrading is safe.
 
 Upgrade:
-For pre-existing PVCs: After upgrading, the `UnusedSince` status field will not be
-present on the PVCs until it transitions from being in use to not in use. PVCs that
-are never used after upgrade won't have this field.
+For pre-existing PVCs: After upgrading, the `Unused` condition will not be
+present on PVCs until a transition is observed by the controller. PVCs that
+are never used after upgrade won't have this condition until the controller
+processes them.
 
-For new PVCs: PVCs that are created after upgrading, will be created with `UnusedSince`
-set to `nil`. The value of the field will be populated on first transition from in use
-to not in use. PVCs that are never used after creation will retain the `nil` value.
+For new PVCs: PVCs that are created after upgrading will not have the `Unused`
+condition initially. The condition will be added on the first observed transition
+(e.g., when a Pod referencing the PVC terminates or when the controller first
+evaluates the PVC's usage state).
 
 Downgrade:
-When downgrading to a version without this feature, the field value (if set) will
-be preserved in etcd. Older controller-managers would simply ignore this field.
-The field value might go stale if transition happens during the downgraded versions
+When downgrading to a version without this feature, the condition (if set) will
+be preserved in etcd. Older controller-managers would simply ignore this condition.
+The condition might go stale if transitions happen during the downgraded versions
 but the updating process resumes when the version is upgraded and the first transition
 occurs.
 
@@ -272,9 +284,9 @@ occurs.
 | API Server | KCM | Behavior |
 | :--- | :--- | :--- |
 | off | off | Existing Kubernetes behavior. |
-| on | off | Existing Kubernetes behavior. The `UnusedSince` field exists but is never populated by the controller. Only users can set it manually via the API. |
-| off | on | PVC protection controller may attempt to set `UnusedSince`, which will be dropped by the API server since the field is not recognized. |
-| on | on | New behavior. `UnusedSince` is updated when a PVC transitions from in use to not in use, and cleared when it transitions to in use. |
+| on | off | Existing Kubernetes behavior. The `Unused` condition type is recognized but never set by the controller. Only users can set it manually via the API. |
+| off | on | PVC protection controller may attempt to set the `Unused` condition, which will be dropped by the API server since the condition type is not recognized. |
+| on | on | New behavior. `Unused` condition is set to `Status=True` when a PVC transitions to not being in use, and `Status=False` when it transitions to being in use. |
 
 ## Production Readiness Review Questionnaire
 
@@ -282,7 +294,7 @@ occurs.
 
 ###### How can this feature be enabled / disabled in a live cluster?
 
-- [x] Feature gate (also fill in values in `kep.yaml`)
+- [x] Feature gate
   - Feature gate name: `PersistentVolumeClaimUnusedSinceTime`
   - Components depending on the feature gate:
     - kube-apiserver
@@ -290,72 +302,85 @@ occurs.
 
 ###### Does enabling the feature change any default behavior?
 
-No. The field is not read by any other Kubernetes component for any purposes
-and so, existing workflows that do not explicitly read this field would remain
-unaffected. The field also is not available on existing PVCs after enabling the
-feature, until it transitions from being in use to not in use, which is when
-the value is populated with the timestamp.
+No. The condition is not read by any other Kubernetes component for any purposes
+and so, existing workflows that do not explicitly read this condition would remain
+unaffected. The condition also is not present on existing PVCs after enabling the
+feature, until the controller observes a transition, which is when the condition
+is added.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes, disabling the feature will stop the controller from updating the status field.
-The value however, once set, would remain stored in etcd, but become stale - disabling
-doesn't remove it. If the field was set to nil (either never set, or currently in use),
-it remains nil and cannot be newly populated while the feature gate is disabled.
+Yes, disabling the feature will stop the controller from updating the `Unused`
+condition. The condition however, once set, would remain stored in etcd, but
+become stale - disabling doesn't remove it. If the condition was not yet set,
+it remains absent and cannot be newly added while the feature gate is disabled.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
-The controller will resume updating the status field. If the PVC didn't transition
-while the feature was disabled, the data already stored represents the correct last used
-timestamp. If the PVC did transition while the feature was disabled, the data might either
-be stale or missing. There could be 2 scenarios:
+The controller will resume managing the `Unused` condition. If the PVC didn't
+transition while the feature was disabled, the condition already stored represents
+the correct state. If the PVC did transition while the feature was disabled, the
+condition might be stale or missing. There could be 2 scenarios:
 
-- If a PVC transitioned from not in use to in use, the old timestamp is retained
-  instead of being cleared to nil, thus becoming stale.
-- If a PVC transitioned from in use to not in use, the value remains nil instead
-  of being set to a timestamp
+- If a PVC transitioned from not in use to in use, the old condition (`Status=True`)
+  is retained instead of being updated to `Status=False`, thus becoming stale.
+- If a PVC transitioned from in use to not in use, the condition remains at
+  `Status=False` (or absent) instead of being set to `Status=True`.
 
-In either case, the value will be corrected on the next transition after the
+In either case, the condition will be corrected on the next transition after the
 feature is re-enabled.
 
 ###### Are there any tests for feature enablement/disablement?
 
 Unit tests for enabling and disabling feature gate are required for alpha - see "Graduation criteria" section.
 
-The tests should verify the correct handling of the new PVC status field in relation to the
-feature gate state. Correct handling means the value of the newly added status field is
-correctly added/updated when the PVC transitions to not being in use, while the feature
-gate is enabled, and the values are persisted when the feature gate is disabled.
+The tests should verify the correct handling of the `Unused` condition in relation to the
+feature gate state. Correct handling means the condition is correctly set/updated when
+the PVC transitions between used and unused states while the feature gate is enabled,
+and the condition values are preserved when the feature gate is disabled.
 
 ### Rollout, Upgrade and Rollback Planning
 
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-<!--
-Try to be as paranoid as possible - e.g., what if some components will restart
-mid-rollout?
-
-Be sure to consider highly-available clusters, where, for example,
-feature flags will be enabled on some API servers and not others during the
-rollout. Similarly, consider large clusters and how enablement/disablement
-will rollout across nodes.
--->
+The controller may temporarily queue all PVCs for re-evaluation on startup. In
+large clusters this may cause temporary throttling. Running workloads are not
+affected since the `Unused` condition is informational only and does not influence
+PVC deletion protection logic or any other controller behavior.
 
 ###### What specific metrics should inform a rollback?
 
-<!--
-What signals should users be paying attention to when the feature is young
-that might indicate a serious problem?
--->
+Monitor the `pvc_protection_controller_unused_condition_syncs_total` metric
+(labeled by `result`: `success` or `error`). An elevated error rate for this
+metric indicates failures when updating the `Unused` condition on PVCs and
+could inform a rollback decision. Additionally, check kube-controller-manager
+logs for PVC status update errors.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
-<!--
-Describe manual testing that was done and the outcomes.
-Longer term, we may want to require automated upgrade/rollback tests, but we
-are missing a bunch of machinery and tooling and can't do that now.
--->
-Yet to be completed for beta.
+Yes. Manual upgrade→downgrade→upgrade testing was performed on a single-node
+cluster (v1.37.0-alpha.1) with 1000 PVCs and 100 pods (each mounting 10 PVCs).
+
+The feature gate was toggled by editing kube-apiserver and kube-controller-manager
+static pod manifests, preserving all cluster state across toggles.
+
+**Step 1 — Enable feature gate (upgrade):**
+- All 1000 PVCs received the `Unused=False` condition within ~49 seconds
+  (processing rate: ~21 PVCs/second)
+- KCM memory increase: +3 MB during reconciliation burst, settled immediately
+- Zero errors, zero KCM restarts
+
+**Step 2 — Disable feature gate (downgrade):**
+- All 1000 `Unused` conditions were preserved in etcd (not stripped)
+- Conditions stopped being updated — creating and deleting a pod referencing
+  a PVC did not change the condition's `lastTransitionTime`
+- Existing workloads continued to function normally (pods created, volumes mounted)
+
+**Step 3 — Re-enable feature gate (re-upgrade):**
+- Condition updates resumed immediately
+- Creating a pod set `Unused=False` with a new `lastTransitionTime`
+- Deleting the pod set `Unused=True` with a newer `lastTransitionTime`
+- Full round-trip verified: the controller correctly picks up where it left off
 
 ###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
 
@@ -365,64 +390,52 @@ No.
 
 ###### How can an operator determine if the feature is in use by workloads?
 
-Operators can check if the PVCs have `status.UnusedSince` field populated.
+Operators can check if PVCs have an `Unused` condition in their `.status.conditions`.
 
 ###### How can someone using this feature know that it is working for their instance?
 
 - [X] API .status
-  - Other field: `pvc.Status.UnusedSince`
+  - Condition type: `Unused`
+  - Other field: Check `.status.conditions` for a condition with `type: Unused`
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
-<!--
-This is your opportunity to define what "normal" quality of service looks like
-for a feature.
-
-It's impossible to provide comprehensive guidance, but at the very
-high level (needs more precise definitions) those may be things like:
-  - per-day percentage of API calls finishing with 5XX errors <= 1%
-  - 99% percentile over day of absolute value from (job creation time minus expected
-    job creation time) for cron job <= 10%
-  - 99.9% of /health requests per day finish with 200 code
-
-These goals will help you determine what you need to measure (SLIs) in the next
-question.
--->
+99% of PVC unused condition transitions should be reflected within 60 seconds
+of the triggering event (e.g., Pod deletion or Pod creation referencing the PVC).
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
-<!--
-Pick one more of these and delete the rest.
--->
-
-- [ ] Metrics
-  - Metric name:
-  - [Optional] Aggregation method:
-  - Components exposing the metric:
-- [ ] Other (treat as last resort)
-  - Details:
+- [x] Metrics
+  - Metric name: `pvc_protection_controller_unused_condition_syncs_total`
+  - Components exposing the metric: kube-controller-manager
+  - This counter tracks the number of PVC `Unused` condition status updates,
+    labeled by `result` (`success` or `error`). Operators can use the error
+    rate (`error / (success + error)`) to monitor the health of the feature
+    and validate the SLO.
+- [x] Other
+  - Latency between Pod deletion and `Unused` condition update on the PVC. Observable by comparing Pod deletion timestamp with the `lastTransitionTime` on the `Unused` condition.
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-<!--
-Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
-implementation difficulties, etc.).
--->
+A `pvc_protection_controller_unused_condition_syncs_total` counter metric
+(labeled by `result`: `success` or `error`) will be added in beta to track
+the number of PVC `Unused` condition updates. This follows the established
+pattern used by other Kubernetes controllers (e.g., the Job controller's
+`job_controller_job_syncs_total{result}` metric).
 
 ### Dependencies
 
 ###### Does this feature depend on any specific services running in the cluster?
 
-No, depends only upon the core Kubernetes components available to a functioning
-cluster.
+No.
 
 ### Scalability
 
 ###### Will enabling / using this feature result in any new API calls?
 
-Yes. A new PATCH call for PersistentVolumeClaimStatus. Estimated throughput would be
-one PATCH call per PVC when transitioning from in use to not in use. The originating
-component is PVC Protection Controller (in kube-controller-manager).
+Yes. A new UpdateStatus call for PersistentVolumeClaim. Estimated throughput would be
+one UpdateStatus call per PVC when transitioning between in use and not in use states.
+The originating component is PVC Protection Controller (in kube-controller-manager).
 
 ###### Will enabling / using this feature result in introducing new API types?
 
@@ -434,8 +447,9 @@ No.
 
 ###### Will enabling / using this feature result in increasing size or count of the existing API objects?
 
-Yes. All PVC objects will have an entirely new status field `UnusedSince` to hold
-the timestamp value. Estimated increase in size would be < 50B.
+Yes. PVC objects will have a new `Unused` condition in their `.status.conditions`
+list. Estimated increase in size would be < 200B per PVC (condition includes type,
+status, reason, message, and lastTransitionTime).
 
 ###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
 
@@ -447,26 +461,26 @@ No.
 
 ###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
 
-No, this feature operates in the control-plane and doesn't affect node resources.
+No.
 
 ### Troubleshooting
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
-The controller will be unable to update the `UnusedSince` status field.
+The controller will be unable to update the `Unused` condition on PVCs.
 
 ###### What are other known failure modes?
 
-One failure mode would be the delay in updating the timestamp values for clusters
+One failure mode would be the delay in updating the condition for clusters
 having a large number of PVCs (this has been discussed in the Risks and Mitigations
-section). This might sometimes lead to timestamp values not being entirely accurate.
-In such cases however, the time reported can be shorter than actual time the PVC was
-unused, but it should never be longer.
+section). This might sometimes lead to the `lastTransitionTime` not being entirely
+accurate. In such cases however, the time reported can be shorter than actual time
+the PVC was unused, but it should never be longer.
 
 This feature extends the PVC Protection controller logic with an additional
-status field update. Other failure modes would be similar to existing failure modes
-of the controller. If KCM is unavailable, timestamps won't be updated. If the API
-server and/or etcd is unavailable, the timestamps won't be updated (covered in the
+status condition update. Other failure modes would be similar to existing failure modes
+of the controller. If KCM is unavailable, conditions won't be updated. If the API
+server and/or etcd is unavailable, the conditions won't be updated (covered in the
 section above).
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
@@ -477,18 +491,23 @@ PVC status updates.
 ## Implementation History
 
 - 1.36: alpha
+- 1.37: beta
 
 ## Drawbacks
 
-<!--
-Why should this KEP _not_ be implemented?
--->
+None.
 
 ## Alternatives
 
 One alternative was the use the deletion of `VolumeAttachment` objects as triggers
-for updating the status field. This was ruled out because of the fact that not all
+for updating the status. This was ruled out because of the fact that not all
 volume types create a `VolumeAttachment` object, restricting the scope of the KEP.
+
+Another alternative considered was using a dedicated status field (`UnusedSince *metav1.Time`)
+on `PersistentVolumeClaimStatus` instead of a condition. The condition-based approach
+was chosen because conditions are Kubernetes-idiomatic, integrate with existing PVC
+condition infrastructure, and provide standardized fields (type, status, reason,
+message, lastTransitionTime) that are well understood by tooling and operators.
 
 ## Infrastructure Needed (Optional)
 

--- a/keps/sig-storage/5541-pvc-last-used-time-status-field/kep.yaml
+++ b/keps/sig-storage/5541-pvc-last-used-time-status-field/kep.yaml
@@ -21,17 +21,17 @@ replaces:
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature
 # and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.36"
-  beta: "TBD"
+  beta: "v1.37"
   stable: "TBD"
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
  - One-line PR description: Update KEP-5541 for beta graduation in v1.37 and add PRR approver

  - Issue link: https://github.com/kubernetes/enhancements/issues/5541

  - Other comments: 
    - Updates KEP-5541 (Report Last Used Time on a PVC) for beta graduation:
      - Updated KEP design to use conditions-based approach (`Unused` condition on PVC status)
      - Updated kep.yaml with stage: beta and milestone v1.37
      - Added beta PRR approver to prod-readiness file