### PR TITLE
KEP-5547: Update job integration to use workloadbuilder

### DIFF
--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -86,10 +86,10 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 ## Summary
 
 This KEP integrates the Workload-aware Scheduling (WAS) APIs (`Workload` and `PodGroup`) into the
-core `batch/v1` Job by adding a user-facing `spec.scheduling` field, letting users express explicit
+batch/v1` Job by adding a user-facing `spec.scheduling` field, allowing users to express explicit
 scheduling intent such as gang scheduling[^1], topology co-location, and disruption policies.
 
-The first alpha was introduced in v1.36 intentionally bypassed this user-facing API: the controller inferred a
+The first alpha, introduced in v1.36, intentionally bypassed this user-facing API: the controller inferred a
 hardcoded `Gang` policy from the Job's type (parallel Jobs with indexed completion mode), with `minCount`
 fixed to `parallelism`. This revision replaces that automatic, controller-inferred model with an
 explicit, user-driven design that separates scheduling *policy* (expressed by the user) from
@@ -123,7 +123,7 @@ gaps of the initial alpha.
 
 - Add a user-facing `spec.scheduling` (`JobSchedulingConfiguration`) field to the `batch/v1` Job,
   embedding the `scheduling.k8s.io/v1alpha3` building blocks (`policy`, `constraints`,
-  `disruptionMode`, `resourceClaims`) so users express explicit scheduling intent.
+  `disruptionMode`, `resourceClaims`) so users can express explicit scheduling intent.
 - Default to `Basic` (standard pod-by-pod) scheduling when `spec.scheduling` is omitted, so the
   runtime scheduling behavior of existing Jobs is unchanged (implicit opt-out from gang). Following
   the [KEP-6089] "Universal Representation" principle, the controller still materializes a `Basic`
@@ -136,8 +136,8 @@ gaps of the initial alpha.
   other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
   `minCount` in `PodGroup`/`PodGroupTemplate` mutable in v1.37 to support workload scaling.
 - Skip `Workload`/`PodGroup` creation when a higher-level controller owns the workload (the Job
-  carries an `OwnerReference` to a registered parent workload), preserving the
-  root-controller-as-compiler principle.
+  carries an `OwnerReference` to a parent controller that itself creates and manages the
+  `Workload`), preserving the root-controller-as-compiler principle.
 - Ensure proper ordering of `Workload` → `PodGroup` → `Pod` creation.
 
 ### Non-Goals
@@ -176,8 +176,8 @@ The key design principles for this alpha are:
   parallelism is unset). `minCount` is mutable to support elastic scaling; all other
   `spec.scheduling` fields are immutable after creation.
 - The Job controller does not create `Workload`/`PodGroup` when the Job carries an `OwnerReference`
-  to a registered parent workload. Higher-level controllers (e.g., `JobSet`) that own the
-  `Workload` set this when they create the Job.
+  to a parent controller that manages the `Workload` (e.g., `JobSet`). Such controllers set this
+  `OwnerReference` when they create the Job.
 - Jobs created by `CronJob` are standalone (no parent-workload `OwnerReference`); the Job controller
   creates one `Workload` and one `PodGroup` per Job for them based on each Job's `spec.scheduling`.
 
@@ -347,8 +347,8 @@ spec:
 #### Example 3: CronJob with Gang Scheduling
 
 A `CronJob` that periodically runs a gang-scheduled training Job. Each `Job` created by the
-`CronJob` is treated as standalone. `CronJob` is *not* a registered parent workload, so the Job
-controller creates a separate `Workload` and `PodGroup` per `Job`. These objects are
+`CronJob` is treated as standalone.`CronJob` does not create or manage `Workload` objects,
+the Job controller creates a separate `Workload` and `PodGroup` per `Job`. These objects are
 garbage-collected when each `Job` completes or is deleted.
 
 ```yaml
@@ -435,8 +435,8 @@ changing how the pods are scheduled.
 - `spec.scheduling.policy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
   other `spec.scheduling` fields are immutable after creation.
 - Opting out of WAS object creation happens implicitly in two ways: omitting `spec.scheduling`
-  yields `Basic` (the controller still owns the objects), and a Job that carries an `OwnerReference`
-  to a registered parent workload is skipped entirely (the parent owns the `Workload`).
+  yields `Basic` (the controller still owns the objects), and a Job whose parent controller manages
+  the `Workload` is skipped entirely.
 
 ### Risks and Mitigations
 
@@ -474,9 +474,9 @@ single-level `Job`:
 - **The Root Controller is the Compiler.** For a standalone `Job`, the Job controller is the
   root-most controller and is responsible for compiling, creating, and managing the
   scheduler-facing `Workload` and its runtime `PodGroup`. When a `Job` instead carries an
-  `OwnerReference` to a registered parent workload (e.g., a `JobSet`-owned Job), the Job controller
-  observes that linkage and **bypasses** creating any `Workload`, so the parent remains the single
-  source of truth.
+  `OwnerReference` to a parent controller that manages the `Workload` (e.g., a `JobSet` owns the Job),
+  the Job controller observes that linkage and *bypasses* creating any `Workload`, so the parent
+  remains the single source of truth.
 - **Separation of Structure and Policy.** The `Job` spec owns the workload *structure*
   (`parallelism`, `completions`, the pod template); the user owns the scheduling *policy* via
   `spec.scheduling`. The Job controller acts as the translator that combines the two and compiles
@@ -569,8 +569,8 @@ The boundary between the library and the Job controller is explicit.
 
 The `workloadbuilder` library is responsible for:
 
-  * Defining the polymorphic, hierarchy-agnostic IR (`SchedulingConfig`, `WorkloadNode`) that 
-  the Job controller populates.
+  * Defining the polymorphic, hierarchy-agnostic intermediate representation (IR)
+  (`SchedulingConfig`, `WorkloadNode`) that the Job controller populates.
   * Merging the controller-supplied defaults (`DefaultConfig`, `DefaultGangMinCount`) with the user's
   `UserConfig`, including escape-hatch resolution.
   * Validating the resolved configuration via a `Validate` entrypoint, which runs the same resolution
@@ -598,64 +598,32 @@ never uses `MapCompositeGroupConfig`, which is reserved for multi-level controll
 #### Building the Logical Tree and Compiling the `Workload`
 
 The controller's `generateWorkload` helper performs four steps: 
-  1. Set the Job's domain default to `Basic`.
+  1. Set the Job's default configuration to `Basic`.
   2. Map the user-facing `spec.scheduling` block into the library IR via `MapPodGroupConfig`.
   3. Assemble a single-node `WorkloadNode`, supplying `DefaultGangMinCount` from `spec.parallelism` 
     as the fallback gang size.
   4. Invoke `Build`, passing the Job's identity and a controller `OwnerReference` so the emitted
     `Workload` is owned by the Job and garbage-collected with it.
 
-```go
-import (
-    "context"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    batchv1 "k8s.io/api/batch/v1"
-    schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-    "k8s.io/utils/ptr"
-)
-
+```
 func (r *JobReconciler) generateWorkload(
     job *batchv1.Job,
-) (*schedulingv1alpha3.Workload, error) {
-    // 1. A Job's context-aware sane default is Basic scheduling (standard pod-by-pod).
-    defaultConfig := &workloadbuilder.SchedulingConfig{
-        Policy: &workloadbuilder.SchedulingPolicy{
-            Basic: &workloadbuilder.BasicSchedulingPolicy{},
-        },
-    }
+) (*Workload, error) {
+    // Default to Basic (standard pod-by-pod) scheduling.
+    defaultConfig = SchedulingConfig{Policy: Basic}
 
-    // 2. Map the public Job.Spec.Scheduling wrapper into the library's IR via the leaf helper.
-    var userConfig *workloadbuilder.SchedulingConfig
-    if job.Spec.Scheduling != nil {
-        userConfig = workloadbuilder.MapPodGroupConfig(
-            job.Spec.Scheduling.Policy,
-            job.Spec.Scheduling.Constraints,
-            job.Spec.Scheduling.DisruptionMode,
-            job.Spec.Scheduling.ResourceClaims,
-        )
-    }
+    // Map the user's spec.scheduling into the workloadbuilder library IR.
+    userConfig = MapPodGroupConfig(job.Spec.Scheduling)
 
-    // 3. Create the flat, single-node logical tree for the Job (one PodGroup).
-    rootNode := &workloadbuilder.WorkloadNode{
-        Name:                "job-root",
+    // Build a single-node logical tree (one PodGroup per Job).
+    rootNode = WorkloadNode{
         DefaultConfig:       defaultConfig,
-        DefaultGangMinCount: ptr.To(job.Spec.Parallelism), // defaults to parallelism if MinCount is nil
+        DefaultGangMinCount: job.Spec.Parallelism, // defaults to parallelism if MinCount is nil
         UserConfig:          userConfig,
     }
 
-    // 4. Let the workloadbuilder compile and generate the Workload object.
-    builder := workloadbuilder.NewBuilder(rootNode)
-    workloadObj, err := builder.Build(
-        context.Background(),
-        job.Name,
-        job.Namespace,
-        metav1.NewControllerRef(job, jobKind),
-    )
-    if err != nil {
-        return nil, err
-    }
-
-    return workloadObj, nil
+    // Compile and emit the Workload object, owned by this Job.
+    return NewBuilder(rootNode).Build(job.Name, job.Namespace, ownerRef=job)
 }
 ```
 
@@ -780,10 +748,10 @@ via informers/listers and continue.
 
 The controller discovers or creates `Workload` and `PodGroup` as follows:
 
-1. If the Job carries an `OwnerReference` to a registered parent workload (i.e., it is owned by a
-   higher-level controller such as `JobSet`), skip `Workload`/`PodGroup` creation entirely since the
-   parent owns them. The controller still discovers any existing objects and uses them when 
-   creating pods.
+1. If the Job carries an `OwnerReference` to a parent controller that manages the `Workload`
+   (i.e., a higher-level controller such as `JobSet` that compiles and owns the workload tree),
+   skip `Workload`/`PodGroup` creation entirely since the parent owns them. The controller still
+   discovers any existing objects and uses them when creating pods.
 2. If the Job already has pods (active or terminal pods owned by this Job), skip creation and only
    discover existing objects.
 3. Look up existing `Workload`(s) in the Job's namespace whose `spec.controllerRef` points to this

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -171,8 +171,8 @@ The key design principles for this alpha are:
 
 - One `Job` maps to one `PodGroup` representing a single group of pods. The `PodGroup` 
 always links to a `Workload` via a `PodGroupTemplate`:
-  * For a root Job the controller compiles the `Workload` itself
-  * For a non-root Job the `PodGroup` links to the parent-owned `Workload`
+  * For a root Job it links to the `Workload` the controller compiles itself
+  * For a non-root Job it links to the parent-owned `Workload`
   * The `PodGroup` links to a parent `CompositePodGroup` instance only when the parent 
   supplies the `scheduling.k8s.io/parent-composite-podgroup` annotation
 - The scheduling policy comes from the user's `spec.scheduling`, not from the Job's type. When
@@ -571,7 +571,7 @@ The Job controller compiles `spec.scheduling` into a `Workload` using the `workl
 The `scheduling.k8s.io/v1alpha3` building-block types live in the API staging repo
 (`k8s.io/api/scheduling/v1alpha3`). The `workloadbuilder` library lives separately in
 `k8s.io/component-helpers`, so it can be vendored by both in-tree controllers and out-of-tree 
-controllers. The Job controller consumes its `NewBuilder`/`Build`, `WorkloadNode`, and 
+controllers. The Job controller consumes its `NewBuilder`/`Build`, `WorkloadItem`, and 
 `MapPodGroupConfig`. If the library API shifts before it stabilizes, the Job integration 
 tracks those changes through the shared dependency rather than maintaining its own copy.
 
@@ -580,7 +580,7 @@ tracks those changes through the shared dependency rather than maintaining its o
 The controller's `generateWorkload` helper performs four steps: 
   1. Set the Job's default configuration to `Basic`.
   2. Map the user-facing `spec.scheduling` block into the library IR via `MapPodGroupConfig`.
-  3. Assemble a single-node `WorkloadNode`, supplying `DefaultGangMinCount` from `spec.parallelism` 
+  3. Assemble a single-node WorkloadItem, if needed supplying minCount for gang from spec.parallelism.
     as the fallback gang size.
   4. Invoke `Build`, passing the Job's identity and a controller `OwnerReference` so the emitted
     `Workload` is owned by the Job and garbage-collected with it.
@@ -741,18 +741,22 @@ flowchart BT
     Workload[Workload]
     Job[Job]
 
-    Workload -->|ownerRef| Job
-    PodGroup -->|ownerRef| Job
-    Pod -->|ownerRef| Job
-
-    PodGroup -->|ownerRef| Workload
     Pod -->|ownerRef| PodGroup
+    Pod -->|ownerRef| Job
+    PodGroup -->|ownerRef| Job
+    PodGroup -->|ownerRef <br/> (root Job only)| Workload
+    Workload -->|ownerRef| Job
+
+    PodGroup -.->|via <br/> podGroupTemplateRef| Workload
+
+    linkStyle 5 stroke:#888,color:#888
 ```
 
 - The `Workload` object has an ownerReference to the `Job` object with `controller: true` in case 
   it was created by the Job controller.
-- The `PodGroup` object has an ownerReference to the `Job` object with `controller: true` in case 
-  it was created by the Job controller and another ownerReference to the `Workload` object.
+- The `PodGroup` object links to a `Workload` via `spec.podGroupTemplateRef`. When created 
+by the Job controller it carries a controller ownerReference to the `Job`. A parent-owned 
+`Workload` is never given an ownerReference from the `PodGroup`.
 - The `Pod` object has an ownerReference to the `Job` object with `controller: true` and another 
   ownerReference to the `PodGroup` object
 
@@ -769,7 +773,9 @@ This is a controller-side resolution that is required to resolve the unset case 
 - **`Scheduling` set but `Policy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
   discriminated union for which the compiled `PodGroup` must carry exactly one concrete policy, so a
   nil `Policy` is resolved to `Basic`.
-- **`Gang` with `MinCount` unset → `MinCount = parallelism`.** a context-aware sane gang size supplied via `DefaultGangMinCount`.
+- **`Gang` with `MinCount` unset → `MinCount = parallelism`.** Done controller-side only 
+without persisting the derived value back onto the Job spec because writing it back would make a 
+user-set `minCount` indistinguishable from the default on later updates, where `minCount` is mutable.
 
 Optional modifiers (`DisruptionMode`, `Constraints`, `ResourceClaims`) are deliberately not
 defaulted. Unlike `Policy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `Constraints`
@@ -818,7 +824,7 @@ In either case, the Job controller reconciles the change as follows:
 
 1. **Detection:** the Job controller's reconcile loop detects the change and fetches the existing
    `Workload` resource from the API server.
-2. **Workload Compilation:** it builds a fresh single-node `WorkloadNode` tree from the updated
+2. **Workload Compilation:** it builds a fresh single-node `WorkloadItem` tree from the updated
    `spec.parallelism`/`minCount` and passes it to the `workloadbuilder` library to compile a fresh
    `Workload` object.
 3. **Workload Update:** the controller applies the newly compiled `Workload` spec to the existing

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -9,11 +9,11 @@
 - [Proposal](#proposal)
   - [Job Integration - API Usage Examples](#job-integration---api-usage-examples)
     - [Example 1: Gang scheduling with zone topology and atomic disruption](#example-1-gang-scheduling-with-zone-topology-and-atomic-disruption)
-    - [Example 2: Backward Compatibility and Sane Defaulting (Implicit Opt-Out)](#example-2-backward-compatibility-and-sane-defaulting-implicit-opt-out)
+    - [Example 2: Backward Compatibility and Defaulting (Implicit Opt-Out)](#example-2-backward-compatibility-and-defaulting-implicit-opt-out)
     - [Example 3: CronJob with Gang Scheduling](#example-3-cronjob-with-gang-scheduling)
   - [User Stories](#user-stories)
     - [ML Training Job with Gang Scheduling](#ml-training-job-with-gang-scheduling)
-    - [Standard Batch Job with Workload Tracking](#standard-batch-job-with-workload-tracking)
+    - [Backward-Compatible Standard Batch Job](#backward-compatible-standard-batch-job)
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
     - [Alpha Constraints](#alpha-constraints)
   - [Risks and Mitigations](#risks-and-mitigations)
@@ -23,7 +23,6 @@
     - [Go Package Placement &amp; Graduation](#go-package-placement--graduation)
   - [Integration with the workloadbuilder Library](#integration-with-the-workloadbuilder-library)
     - [Library Dependency and Packaging](#library-dependency-and-packaging)
-    - [Division of Responsibilities](#division-of-responsibilities)
     - [Building the Logical Tree and Compiling the <code>Workload</code>](#building-the-logical-tree-and-compiling-the-workload)
     - [API Validation via the <code>workloadbuilder</code> Library](#api-validation-via-the-workloadbuilder-library)
     - [Instantiating the runtime <code>PodGroup</code>](#instantiating-the-runtime-podgroup)
@@ -86,7 +85,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 ## Summary
 
 This KEP integrates the Workload-aware Scheduling (WAS) APIs (`Workload` and `PodGroup`) into the
-batch/v1` Job by adding a user-facing `spec.scheduling` field, allowing users to express explicit
+`batch/v1` Job by adding a user-facing `spec.scheduling` field, allowing users to express explicit
 scheduling intent such as gang scheduling[^1], topology co-location, and disruption policies.
 
 The first alpha, introduced in v1.36, intentionally bypassed this user-facing API: the controller inferred a
@@ -98,8 +97,8 @@ and the shared `workloadbuilder` translation library defined in [KEP-6089], keep
 integration consistent with the rest of the ecosystem rather than reinventing bespoke logic.
 
 The Job controller acts as a translator, compiling `spec.scheduling` into the underlying
-`Workload`/`PodGroup` objects. When `spec.scheduling` is omitted, it defaults to standard
-pod-by-pod (`Basic`) scheduling, so the scheduling outcome of existing Jobs is preserved. The Job
+`Workload`/`PodGroup` objects. When `spec.scheduling` is omitted, it defaults to `Basic` 
+scheduling, so the scheduling outcome of existing Jobs is preserved. The Job
 integration remains in Alpha for the v1.37 cycle, allowing the user-facing API to be validated
 before graduation.
 
@@ -124,10 +123,11 @@ gaps of the initial alpha.
 - Add a user-facing `spec.scheduling` (`JobSchedulingConfiguration`) field to the `batch/v1` Job,
   embedding the `scheduling.k8s.io/v1alpha3` building blocks (`policy`, `constraints`,
   `disruptionMode`, `resourceClaims`) so users can express explicit scheduling intent.
-- Default to `Basic` (standard pod-by-pod) scheduling when `spec.scheduling` is omitted, so the
-  runtime scheduling behavior of existing Jobs is unchanged (implicit opt-out from gang). Following
-  the [KEP-6089] "Universal Representation" principle, the controller still materializes a `Basic`
-  `Workload`/`PodGroup` for these Jobs.
+- Default to `Basic` scheduling when `spec.scheduling` is omitted, so the observable scheduling 
+  outcome of existing Jobs is preserved (no all-or-nothing gate, and any number of schedulable 
+  pods proceed to binding). Following the [KEP-6089], the controller still materializes a `Basic`
+  `Workload`/`PodGroup`, which routes these pods through the Workload Scheduling Cycle 
+  (batched scheduling and workload-aware preemption) without enforcing minCount.
 - Let users opt in to `Gang` scheduling, with `minCount` defaulting to `parallelism` (or
   `completions` when parallelism is unset) when omitted.
 - Compile `spec.scheduling` into `Workload`/`PodGroup` objects via the shared `workloadbuilder`
@@ -135,9 +135,12 @@ gaps of the initial alpha.
 - Support mutable `spec.scheduling.policy.gang.minCount` for elastic scaling, while keeping all
   other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
   `minCount` in `PodGroup`/`PodGroupTemplate` mutable in v1.37 to support workload scaling.
-- Skip `Workload`/`PodGroup` creation when a higher-level controller owns the workload (the Job
-  carries an `OwnerReference` to a parent controller that itself creates and manages the
-  `Workload`), preserving the root-controller-as-compiler principle.
+- When the Job is not the root of the workload tree (the `OwnerReference` refers to a parent
+  controller that compiles and owns the `Workload`), defer `Workload` management to that parent,
+  preserving the root-controller-as-compiler principle. A parent may own the `Workload` while still
+  delegating `PodGroup` management to the Job (e.g., a `Job` running under a `TrainJob` that does not
+  know about Jobs). The parent signals this split via [KEP-6089]'s downward-mapping annotations, so 
+  a non-root controller can still create and manage the `PodGroup` for its own pods.
 - Ensure proper ordering of `Workload` → `PodGroup` → `Pod` creation.
 
 ### Non-Goals
@@ -166,8 +169,10 @@ through a new `spec.scheduling` field.
 
 The key design principles for this alpha are:
 
-- One `Job` maps to one `Workload` with one `PodGroup` representing a single homogeneous group of
-  pods (a flat, single-level structure).
+- One `Job` maps to one `PodGroup` representing a single homogeneous group of pods (a flat,
+  single-level structure). For a root Job, the controller also compiles the enclosing `Workload`;
+  for a non-root Job whose parent owns the `Workload`, that single `PodGroup` instead attaches to
+  the parent's compiled `Workload`/`CompositePodGroup`.
 - The scheduling policy comes from the user's `spec.scheduling`, not from the Job's type. When
   `spec.scheduling` is omitted, the controller defaults to the `Basic` policy.
 - Following the [KEP-6089], the controller always materializes a `Workload`/`PodGroup` for an 
@@ -175,9 +180,13 @@ The key design principles for this alpha are:
 - For `Gang`, an omitted `minCount` defaults to the Job's `parallelism` (or `completions` when
   parallelism is unset). `minCount` is mutable to support elastic scaling; all other
   `spec.scheduling` fields are immutable after creation.
-- The Job controller does not create `Workload`/`PodGroup` when the Job carries an `OwnerReference`
-  to a parent controller that manages the `Workload` (e.g., `JobSet`). Such controllers set this
-  `OwnerReference` when they create the Job.
+- The Job controller does not create a `Workload` when the Job carries an `OwnerReference` to a
+  parent controller that compiles and owns the `Workload` (e.g., `JobSet`). Such controllers set
+  this `OwnerReference` when they create the Job. Whether the Job controller also skips `PodGroup`
+  creation depends on what the parent delegates: if the parent injects the annotation 
+  ([KEP-6089]), the Job controller still creates and manages the runtime `PodGroup` for its own 
+  pods, mapping them to the parent's named `PodGroupTemplate` and attaching to the parent instance. 
+  If no such annotation is present, the parent owns both objects and the Job controller skips both.
 - Jobs created by `CronJob` are standalone (no parent-workload `OwnerReference`); the Job controller
   creates one `Workload` and one `PodGroup` per Job for them based on each Job's `spec.scheduling`.
 
@@ -271,12 +280,11 @@ spec:
       minCount: 4
 ```
 
-#### Example 2: Backward Compatibility and Sane Defaulting (Implicit Opt-Out)
+#### Example 2: Backward Compatibility and Defaulting (Implicit Opt-Out)
 
-A standard Job that omits the `scheduling` block. It defaults to `Basic` scheduling, so its pods are
-scheduled pod-by-pod exactly as before. Per the [KEP-6089], the controller still materializes a 
-`Basic` scheduling policy (which can be used for tracking), but no all-or-nothing or topology 
-constraint is applied:
+A standard Job that omits the `scheduling` block. It defaults to `Basic` scheduling. Per 
+the [KEP-6089], the controller does not impose all-or-nothing, so the scheduling 
+outcome matches a standard Job (batched scheduling cycle, no minCount enforcement):
 
 ```yaml
 apiVersion: batch/v1
@@ -287,8 +295,8 @@ metadata:
 spec:
   parallelism: 10
   completions: 10
-  # The scheduling block is omitted, which defaults to Basic (pod-by-pod)
-  # scheduling. This acts as an implicit opt-out from gang scheduling.
+  # The scheduling block is omitted, which defaults to Basic scheduling. 
+  # This acts as an implicit opt-out from gang scheduling.
   template:
     spec:
       containers:
@@ -417,26 +425,26 @@ topology constraint to co-locate the workers), so that if only 7 workers can be 
 start and no resources are wasted. I do not have to set `parallelism` and `completions`
 in a specific way to "qualify" for gang scheduling; I declare my intent explicitly.
 
-#### Standard Batch Job with Workload Tracking
+#### Backward-Compatible Standard Batch Job
 
 As a data engineer, I want to run a batch processing job that processes files independently without
-gang scheduling requirements. I omit `spec.scheduling` entirely, so the Job defaults to `Basic`
-(pod-by-pod) scheduling and behaves exactly as it does today. A `Basic` scheduling policy is
-set for the Job, giving me a consistent objects to observe its scheduling state without
-changing how the pods are scheduled.
+gang scheduling requirements. I omit `spec.scheduling` entirely (or set `spec.scheduling.policy.basic`
+explicitly for the same effect), so the Job defaults to `Basic` scheduling. The observable scheduling
+outcome matches a standard Job, while a `Basic` `Workload`/`PodGroup` is still materialized, giving me consistent objects to observe its scheduling state.
 
 ### Notes/Constraints/Caveats
 
 #### Alpha Constraints
 
-- The alpha targets single-level `Job` workloads: one `Job` maps to one `Workload` with one `PodGroup`, 
-  and all pods in the `Job` share a single scheduling policy. Elastic scaling is supported through the 
-  mutable `gang.minCount`.
+- The alpha targets single-level `Job` workloads: one `Job` maps to one `PodGroup`, and all pods in
+  the `Job` share a single scheduling policy. Elastic scaling is supported through the mutable `gang.minCount`.
 - `spec.scheduling.policy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
   other `spec.scheduling` fields are immutable after creation.
-- Opting out of WAS object creation happens implicitly in two ways: omitting `spec.scheduling`
-  yields `Basic` (the controller still owns the objects), and a Job whose parent controller manages
-  the `Workload` is skipped entirely.
+- Opting out of `Workload` creation happens implicitly in two ways: omitting `spec.scheduling`
+  still yields a controller-owned `Basic` `Workload`/`PodGroup`, while a Job whose parent owns the
+  `Workload` does not create its own `Workload`. In the latter case, the Job controller still
+  creates the runtime `PodGroup` when the parent delegates it via annotation ([KEP-6089]), and 
+  skips the `PodGroup` too only when the parent owns both objects.
 
 ### Risks and Mitigations
 
@@ -444,13 +452,15 @@ changing how the pods are scheduled.
   may expose its own scheduling fields while the child `Job` now also has native `spec.scheduling`
   fields, letting a user configure scheduling in two conflicting places. 
   * *Mitigation:* the parent controller remains the sole compiler of the workload tree and can map 
-  its own fields onto thecompiled `Workload`, strip/ignore the child's nested scheduling fields, 
-  or reject requests that populate both. The Job controller cooperates by skipping 
-  `Workload`/`PodGroup` creation whenever the Job carries an `OwnerReference` to a registered 
-  parent workload (replacing the v1.36 `spec.template.spec.schedulingGroup`-based opt-out).
+  its own fields onto the compiled `Workload`, strip/ignore the child's nested scheduling fields, 
+  or reject requests that populate both. The Job controller cooperates by deferring `Workload`
+  ownership whenever the Job carries an `OwnerReference` to a registered parent workload (replacing
+  the v1.36 `spec.template.spec.schedulingGroup`-based opt-out). The parent then decides whether 
+  the Job also defers `PodGroup` creation or manages its own `PodGroup` mapped to the parent's 
+  `PodGroupTemplate`.
 
 - **Increased object count.** Because the controller now materializes a `Workload`/`PodGroup` for
-  every eligible Job (Universal Representation), the number of scheduling objects grows relative to
+  every eligible Job, the number of scheduling objects grows relative to
   the v1.36 alpha, which only created objects for inferred gang Jobs. 
   * *Mitigation:* objects are small and garbage-collected with the Job; the Scalability section 
   quantifies the impact, and the feature stays behind the `WorkloadWithJob` feature gate for alpha.
@@ -460,9 +470,11 @@ changing how the pods are scheduled.
   * *Mitigation:* gang is now an explicit opt-in; this is documented in the 
   [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy) and release notes.
 
-- **Suspended Jobs and resource release** rely only on GC, which does not address releasing
-  resources (DRA) while a Job is suspended. This is acceptable for alpha. Future work may require
-  the controller to delete `PodGroup`/`Workload` on suspend and recreate on resume.
+- **Suspended Jobs and resource release.** In alpha the controller relies only on GC, which does not
+  release resources (e.g., DRA claims) while a Job is suspended. This is acceptable for alpha.
+  * *Mitigation:* it is a committed [Beta requirement](#beta) for the controller to delete
+  `PodGroup`/`Workload` on suspend and recreate them on resume, so that resources are released and
+  the scheduler can make fresh placement decisions.
 
 ## Design Details
 
@@ -473,21 +485,19 @@ single-level `Job`:
 
 - **The Root Controller is the Compiler.** For a standalone `Job`, the Job controller is the
   root-most controller and is responsible for compiling, creating, and managing the
-  scheduler-facing `Workload` and its runtime `PodGroup`. When a `Job` instead carries an
-  `OwnerReference` to a parent controller that manages the `Workload` (e.g., a `JobSet` owns the Job),
-  the Job controller observes that linkage and *bypasses* creating any `Workload`, so the parent
-  remains the single source of truth.
-- **Separation of Structure and Policy.** The `Job` spec owns the workload *structure*
-  (`parallelism`, `completions`, the pod template); the user owns the scheduling *policy* via
-  `spec.scheduling`. The Job controller acts as the translator that combines the two and compiles
-  the low-level `Workload`/`PodGroup` for the scheduler.
+  scheduler-facing `Workload`. When a `Job` instead carries an `OwnerReference` to a parent 
+  controller that compiles the `Workload` (e.g., `JobSet`), the Job controller observes 
+  that linkage and *bypasses* compiling the `Workload`, so the parent remains the single 
+  source of truth for workload structure and policy. Ownership of the runtime `PodGroup` 
+  is decided separately and is not necessarily transferred with the `Workload`. Only in 
+  the delegated case the Job controller creates and manages the `PodGroup` for its own 
+  pods even though it does not own the `Workload`.
 - **Universal Representation.** Standard pod-by-pod scheduling is a first-class policy (`Basic`).
   The controller always emits a `Workload`/`PodGroup` for an eligible Job, using `Basic` as the
-  backward-compatible default. `Basic` keeps the standard scheduling outcome and does not impose
-  all-or-nothing semantics.
+  backward-compatible default. `Basic` keeps the standard scheduling outcome, while still 
+  participating in the Workload Scheduling Cycle, without enforcing minCount.
 - **Sane Defaults and Escape Hatches.** A `Job` defaults to `Basic`. Users can opt in to `Gang`,
-  request topology constraints, and configure disruption modes; an escape hatch lets a user request
-  topology-only co-location while keeping the `Basic` policy.
+  request topology constraints, and configure disruption modes.
 
 ### Job API Changes
 
@@ -555,45 +565,12 @@ The Job controller compiles `spec.scheduling` into a `Workload` using the `workl
 
 #### Library Dependency and Packaging
 
-The `workloadbuilder` library lives alongside the `scheduling.k8s.io/v1alpha3` types so it 
-can be vendored by both in-tree controllers (the Job controller, here) and out-of-tree 
-controllers. The Job controller depends on it as a normal package import; this KEP does 
-not define or fork the library, it only consumes its `NewBuilder`/`Build`, `WorkloadNode`, 
-and `MapPodGroupConfig` surface. If the library API shifts before it stabilizes, the Job 
-integration tracks those changes through the shared dependency rather than maintaining 
-its own copy.
-
-#### Division of Responsibilities
-
-The boundary between the library and the Job controller is explicit.
-
-The `workloadbuilder` library is responsible for:
-
-  * Defining the polymorphic, hierarchy-agnostic intermediate representation (IR)
-  (`SchedulingConfig`, `WorkloadNode`) that the Job controller populates.
-  * Merging the controller-supplied defaults (`DefaultConfig`, `DefaultGangMinCount`) with the user's
-  `UserConfig`, including escape-hatch resolution.
-  * Validating the resolved configuration via a `Validate` entrypoint, which runs the same resolution
-  and policy validation as `Build` and rejects invalid combinations early (e.g. an unsupported
-  disruption mode). The API server calls `Validate` directly for semantic validation; this
-  complements, and does not replace, the API-server's structural and immutability validation on
-  `spec.scheduling`.
-  * Emitting the `scheduling.k8s.io/v1alpha3` `Workload` object (the scheduling template, including its
-  `PodGroupTemplate`) via `Build`.
-
-The Job controller is responsible for:
-
-  * Choosing the batch-specific defaults — `Basic` scheduling and a fallback gang size of
-  `spec.parallelism` and passing them to the library.
-  * Mapping `spec.scheduling` into the library IR with the leaf helper `MapPodGroupConfig`.
-  * Instantiating the runtime `PodGroup` from the compiled `Workload`, since `Build` only produces the
-    `Workload` template.
-  * Discovery, ownerReferences, garbage collection, and object creation ordering, as described in
-  [Job Controller Changes](#job-controller-changes).
-
-Because a standalone `Job` is a single-level workload, the controller builds a **flat, single-node**
-`WorkloadNode` tree (`len(Children) == 0`) and uses the leaf mapping helper (`MapPodGroupConfig`); it
-never uses `MapCompositeGroupConfig`, which is reserved for multi-level controllers.
+The `scheduling.k8s.io/v1alpha3` building-block types live in the API staging repo
+(`k8s.io/api/scheduling/v1alpha3`). The `workloadbuilder` library lives separately in
+`k8s.io/component-helpers`, so it can be vendored by both in-tree controllers and out-of-tree 
+controllers. The Job controller consumes its `NewBuilder`/`Build`, `WorkloadNode`, and 
+`MapPodGroupConfig`. If the library API shifts before it stabilizes, the Job integration 
+tracks those changes through the shared dependency rather than maintaining its own copy.
 
 #### Building the Logical Tree and Compiling the `Workload`
 
@@ -605,27 +582,6 @@ The controller's `generateWorkload` helper performs four steps:
   4. Invoke `Build`, passing the Job's identity and a controller `OwnerReference` so the emitted
     `Workload` is owned by the Job and garbage-collected with it.
 
-```
-func (r *JobReconciler) generateWorkload(
-    job *batchv1.Job,
-) (*Workload, error) {
-    // Default to Basic (standard pod-by-pod) scheduling.
-    defaultConfig = SchedulingConfig{Policy: Basic}
-
-    // Map the user's spec.scheduling into the workloadbuilder library IR.
-    userConfig = MapPodGroupConfig(job.Spec.Scheduling)
-
-    // Build a single-node logical tree (one PodGroup per Job).
-    rootNode = WorkloadNode{
-        DefaultConfig:       defaultConfig,
-        DefaultGangMinCount: job.Spec.Parallelism, // defaults to parallelism if MinCount is nil
-        UserConfig:          userConfig,
-    }
-
-    // Compile and emit the Workload object, owned by this Job.
-    return NewBuilder(rootNode).Build(job.Name, job.Namespace, ownerRef=job)
-}
-```
 
 #### API Validation via the `workloadbuilder` Library
 
@@ -634,8 +590,12 @@ func (r *JobReconciler) generateWorkload(
 1. **api-server validation** owns the structural and *mutability* rules. It runs on every 
   create/update and must be self-contained (no dependency on cluster state or other 
   live objects). It checks:
-   * exactly one scheduling policy is set (`basic` xor `gang`);
-   * `gang.minCount`, when set, is `>= 1`;
+   * exactly one scheduling policy is set (`basic` xor `gang`).
+   * `gang.minCount`, when set, is `>= 1`and does not exceed `spec.parallelism`. A gang 
+   larger than the pod count can never be satisfied and the Job would stall indefinitely 
+   with pending pods, so this faulty state is rejected at admission rather than left to 
+   surface only at runtime. An elastic scale-up that sets `spec.parallelism` and 
+   `gang.minCount` in the same request is validated against the final state.
    * topology constraints, disruption mode, and resourceClaims are individually well-formed;
    * on update, every `spec.scheduling` field is immutable **except** `gang.minCount`.
 2. **`workloadbuilder` semantic validation** owns the *consistency* rules. The API server calls the
@@ -658,38 +618,6 @@ so the controller creates one `PodGroup` that references the template and carrie
 ownerReferences — a controller ref to the `Job` (so it is GC'd with the Job) and a non-controller
 ref to the `Workload`:
 
-```go
-func (r *JobReconciler) instantiatePodGroup(
-    job *batchv1.Job,
-    workload *schedulingv1alpha3.Workload,
-) (*schedulingv1alpha3.PodGroup, error) {
-    // Alpha supports exactly one PodGroupTemplate per Job-owned Workload.
-    if len(workload.Spec.PodGroups) != 1 {
-        return nil, fmt.Errorf("unsupported Workload structure: expected 1 PodGroupTemplate, got %d",
-            len(workload.Spec.PodGroups))
-    }
-    tmpl := workload.Spec.PodGroups[0]
-
-    pg := &schedulingv1alpha3.PodGroup{
-        ObjectMeta: metav1.ObjectMeta{
-            Name:      podGroupName(workload.Name, tmpl.Name),
-            Namespace: job.Namespace,
-            OwnerReferences: []metav1.OwnerReference{
-                *metav1.NewControllerRef(job, jobKind),         // controller: true
-                workloadOwnerRef(workload),                     // controller: false
-            },
-        },
-        Spec: schedulingv1alpha3.PodGroupSpec{
-            // Link the runtime instance back to its template in the Workload.
-            PodGroupTemplateReference: schedulingv1alpha3.PodGroupTemplateReference{
-                Workload: schedulingv1alpha3.WorkloadReference{WorkloadName: workload.Name},
-                Name:     tmpl.Name,
-            },
-        },
-    }
-    return pg, nil
-}
-```
 
 Pods are then created by the existing Job pod-management logic with
 `pod.Spec.SchedulingGroup.PodGroupName` set to the `PodGroup`'s name, which is what the scheduler
@@ -748,10 +676,18 @@ via informers/listers and continue.
 
 The controller discovers or creates `Workload` and `PodGroup` as follows:
 
-1. If the Job carries an `OwnerReference` to a parent controller that manages the `Workload`
-   (i.e., a higher-level controller such as `JobSet` that compiles and owns the workload tree),
-   skip `Workload`/`PodGroup` creation entirely since the parent owns them. The controller still
-   discovers any existing objects and uses them when creating pods.
+1. If the Job carries an `OwnerReference` to a parent controller that owns the `Workload` 
+(i.e., `JobSet`), the Job controller does not create a `Workload` (skip step 3 and step 4). 
+It then branches on whether the parent delegates `PodGroup` management, detected via the 
+`scheduling.k8s.io/podgroup-template` annotation on the Job:
+   - **Annotation present (PodGroup delegated):** the parent owns the `Workload` but expects the Job
+     to manage its own runtime `PodGroup`. Proceed to step 5, creating the `PodGroup` mapped to the
+     parent's named `PodGroupTemplate` (annotation value) and attaching it to the parent instance
+     named by `scheduling.k8s.io/parent-composite-podgroup`. The `PodGroup` gets a controller
+     `ownerReference` to the Job.
+   - **Annotation absent (both delegated):** the parent owns both the `Workload` and the `PodGroup`.
+     The Job controller skips creation entirely, discovers any existing objects, and uses them when
+     creating pods.
 2. If the Job already has pods (active or terminal pods owned by this Job), skip creation and only
    discover existing objects.
 3. Look up existing `Workload`(s) in the Job's namespace whose `spec.controllerRef` points to this
@@ -764,13 +700,14 @@ The controller discovers or creates `Workload` and `PodGroup` as follows:
 4. When creating a new `Workload`, the controller derives the scheduling policy from the Job's
    `spec.scheduling` rather than from the Job's type. It maps `spec.scheduling` into the
    `workloadbuilder` library, which applies the defaulting rules (defaulting to `Basic`, defaulting
-   `Gang.minCount` to `parallelism`) and compiles the `Workload`. Per the Universal Representation
-   principle, this happens for every eligible Job, including those that default to `Basic`.
+   `Gang.minCount` to `parallelism`) and compiles the `Workload`. This happens for every eligible Job, including those that default to `Basic`.
 5. Look up `PodGroup`(s) in the Job's namespace whose `podGroup.spec.podGroupTemplateRef` is
-   associated with the `Workload` for this Job. If the `PodGroup` was created by the Job controller,
-   it has two ownerReferences: the Job controller and the `Workload` object.
-  - If none found, create a `PodGroup` with an ownerReference to the `Job` (`controller: true`) and
-    another ownerReference to the `Workload`.
+   associated with the target `PodGroupTemplate` for this Job. For a root Job that template lives in
+   the Job-owned `Workload` while a delegated non-root Job (step 1, annotation present) it is the
+   parent's `PodGroupTemplate`.
+  - If none found, create a `PodGroup` with a controller `ownerReference` to the `Job`. For a root
+    Job, also add an `ownerReference` to the Job-owned `Workload`; for a delegated Job, link it to
+    the parent instance named by `scheduling.k8s.io/parent-composite-podgroup` instead.
   - If exactly one, that is the `PodGroup` for this Job; no changes to its `ownerReference`.
   - If multiple PodGroups, fall back as that is not supported in alpha.
 6. Execute the existing pod-management logic to create pods, including `schedulingGroup.podGroupName`
@@ -935,18 +872,26 @@ to implement this enhancement.
   - `workloadbuilder` compilation: `Basic` vs `Gang` policy, and that topology constraints,
     disruption mode (single/all), and resourceClaims are mapped into the generated `Workload`/
     `PodGroup`; that a `Job` builds a flat single-node tree via `MapPodGroupConfig`.
-  - Universal Representation: a `Basic` `Workload`/`PodGroup` IS created for a Job with
-    `spec.scheduling` omitted.
+  - A `Basic` `Workload`/`PodGroup` is created for a Job with `spec.scheduling` omitted.
   - pod creation includes the correct `schedulingGroup`.
   - Mutability/validation: updates to `spec.scheduling.policy.gang.minCount` are allowed; updates to
     any other `spec.scheduling` field are rejected.
+  - `gang.minCount > spec.parallelism` is rejected on both create and update. A single 
+  request that raises `spec.parallelism` and `gang.minCount` together is accepted.
   - Feature gate disabled: `spec.scheduling` is dropped on create and no `Workload`/`PodGroup` is
     created.
-  - Jobs with an `OwnerReference` to a parent workload do not create `Workload`/`PodGroup`.
+  - Parent-owned `Workload`, both delegated: a Job with an `OwnerReference` to a parent workload and
+    no annotation creates neither `Workload` nor `PodGroup`.
+  - Parent-owned `Workload`, `PodGroup` delegated: a Job with an `OwnerReference` to a parent
+    workload and the annotation present does not create a `Workload`, but does create a `PodGroup` 
+    mapped to the parent's named `PodGroupTemplate` and linked to the
+    parent instance from `scheduling.k8s.io/parent-composite-podgroup`.
   - Job deletion cascades to `Workload` and `PodGroup` deletion.
-  - ownerReferences on controller-created `Workload` and `PodGroup` match the expected structure:
-    - `Workload` has a controller ownerRef to the Job.
-    - `PodGroup` has a controller ownerRef to the Job and a non-controller ownerRef to the `Workload`.
+  - ownerReferences on controller-created objects match the expected structure:
+    - Root Job: `Workload` has a controller ownerRef to the Job; `PodGroup` has a controller ownerRef
+      to the Job and a non-controller ownerRef to the `Workload`.
+    - Delegated Job: `PodGroup` has a controller ownerRef to the Job and links to the parent-owned
+      `Workload`/`CompositePodGroup` (no Job-owned `Workload` exists).
   - Naming abbreviations for `Workload` and `PodGroup`.
 
 ##### Integration tests
@@ -961,8 +906,10 @@ We will add the following integration tests to the Job controller (`test/integra
   `spec.scheduling` appear in the compiled `Workload`/`PodGroup`.
 - Failure Recovery test (create a Job while the `Workload` API is unavailable, verify the controller
   retries and the `Workload` is eventually created).
-- Feature gate disable/enable (Jobs work without `Workload`/`PodGroup` creation; Jobs with an
-  `OwnerReference` to a parent workload do not create `Workload`/`PodGroup`).
+- Feature gate disable/enable (Jobs work without `Workload`/`PodGroup` creation).
+- A Job owned by a parent workload skips `Workload` creation and skips `PodGroup`
+  creation when no annotation is set, but creates a `PodGroup`
+  mapped to the parent's `PodGroupTemplate` when the annotation is present.
 - Jobs created by CronJob get one `Workload` and one `PodGroup` per Job, and these are GC'd when the
   Job completes or is deleted.
 - When a Job is suspended, pods are deleted but `Workload`/`PodGroup` remain; on resume the same
@@ -972,12 +919,13 @@ We will add the following integration tests to the Job controller (`test/integra
 ##### e2e tests
 
 - End-to-end gang scheduling: all pods are scheduled together or none.
-- `Basic` Jobs schedule pod-by-pod while still producing a `Workload`/`PodGroup`.
+- `Basic` scheduling policy: pods are scheduled through the same Workload Scheduling Cycle as gang 
+scheduling, without enforcing minCount.
 - Elastic gang resize via `minCount` update.
 - Mixed workloads: gang and basic Jobs coexist.
 - Failure scenarios, e.g., insufficient resources for a gang, partial failures.
-- CronJob with gang scheduling: each Job created by the CronJob gets its own `Workload`/`PodGroup`,
-  and completed Jobs clean up their scheduling objects via GC.
+- CronJob with gang scheduling: each Job created by the CronJob gets its own `Workload`/`PodGroup` 
+and completed Jobs clean up their scheduling objects via GC.
 
 ### Graduation Criteria
 
@@ -999,12 +947,13 @@ This second alpha replaces the automatic model with the user-facing API:
   existing `WorkloadWithJob` feature gate (still default-disabled).
 - The Job controller compiles `spec.scheduling` into `Workload`/`PodGroup` via the shared
   `workloadbuilder` library, defaulting to `Basic` and materializing a `Workload`/`PodGroup` for
-  every eligible Job (Universal Representation).
+  every eligible Job.
 - `Gang` opt-in with `minCount` defaulting to `parallelism`, plus support for mutable `minCount`
   (elastic scaling) and passthrough of topology constraints, disruption mode, and resourceClaims.
 - API validation makes `spec.scheduling` fields immutable except `gang.minCount`; the v1.36
   `spec.parallelism`-rejection validation is removed.
-- Jobs owned by a higher-level controller (via `OwnerReference`) skip `Workload`/`PodGroup` creation.
+- Jobs owned by a higher-level controller (via `OwnerReference`) defer `Workload` ownership to the
+  parent; they manage their own `PodGroup` when the parent delegates it via the annotation, and skip both objects otherwise.
 - Unit and integration tests for the new API, defaulting, mutability, and `workloadbuilder`
   compilation; user-facing documentation for the new API.
 
@@ -1113,9 +1062,8 @@ Yes. When the feature gate is enabled:
 
 1. The `batch/v1` `spec.scheduling` field becomes available; the API server persists it and defaults
    it to the `Basic` policy when omitted.
-2. The Job controller compiles `spec.scheduling` into a `Workload` and `PodGroup` for every eligible Job
-   (one not owned by a higher-level controller) before creating pods — including `Basic` Jobs
-   (Universal Representation).
+2. The Job controller compiles `spec.scheduling` into a `Workload` and `PodGroup` for every root Job
+   (one that owns its `Workload`) before creating pods — including `Basic` Jobs.
 3. Jobs that set `spec.scheduling.policy.gang` use gang scheduling, meaning all `minCount` pods must
    be scheduled together or none are scheduled.
 4. The binding of pods referencing a `PodGroup` is delayed until the `PodGroup` object exists.
@@ -1222,11 +1170,14 @@ No.
 
 Yes. The Job controller uses informers and listers for `Workload` and `PodGroup` for lookups 
 and watches. The following additional API calls are made when this feature is enabled, for 
-every eligible Job (one not owned by a higher-level controller), including `Basic` Jobs due 
-to Universal Representation:
+every root Job (one that owns its `Workload`), including `Basic` Jobs:
 - `CREATE Workload` - 1 per Job creation
 - `CREATE PodGroup` - 1 per Job creation
 - `UPDATE Workload`/`PodGroup` - on `gang.minCount` (or `parallelism`-driven) elastic resize
+
+A non-root Job whose parent owns the `Workload` but delegates the `PodGroup` makes only 
+the `CREATE PodGroup` call (no `Workload`). A non-root Job where the parent owns both 
+objects makes none of these calls.
 
 ###### Will enabling / using this feature result in introducing new API types?
 

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -7,6 +7,9 @@
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
+  - [Job Integration - API Usage Examples](#job-integration---api-usage-examples)
+    - [Example 1: Gang scheduling with zone topology and atomic disruption](#example-1-gang-scheduling-with-zone-topology-and-atomic-disruption)
+    - [Example 2: Backward Compatibility and Sane Defaulting (Implicit Opt-Out)](#example-2-backward-compatibility-and-sane-defaulting-implicit-opt-out)
   - [User Stories](#user-stories)
     - [ML Training Job with Gang Scheduling](#ml-training-job-with-gang-scheduling)
     - [Standard Batch Job with Workload Tracking](#standard-batch-job-with-workload-tracking)
@@ -14,13 +17,26 @@
     - [Alpha Constraints](#alpha-constraints)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
+  - [Core Principles &amp; Assumptions](#core-principles--assumptions)
+  - [Job API Changes](#job-api-changes)
+    - [Go Package Placement &amp; Graduation](#go-package-placement--graduation)
+  - [Integration with the workloadbuilder Library](#integration-with-the-workloadbuilder-library)
+    - [Library Dependency and Packaging](#library-dependency-and-packaging)
+    - [Division of Responsibilities](#division-of-responsibilities)
+    - [Building the Logical Tree and Compiling the <code>Workload</code>](#building-the-logical-tree-and-compiling-the-workload)
+    - [API Validation via the <code>workloadbuilder</code> Library](#api-validation-via-the-workloadbuilder-library)
+    - [Instantiating the runtime <code>PodGroup</code>](#instantiating-the-runtime-podgroup)
+    - [Reconcile Integration and Error Handling](#reconcile-integration-and-error-handling)
   - [Job Controller Changes](#job-controller-changes)
     - [Workload and PodGroup Discovery](#workload-and-podgroup-discovery)
     - [Controller Workflow](#controller-workflow)
     - [OwnerReferences Relationship](#ownerreferences-relationship)
+    - [Defaulting Rules](#defaulting-rules)
     - [Object Creation Order](#object-creation-order)
-  - [Validation for Parallelism Changes](#validation-for-parallelism-changes)
+    - [Handling Updates and Mutability](#handling-updates-and-mutability)
+    - [Reconciliation Flow upon Updates](#reconciliation-flow-upon-updates)
   - [Naming Conventions](#naming-conventions)
+  - [Deletion and Garbage Collection](#deletion-and-garbage-collection)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
       - [Unit tests](#unit-tests)
@@ -28,6 +44,7 @@
       - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
     - [Alpha (v1.36)](#alpha-v136)
+    - [Alpha (v1.37)](#alpha-v137)
     - [Beta](#beta)
     - [GA](#ga)
     - [Deprecation](#deprecation)
@@ -59,7 +76,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
   - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
 - [ ] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
-- [ ] (R) Production readiness review completed
+- [x] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
@@ -67,48 +84,108 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 
 ## Summary
 
-This KEP introduces native integration between the Job controller and the gang scheduling[^1] APIs ([Workload](https://github.com/kubernetes/kubernetes/blob/release-1.35/pkg/apis/scheduling/types.go#L97) and [PodGroup](https://github.com/kubernetes/enhancements/pull/5833)).
+This KEP integrates the Workload-aware Scheduling (WAS) APIs (`Workload` and `PodGroup`) into the
+core `batch/v1` Job by adding a user-facing `spec.scheduling` field, letting users express explicit
+scheduling intent such as gang scheduling[^1], topology co-location, and disruption policies.
 
-The Job controller will automatically create `Workload` and `PodGroup` objects before creating pods for parallel Jobs, enabling native gang scheduling support in Kubernetes. 
+The first alpha was introduced in v1.36 intentionally bypassed this user-facing API: the controller inferred a
+hardcoded `Gang` policy from the Job's type (parallel Jobs with indexed completion mode), with `minCount`
+fixed to `parallelism`. This revision replaces that automatic, controller-inferred model with an
+explicit, user-driven design that separates scheduling *policy* (expressed by the user) from
+workload *structure* (owned by the Job API). It is built on the reusable scheduling building blocks
+and the shared `workloadbuilder` translation library defined in [KEP-6089], keeping the Job
+integration consistent with the rest of the ecosystem rather than reinventing bespoke logic.
+
+The Job controller acts as a translator, compiling `spec.scheduling` into the underlying
+`Workload`/`PodGroup` objects. When `spec.scheduling` is omitted, it defaults to standard
+pod-by-pod (`Basic`) scheduling, so the scheduling outcome of existing Jobs is preserved. The Job
+integration remains in Alpha for the v1.37 cycle, allowing the user-facing API to be validated
+before graduation.
 
 ## Motivation
 
-The Kubernetes Job Controller currently creates pods independently without workload-aware scheduling constraints. This creates challenges for parallel applications (i.e., AI/ML training workloads, MPI jobs) that require all pods to be scheduled and run together or none(gang scheduling[^1]). Since there is now a native mechanism to express gang scheduling requirements now via `Workload` and `PodGroup` APIs, this KEP brings gang scheduling feature to Job Controller by integrating these APIs directly into the Job controller lifecycle.
+The Kubernetes Job Controller historically created pods independently without workload-aware
+scheduling constraints. This is a challenge for parallel applications (i.e., AI/ML training
+workloads, MPI jobs) that require all pods to be scheduled and run together or none (gang
+scheduling[^1]). The v1.36 alpha brought gang scheduling to the Job controller, but it did so by
+inferring a hardcoded `Gang` policy from the Job's type rather than from explicit user intent.
+
+Users have diverse use cases and require the ability to express explicit intent, such as opting
+in or out of gang scheduling, requesting specific topologies, or configuring disruption policies
+for their workloads. [KEP-6089] standardizes the reusable scheduling building blocks
+(`scheduling.k8s.io/v1alpha3`) and a shared `workloadbuilder` translation library so that workload
+controllers can expose these features consistently. This KEP integrates those building blocks into
+the core `Job` API, "blazing the path" for the rest of the ecosystem while resolving the usability
+gaps of the initial alpha.
 
 ### Goals
 
-- Job controller automatically creates `Workload` and `PodGroup` objects for Jobs that require gang scheduling
-- Support opt-out mechanism to define when Job controller skips creating `Workload` and `PodGroup` objects
-- Use`GangSchedulingPolicy` with `minCount = parallelism` for Jobs with `parallelism > 1`, `completionMode: Indexed`, and `parallelism = completions`.
-- Jobs that don't qualify for gang scheduling will not have `Workload` and `PodGroup` objects created.
-- Ensure proper ordering of `Workload` and `PodGroup` creation before pods creation
-- Existing Jobs without gang scheduling continue to work normally
+- Add a user-facing `spec.scheduling` (`JobSchedulingConfiguration`) field to the `batch/v1` Job,
+  embedding the `scheduling.k8s.io/v1alpha3` building blocks (`policy`, `constraints`,
+  `disruptionMode`, `resourceClaims`) so users express explicit scheduling intent.
+- Default to `Basic` (standard pod-by-pod) scheduling when `spec.scheduling` is omitted, so the
+  runtime scheduling behavior of existing Jobs is unchanged (implicit opt-out from gang). Following
+  the [KEP-6089] "Universal Representation" principle, the controller still materializes a `Basic`
+  `Workload`/`PodGroup` for these Jobs.
+- Let users opt in to `Gang` scheduling, with `minCount` defaulting to `parallelism` (or
+  `completions` when parallelism is unset) when omitted.
+- Compile `spec.scheduling` into `Workload`/`PodGroup` objects via the shared `workloadbuilder`
+  library instead of bespoke controller logic.
+- Support mutable `spec.scheduling.policy.gang.minCount` for elastic scaling, while keeping all
+  other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
+  `minCount` in `PodGroup`/`PodGroupTemplate` mutable in v1.37 to support workload scaling.
+- Skip `Workload`/`PodGroup` creation when a higher-level controller owns the workload (the Job
+  carries an `OwnerReference` to a registered parent workload), preserving the
+  root-controller-as-compiler principle.
+- Ensure proper ordering of `Workload` → `PodGroup` → `Pod` creation.
 
 ### Non-Goals
 
-- Supporting dynamic changes to `minCount` or gang membership at runtime
-- Complex workload structures with multiple nested PodGroups are not supported in alpha.
-- Support for scaling up/down gang scheduling Jobs is not supported in alpha.
+- Multi-level / nested composite (`CompositePodGroup`) structures, since this KEP covers 
+  single-level, flat `Job` workloads only.
+- Implementing the integration in composite controllers (`JobSet`, `LWS`, `TrainJob`). Those 
+  are pursued independently in their own repositories.
+- Defining the `scheduling.k8s.io` building-block API or the `workloadbuilder` library 
+  itself (owned by [KEP-6089] and consumed here).
 
 ## Proposal
-> This KEP depends on:
-> - [KEP-4671: Gang Scheduling using Workload Object](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4671-gang-scheduling)
-> - [KEP-5832: Decouple PodGroup API from Workload API](https://github.com/kubernetes/enhancements/pull/5833)
 
-The Job controller will be extended to create `Workload` and `PodGroup` objects as part of its pod management lifecycle. 
-This integration ensures that pods belonging to a Job are scheduled according to the appropriate scheduling policy (gang or basic) before they are created. If `Job.spec.template.spec.schedulingGroup` is set, the Job controller does not create or update `Workload`/`PodGroup` (opt-out due to preexisting or parent-managed controller).
+This proposal builds on the recently introduced Workload-aware Scheduling enhancements. We assume
+the reader is acquainted with the following KEPs:
 
-For the alpha release, this feature is optimized for static batch workloads with a flat API structure where 
-`minCount` is immutable. The key design principles are:
-- One `Job` creates one `Workload` with one `PodGroup` representing a single homogeneous group of pods.
-- The automatic policy selection is based on `Job` Type
-  - Jobs with `parallelism > 1` , `completionMode: Indexed` and `parallelism = completions` use gang scheduling policy where `minCount` equals the Job's parallelism.
-  - Other Jobs  cases will not have `Workload` and `PodGroup` objects created and will keep scheduling as is (pod-by-pod scheduling).
-- Elastic Jobs (changing parallelism at runtime) are not supported when gang scheduling is active.
-- The Job controller does not create `Workload`/`PodGroup` when `Job.spec.template.spec.schedulingGroup` is set. Higher-level controllers that want to own the `Workload` and `PodGroup` (i.e., JobSet) set this field when they create the Job.
-- Jobs created by CronJob do not have `schedulingGroup` set, the Job controller creates one `Workload` and one `PodGroup` per Job for them if they match the gang scheduling criteria.
+- [KEP-4671]: Gang Scheduling.
+- [KEP-5710]: Workload-aware preemption.
+- [KEP-5732]: Topology-aware workload scheduling.
+- [KEP-6089]: WAS Controller APIs.
 
-An example of the Job and the corresponding `Workload`/`PodGroup` creation:
+The Job controller is extended to compile the user's scheduling intent into `Workload` and
+`PodGroup` objects as part of its pod-management lifecycle, so that pods belonging to a Job are
+scheduled according to the requested policy before they are created. The intent is expressed
+through a new `spec.scheduling` field.
+
+The key design principles for this alpha are:
+
+- One `Job` maps to one `Workload` with one `PodGroup` representing a single homogeneous group of
+  pods (a flat, single-level structure).
+- The scheduling policy comes from the user's `spec.scheduling`, not from the Job's type. When
+  `spec.scheduling` is omitted, the controller defaults to the `Basic` policy.
+- Following the [KEP-6089], the controller always materializes a `Workload`/`PodGroup` for an 
+  eligible Job, even for `Basic` scheduling policy.
+- For `Gang`, an omitted `minCount` defaults to the Job's `parallelism` (or `completions` when
+  parallelism is unset). `minCount` is mutable to support elastic scaling; all other
+  `spec.scheduling` fields are immutable after creation.
+- The Job controller does not create `Workload`/`PodGroup` when the Job carries an `OwnerReference`
+  to a registered parent workload. Higher-level controllers (e.g., `JobSet`) that own the
+  `Workload` set this when they create the Job.
+- Jobs created by `CronJob` are standalone (no parent-workload `OwnerReference`); the Job controller
+  creates one `Workload` and one `PodGroup` per Job for them based on each Job's `spec.scheduling`.
+
+### Job Integration - API Usage Examples
+
+#### Example 1: Gang scheduling with zone topology and atomic disruption
+
+A distributed training `Job` whose 4 pods must schedule together (all-or-nothing), co-locate within
+the same availability zone, and be disrupted together (if one pod is preempted, the whole group is):
 
 ```yaml
 apiVersion: batch/v1
@@ -117,9 +194,17 @@ metadata:
   name: <job-name>
   namespace: training
 spec:
-  parallelism: 8
-  completions: 8
+  parallelism: 4
+  completions: 4
   completionMode: Indexed
+  scheduling:               # New API field - scheduling intent
+    policy:
+      gang: {}              # minCount omitted -> defaults to parallelism (4)
+    constraints:
+      topology:
+        - level: "topology.kubernetes.io/zone"
+    disruptionMode:
+      all: {}               # entire group must be disrupted together
   template:
     spec:
       containers:
@@ -128,8 +213,12 @@ spec:
         resources:
           limits:
             nvidia.com/gpu: 1
----
-apiVersion: scheduling.k8s.io/v1alpha1
+```
+
+The Job controller compiles this intent into a `Workload` and its runtime `PodGroup`:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
 kind: Workload
 metadata:
   name: <job-name>-<hash>
@@ -145,13 +234,18 @@ spec:
     apiVersion: batch/v1
     kind: Job
     name: <job-name>
-  podGroupTemplate:
-  - name: pg-w-distributed-training
+  podGroupTemplates:
+  - name: <podGroupTemplateName>
     schedulingPolicy:
       gang:
-        minCount: 8  # Equal to Job.spec.parallelism
+        minCount: 4         # defaulted from Job.spec.parallelism
+    constraints:
+      topology:
+        - level: "topology.kubernetes.io/zone"
+    disruptionMode:
+      all: {}
 ---
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1alpha3
 kind: PodGroup
 metadata:
   name: <workload-name>-<podGroup-template-name>-<hash>
@@ -162,7 +256,7 @@ metadata:
     name: <job-name>
     uid: <job-uid>
     controller: true
-  - apiVersion: scheduling.k8s.io/v1alpha1
+  - apiVersion: scheduling.k8s.io/v1alpha3
     kind: Workload
     name: <workload-name>
     uid: <workload-uid>
@@ -173,23 +267,98 @@ spec:
       podGroupTemplateName: <podGroup-template-name>
   schedulingPolicy:
     gang:
-      minCount: 8  # Equal to Job.spec.parallelism
+      minCount: 4
 ```
-Then, the Job Controller will create the corresponding pods and set the `schedulingGroup` field:
+
+#### Example 2: Backward Compatibility and Sane Defaulting (Implicit Opt-Out)
+
+A standard Job that omits the `scheduling` block. It defaults to `Basic` scheduling, so its pods are
+scheduled pod-by-pod exactly as before. Per the [KEP-6089], the controller still materializes a 
+`Basic` scheduling policy (which can be used for tracking), but no all-or-nothing or topology 
+constraint is applied:
 
 ```yaml
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: <job-name>-<random-suffix>
-  namespace: training
+  name: <job-name>
+  namespace: batch
+spec:
+  parallelism: 10
+  completions: 10
+  # The scheduling block is omitted, which defaults to Basic (pod-by-pod)
+  # scheduling. This acts as an implicit opt-out from gang scheduling.
+  template:
+    spec:
+      containers:
+      - name: processor
+        image: processor-image:v1
+```
+
+This compiles into a `Basic` scheduling policy:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: Workload
+metadata:
+  name: <job-name>-<hash>
+  namespace: batch
   ownerReferences:
   - apiVersion: batch/v1
     kind: Job
     name: <job-name>
     uid: <job-uid>
     controller: true
-  - apiVersion: scheduling.k8s.io/v1alpha1
+spec:
+  controllerRef:
+    apiVersion: batch/v1
+    kind: Job
+    name: <job-name>
+  podGroupTemplates:
+  - name: <podGroup-template-name>
+    schedulingPolicy:
+      basic: {}
+---
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: PodGroup
+metadata:
+  name: <workload-name>-<podGroup-template-name>-<hash>
+  namespace: batch
+  ownerReferences:
+  - apiVersion: batch/v1
+    kind: Job
+    name: <job-name>
+    uid: <job-uid>
+    controller: true
+  - apiVersion: scheduling.k8s.io/v1alpha3
+    kind: Workload
+    name: <workload-name>
+    uid: <workload-uid>
+spec:
+  podGroupTemplateRef:
+    workload:
+      workloadName: <workload-name>
+      podGroupTemplateName: <podGroup-template-name>
+  schedulingPolicy:
+    basic: {}
+```
+
+In both cases, the Job controller then creates the pods and sets the `schedulingGroup` field so the
+scheduler can associate each pod with its `PodGroup`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: <job-name>-<random-suffix>
+  namespace: <namespace>
+  ownerReferences:
+  - apiVersion: batch/v1
+    kind: Job
+    name: <job-name>
+    uid: <job-uid>
+    controller: true
+  - apiVersion: scheduling.k8s.io/v1alpha3
     kind: PodGroup
     name: <podGroup-name>
     uid: <podGroup-uid>
@@ -204,43 +373,349 @@ spec:
 
 #### ML Training Job with Gang Scheduling
 
-As a machine learning engineer, I want to run a distributed training job with 8 workers that must all be scheduled together. 
-If only 7 workers can be scheduled, I don't want any pods to start because partial training would waste resources.
+As a machine learning engineer, I want to run a distributed training job with 8 workers that must
+all be scheduled together. I set `spec.scheduling.policy.gang` on the Job (optionally with a
+topology constraint to co-locate the workers), so that if only 7 workers can be scheduled, no pods
+start and no resources are wasted. I do not have to set `parallelism` and `completions`
+in a specific way to "qualify" for gang scheduling; I declare my intent explicitly.
 
 #### Standard Batch Job with Workload Tracking
 
-As a data engineer, I want to run a batch processing job that processes files sequentially without gang scheduling requirements.
+As a data engineer, I want to run a batch processing job that processes files independently without
+gang scheduling requirements. I omit `spec.scheduling` entirely, so the Job defaults to `Basic`
+(pod-by-pod) scheduling and behaves exactly as it does today. A `Basic` scheduling policy is
+set for the Job, giving me a consistent objects to observe its scheduling state without
+changing how the pods are scheduled.
 
 ### Notes/Constraints/Caveats
 
 #### Alpha Constraints
 
-- The alpha release targets simple, static batch workloads where the workload requirements are known at creation time.
-- Each Job maps to one `PodGroup`. All pods in the Job are identical from a scheduling policy perspective.
-- The `minCount` field in the Workload's `GangSchedulingPolicy` mirrors the Job's parallelism.
-- The opt-out mechanism is supported by setting `Job.spec.template.spec.schedulingGroup` to reference an existing `Workload`. In this case, the Job controller will not create `Workload`/`PodGroup` objects.
-- When gang scheduling is active (`GangSchedulingPolicy`), changes to `spec.parallelism` (scaling up/down) 
-are rejected via conditional validation depends on feature enablement. This is because this would require changing 
-`minCount` in the `Workload` object, which is immutable. This will disable [Elastic Indexed Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#elastic-indexed-jobs).
+- The alpha targets single-level `Job` workloads: one `Job` maps to one `Workload` with one `PodGroup`, 
+  and all pods in the `Job` share a single scheduling policy. Elastic scaling is supported through the 
+  mutable `gang.minCount`.
+- `spec.scheduling.policy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
+  other `spec.scheduling` fields are immutable after creation.
+- Opting out of WAS object creation happens implicitly in two ways: omitting `spec.scheduling`
+  yields `Basic` (the controller still owns the objects), and a Job that carries an `OwnerReference`
+  to a registered parent workload is skipped entirely (the parent owns the `Workload`).
 
 ### Risks and Mitigations
 
-- `JobSet` or other higher-level controllers will create `Workload`/`PodGroup` objects for their `Workload`, the Job 
-controller will duplicate or update the objects and create a conflict. We can mitigate this by ensuring the Job
-controller will not create `Workload`/`PodGroup` objects if the Job has `spec.template.spec.schedulingGroup` indicating it is managed by higher-level controller.
+- **Split-brain configuration.** A composite wrapper controller (such as `JobSet` or `TrainJob`)
+  may expose its own scheduling fields while the child `Job` now also has native `spec.scheduling`
+  fields, letting a user configure scheduling in two conflicting places. 
+  * *Mitigation:* the parent controller remains the sole compiler of the workload tree and can map 
+  its own fields onto thecompiled `Workload`, strip/ignore the child's nested scheduling fields, 
+  or reject requests that populate both. The Job controller cooperates by skipping 
+  `Workload`/`PodGroup` creation whenever the Job carries an `OwnerReference` to a registered 
+  parent workload (replacing the v1.36 `spec.template.spec.schedulingGroup`-based opt-out).
 
-- When the feature is enabled, Jobs that identify as gang scheduling cannot have `spec.parallelism` changed. That
-effectively disables [Elastic Indexed Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#elastic-indexed-jobs) for those Jobs. This is accepted 
-for alpha with clear documentation and a committed path to beta to not break Elastic Indexed Jobs.
+- **Increased object count.** Because the controller now materializes a `Workload`/`PodGroup` for
+  every eligible Job (Universal Representation), the number of scheduling objects grows relative to
+  the v1.36 alpha, which only created objects for inferred gang Jobs. 
+  * *Mitigation:* objects are small and garbage-collected with the Job; the Scalability section 
+  quantifies the impact, and the feature stays behind the `WorkloadWithJob` feature gate for alpha.
 
-- Suspended Jobs and resource release rely only on GC, which does not address releasing resources (DRA) while a Job is 
-suspended. This behavior is acceptable for alpha. Future work may require the controller to delete `PodGroup`/`Workload` on suspend and recreate on resume.
+- **Behavior change between alphas.** Jobs that were automatically gang-scheduled in v1.36 default
+  to `Basic` in v1.37 unless the user sets `spec.scheduling.policy.gang`. 
+  * *Mitigation:* gang is now an explicit opt-in; this is documented in the 
+  [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy) and release notes.
+
+- **Suspended Jobs and resource release** rely only on GC, which does not address releasing
+  resources (DRA) while a Job is suspended. This is acceptable for alpha. Future work may require
+  the controller to delete `PodGroup`/`Workload` on suspend and recreate on resume.
 
 ## Design Details
 
+### Core Principles & Assumptions
+
+The integration follows the Workload-aware Scheduling design principles from [KEP-6089] for the 
+single-level `Job`:
+
+- **The Root Controller is the Compiler.** For a standalone `Job`, the Job controller is the
+  root-most controller and is responsible for compiling, creating, and managing the
+  scheduler-facing `Workload` and its runtime `PodGroup`. When a `Job` instead carries an
+  `OwnerReference` to a registered parent workload (e.g., a `JobSet`-owned Job), the Job controller
+  observes that linkage and **bypasses** creating any `Workload`, so the parent remains the single
+  source of truth.
+- **Separation of Structure and Policy.** The `Job` spec owns the workload *structure*
+  (`parallelism`, `completions`, the pod template); the user owns the scheduling *policy* via
+  `spec.scheduling`. The Job controller acts as the translator that combines the two and compiles
+  the low-level `Workload`/`PodGroup` for the scheduler.
+- **Universal Representation.** Standard pod-by-pod scheduling is a first-class policy (`Basic`).
+  The controller always emits a `Workload`/`PodGroup` for an eligible Job, using `Basic` as the
+  backward-compatible default. `Basic` keeps the standard scheduling outcome and does not impose
+  all-or-nothing semantics.
+- **Sane Defaults and Escape Hatches.** A `Job` defaults to `Basic`. Users can opt in to `Gang`,
+  request topology constraints, and configure disruption modes; an escape hatch lets a user request
+  topology-only co-location while keeping the `Basic` policy.
+
+### Job API Changes
+
+To deliver native, typed Workload-aware Scheduling on core Kubernetes, we add a new `Scheduling`
+field to `JobSpec`. This integration is the foundational, single-level implementation that
+demonstrates the building blocks before out-of-tree controllers adopt them.
+
+We introduce a new optional `Scheduling` field in `JobSpec` that embeds a curated composition of
+the standardized building blocks:
+
+```go
+// API Group: batch/v1
+
+// JobSpec defines the desired state of a Job.
+type JobSpec struct {
+    // ... existing fields ...
+
+    // Scheduling defines the Workload-aware Scheduling configuration for this Job.
+    // This field is alpha-gated by the WorkloadWithJob feature gate.
+    // +optional
+    Scheduling *JobSchedulingConfiguration `json:"scheduling,omitempty"`
+}
+
+// JobSchedulingConfiguration composes the reusable WAS building blocks.
+type JobSchedulingConfiguration struct {
+    // Policy defines the gang or basic scheduling rules for this Job.
+    // +optional
+    Policy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"policy,omitempty"`
+
+    // Constraints defines topology co-location constraints for the Job's pods.
+    // +optional
+    Constraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"constraints,omitempty"`
+
+    // DisruptionMode specifies how the pods in this Job should be disrupted (Single vs All).
+    // +optional
+    DisruptionMode *schedulingv1alpha3.WorkloadPodGroupDisruptionMode `json:"disruptionMode,omitempty"`
+
+    // ResourceClaims specifies dynamic resource claims shared across the Job's pods.
+    // +optional
+    ResourceClaims []schedulingv1alpha3.WorkloadPodGroupResourceClaim `json:"resourceClaims,omitempty"`
+}
+```
+
+The `Scheduling` field is gated by the existing `WorkloadWithJob` feature gate. Standard alpha
+field-gating semantics apply: when the gate is disabled, the API server clears `spec.scheduling` on
+create and ignores it on update (preserving an already-set value on the stored object), and the
+field's defaulting, validation, and controller compilation only run when the gate is enabled.
+
+This typed, user-facing field replaces the v1.36 alpha's implicit mechanisms: the type-based
+automatic policy inference and the `spec.template.spec.schedulingGroup`-based opt-out are no longer
+how users express or suppress scheduling intent.
+
+#### Go Package Placement & Graduation
+
+Embedding a pre-stable `scheduling.k8s.io/v1alpha3` type inside the GA `batch/v1.JobSpec` is
+permitted while the `Scheduling` field itself remains alpha-gated. Following the transition pattern
+described in [KEP-6089], when the field graduates to default-enabled the building blocks graduate
+straight into the stable `scheduling.k8s.io/v1` package, the `batch/v1.JobSpec` field is updated to
+reference the `v1` type, and Go type aliases are left in the `v1alpha3` package so third-party
+controllers that still import the alpha package continue to compile.
+
+### Integration with the workloadbuilder Library
+
+The Job controller compiles `spec.scheduling` into a `Workload` using the `workloadbuilder` library.
+
+#### Library Dependency and Packaging
+
+The `workloadbuilder` library lives alongside the `scheduling.k8s.io/v1alpha3` types so it 
+can be vendored by both in-tree controllers (the Job controller, here) and out-of-tree 
+controllers. The Job controller depends on it as a normal package import; this KEP does 
+not define or fork the library, it only consumes its `NewBuilder`/`Build`, `WorkloadNode`, 
+and `MapPodGroupConfig` surface. If the library API shifts before it stabilizes, the Job 
+integration tracks those changes through the shared dependency rather than maintaining 
+its own copy.
+
+#### Division of Responsibilities
+
+The boundary between the library and the Job controller is explicit.
+
+The `workloadbuilder` library is responsible for:
+
+  * Defining the polymorphic, hierarchy-agnostic IR (`SchedulingConfig`, `WorkloadNode`) that 
+  the Job controller populates.
+  * Merging the controller-supplied defaults (`DefaultConfig`, `DefaultGangMinCount`) with the user's
+  `UserConfig`, including escape-hatch resolution.
+  * Validating the resolved configuration via a `Validate` entrypoint, which runs the same resolution
+  and policy validation as `Build` and rejects invalid combinations early (e.g. an unsupported
+  disruption mode). The API server calls `Validate` directly for semantic validation; this
+  complements, and does not replace, the API-server's structural and immutability validation on
+  `spec.scheduling`.
+  * Emitting the `scheduling.k8s.io/v1alpha3` `Workload` object (the scheduling template, including its
+  `PodGroupTemplate`) via `Build`.
+
+The Job controller is responsible for:
+
+  * Choosing the batch-specific defaults — `Basic` scheduling and a fallback gang size of
+  `spec.parallelism` and passing them to the library.
+  * Mapping `spec.scheduling` into the library IR with the leaf helper `MapPodGroupConfig`.
+  * Instantiating the runtime `PodGroup` from the compiled `Workload`, since `Build` only produces the
+    `Workload` template.
+  * Discovery, ownerReferences, garbage collection, and object creation ordering, as described in
+  [Job Controller Changes](#job-controller-changes).
+
+Because a standalone `Job` is a single-level workload, the controller builds a **flat, single-node**
+`WorkloadNode` tree (`len(Children) == 0`) and uses the leaf mapping helper (`MapPodGroupConfig`); it
+never uses `MapCompositeGroupConfig`, which is reserved for multi-level controllers.
+
+#### Building the Logical Tree and Compiling the `Workload`
+
+The controller's `generateWorkload` helper performs four steps: 
+  1. Set the Job's domain default to `Basic`.
+  2. Map the user-facing `spec.scheduling` block into the library IR via `MapPodGroupConfig`.
+  3. Assemble a single-node `WorkloadNode`, supplying `DefaultGangMinCount` from `spec.parallelism` 
+    as the fallback gang size.
+  4. Invoke `Build`, passing the Job's identity and a controller `OwnerReference` so the emitted
+    `Workload` is owned by the Job and garbage-collected with it.
+
+```go
+import (
+    "context"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    batchv1 "k8s.io/api/batch/v1"
+    schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+    "k8s.io/utils/ptr"
+)
+
+func (r *JobReconciler) generateWorkload(
+    job *batchv1.Job,
+) (*schedulingv1alpha3.Workload, error) {
+    // 1. A Job's context-aware sane default is Basic scheduling (standard pod-by-pod).
+    defaultConfig := &workloadbuilder.SchedulingConfig{
+        Policy: &workloadbuilder.SchedulingPolicy{
+            Basic: &workloadbuilder.BasicSchedulingPolicy{},
+        },
+    }
+
+    // 2. Map the public Job.Spec.Scheduling wrapper into the library's IR via the leaf helper.
+    var userConfig *workloadbuilder.SchedulingConfig
+    if job.Spec.Scheduling != nil {
+        userConfig = workloadbuilder.MapPodGroupConfig(
+            job.Spec.Scheduling.Policy,
+            job.Spec.Scheduling.Constraints,
+            job.Spec.Scheduling.DisruptionMode,
+            job.Spec.Scheduling.ResourceClaims,
+        )
+    }
+
+    // 3. Create the flat, single-node logical tree for the Job (one PodGroup).
+    rootNode := &workloadbuilder.WorkloadNode{
+        Name:                "job-root",
+        DefaultConfig:       defaultConfig,
+        DefaultGangMinCount: ptr.To(job.Spec.Parallelism), // defaults to parallelism if MinCount is nil
+        UserConfig:          userConfig,
+    }
+
+    // 4. Let the workloadbuilder compile and generate the Workload object.
+    builder := workloadbuilder.NewBuilder(rootNode)
+    workloadObj, err := builder.Build(
+        context.Background(),
+        job.Name,
+        job.Namespace,
+        metav1.NewControllerRef(job, jobKind),
+    )
+    if err != nil {
+        return nil, err
+    }
+
+    return workloadObj, nil
+}
+```
+
+#### API Validation via the `workloadbuilder` Library
+
+`spec.scheduling` is validated in two layers with distinct responsibilities:
+
+1. **api-server validation** owns the structural and *mutability* rules. It runs on every 
+  create/update and must be self-contained (no dependency on cluster state or other 
+  live objects). It checks:
+   * exactly one scheduling policy is set (`basic` xor `gang`);
+   * `gang.minCount`, when set, is `>= 1`;
+   * topology constraints, disruption mode, and resourceClaims are individually well-formed;
+   * on update, every `spec.scheduling` field is immutable **except** `gang.minCount`.
+2. **`workloadbuilder` semantic validation** owns the *consistency* rules. The API server calls the
+   library's `Validate` entrypoint, which performs the same configuration resolution and policy
+   validation that `Build` runs — resolving `DefaultConfig` + `DefaultGangMinCount` + `UserConfig`
+   and validating the resulting policies and constraints — and returns aggregated field errors. This
+   guarantees that any configuration the API server accepts is one the controller can compile into a
+   valid `Workload`, rejecting combinations that are structurally legal but semantically invalid
+   (e.g. an unsupported disruption mode, or a policy/constraint pairing the builder cannot translate)
+   uniformly across all integrating controllers. Because resolution reads only the incoming object
+   and never cluster state, it is safe to call from the registry layer; it complements, and does not
+   replace, the structural and immutability checks in the api-server validation.
+
+#### Instantiating the runtime `PodGroup`
+
+`Build` returns only the `Workload` (the scheduling template); it does not create the runtime
+`PodGroup`. After the `Workload` exists on the API server, the Job controller instantiates the
+`PodGroup` from the `Workload`'s single `PodGroupTemplate`. For a Job there is exactly one template,
+so the controller creates one `PodGroup` that references the template and carries two
+ownerReferences — a controller ref to the `Job` (so it is GC'd with the Job) and a non-controller
+ref to the `Workload`:
+
+```go
+func (r *JobReconciler) instantiatePodGroup(
+    job *batchv1.Job,
+    workload *schedulingv1alpha3.Workload,
+) (*schedulingv1alpha3.PodGroup, error) {
+    // Alpha supports exactly one PodGroupTemplate per Job-owned Workload.
+    if len(workload.Spec.PodGroups) != 1 {
+        return nil, fmt.Errorf("unsupported Workload structure: expected 1 PodGroupTemplate, got %d",
+            len(workload.Spec.PodGroups))
+    }
+    tmpl := workload.Spec.PodGroups[0]
+
+    pg := &schedulingv1alpha3.PodGroup{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      podGroupName(workload.Name, tmpl.Name),
+            Namespace: job.Namespace,
+            OwnerReferences: []metav1.OwnerReference{
+                *metav1.NewControllerRef(job, jobKind),         // controller: true
+                workloadOwnerRef(workload),                     // controller: false
+            },
+        },
+        Spec: schedulingv1alpha3.PodGroupSpec{
+            // Link the runtime instance back to its template in the Workload.
+            PodGroupTemplateReference: schedulingv1alpha3.PodGroupTemplateReference{
+                Workload: schedulingv1alpha3.WorkloadReference{WorkloadName: workload.Name},
+                Name:     tmpl.Name,
+            },
+        },
+    }
+    return pg, nil
+}
+```
+
+Pods are then created by the existing Job pod-management logic with
+`pod.Spec.SchedulingGroup.PodGroupName` set to the `PodGroup`'s name, which is what the scheduler
+keys on for gang/topology behavior.
+
+#### Reconcile Integration and Error Handling
+
+`generateWorkload`/`instantiatePodGroup` are invoked from the Job reconcile loop, gated on the
+`WorkloadWithJob` feature gate and only when the Job has no pods yet. The integration is 
+designed to be idempotent and crash-safe:
+
+- **Discovery first:** the controller looks up an existing `Workload`/`PodGroup` (via
+  `spec.controllerRef` / `spec.podGroupTemplateReference`) before compiling, so a restart between
+  creating the `Workload` and the `PodGroup` does not produce duplicates.
+- **Ordering:** `Workload` is created (or found) before the `PodGroup`, and both before pods, so
+  references always resolve.
+- **Errors are retryable:** a validation error returned by `Build` is terminal for that spec and is
+  surfaced as a Job condition/event (the user must fix `spec.scheduling`); an API error creating the
+  `Workload`/`PodGroup` requeues the Job with backoff and blocks pod creation until it succeeds.
+- **Updates:** on a `gang.minCount` (or `parallelism`-driven) change the controller re-runs
+  `generateWorkload` to produce a fresh `Workload` spec and applies it to the existing object, then
+  propagates the size to the runtime `PodGroup`. Re-running the builder rather than 
+  hand-patching keeps the merge/validation path identical between create and update.
+
 ### Job Controller Changes
 
-The Job controller reconciliation loop that processes each Job will be extended to ensure `Workload` and `PodGroup` objects exist before creating pods. 
+The Job controller reconciliation loop that processes each Job will be extended to ensure `Workload`
+and `PodGroup` objects exist before creating pods.
+
+Because a standalone `Job` is a single-level workload, the Job controller is solely responsible for
+both objects: it creates and owns the `Workload` and its corresponding runtime `PodGroup`, and 
+garbage-collects them when the `Job` is deleted.
 
 #### Workload and PodGroup Discovery
 
@@ -259,7 +734,7 @@ Similarly, a `PodGroup` is considered the `PodGroup` for this Job if:
 #### Controller Workflow
 
 The Job controller attempts to create `Workload` and `PodGroup` only when the Job has no pods associated with it 
-(no active or terminal pods owned by the Job). If the Job already has one or more pods, the controller only 
+(no active or terminal pods owned by the `Job`). If the Job already has one or more pods, the controller only 
 discovers and uses existing `Workload`/`PodGroup` if any and does not create new ones. This rule is important for 
 correctness when the controller restarts or is upgraded in the middle of the workflow (i.e., after creating 
 `Workload` but before creating `PodGroup` or pods). On the next sync, the controller will find the existing objects 
@@ -267,36 +742,46 @@ via informers/listers and continue.
 
 The controller discovers or creates `Workload` and `PodGroup` as follows:
 
-1.  If the Job already has pods (pods owned by this Job), skip creation.
-2. Look up existing `Workload`(s) in Job’s namespace whose `spec.ControllerRef` points to this Job. If the `Workload` was created by the Job controller, it also has a controller `ownerReference` pointing to this Job (`controller: true`)
-  - If none found, create a `Workload` with `ownerReference` and `spec.ControllerRef` pointing to this Job
-  - If more than one, treat as ambiguous and fall back (update a condition or trigger an event)
-  - If exactly one, that’s the `Workload` for this Job. No changes to its `ownerReference`
+1. If the Job carries an `OwnerReference` to a registered parent workload (i.e., it is owned by a
+   higher-level controller such as `JobSet`), skip `Workload`/`PodGroup` creation entirely since the
+   parent owns them. The controller still discovers any existing objects and uses them when 
+   creating pods.
+2. If the Job already has pods (active or terminal pods owned by this Job), skip creation and only
+   discover existing objects.
+3. Look up existing `Workload`(s) in the Job's namespace whose `spec.controllerRef` points to this
+   Job. If the `Workload` was created by the Job controller, it also has a controller
+   `ownerReference` pointing to this Job (`controller: true`).
+  - If none found, compile a `Workload` from the Job's `spec.scheduling` and create it with an 
+  `ownerReference` and `spec.controllerRef` pointing to this Job.
+  - If more than one, treat as ambiguous and fall back (update a condition or trigger an event).
+  - If exactly one, that is the `Workload` for this Job; no changes to its `ownerReference`.
+4. When creating a new `Workload`, the controller derives the scheduling policy from the Job's
+   `spec.scheduling` rather than from the Job's type. It maps `spec.scheduling` into the
+   `workloadbuilder` library, which applies the defaulting rules (defaulting to `Basic`, defaulting
+   `Gang.minCount` to `parallelism`) and compiles the `Workload`. Per the Universal Representation
+   principle, this happens for every eligible Job, including those that default to `Basic`.
+5. Look up `PodGroup`(s) in the Job's namespace whose `podGroup.spec.podGroupTemplateRef` is
+   associated with the `Workload` for this Job. If the `PodGroup` was created by the Job controller,
+   it has two ownerReferences: the Job controller and the `Workload` object.
+  - If none found, create a `PodGroup` with an ownerReference to the `Job` (`controller: true`) and
+    another ownerReference to the `Workload`.
+  - If exactly one, that is the `PodGroup` for this Job; no changes to its `ownerReference`.
+  - If multiple PodGroups, fall back as that is not supported in alpha.
+6. Execute the existing pod-management logic to create pods, including `schedulingGroup.podGroupName`
+   in the pod spec to associate pods with the `PodGroup`.
 
-3. When creating a new `Workload`, determine the appropriate scheduling policy and create the `Workload` object with the determined policy based on Job configuration:
-  - `GangSchedulingPolicy` with `minCount=parallelism`: when `parallelism > 1` and `completionMode: Indexed` and `parallelism = completions`
-  - For alpha, all other cases will not have `Workload` and `PodGroup` objects created, this includes:
-    - `parallelism = 1`
-    - `completions` not equal to `parallelism`
-    - `completionMode` is not `Indexed` (non-indexed Jobs)
+Note that the controller does not update the `Workload` or `PodGroup` objects at this point if they
+already exist.
 
-4. Look up `PodGroup`(s) in Job’s namespace whose `podGroup.spec.podGroupTemplateRef` is associated with the `Workload` for this Job. If the `PodGroup` was created by the Job controller, it has two ownerReferences; the Job controller and the `Workload` object
-  - If none found, create a `PodGroup` with ownerReference to `Job` with `controller: true` and another ownerReference to the `Workload`
-  - If exactly one, that’s the `PodGroup` for this Job. No changes to its `ownerReference`
-  - If multiple PodGroups, fall back as it's not supported in alpha
+The controller will require additional informers and listers for `Workload` and `PodGroup` objects.
+Both `Workload` and `PodGroup` are automatically garbage collected when they were created by the Job
+controller and the corresponding Job is deleted.
 
-5. Execute existing pod management logic to create pods, include `schedulingGroup.podGroupName` in the pod spec to associate pods with the `PodGroup`.
-
-Note that the controller will not update the `Workload` or `PodGroup` objects if they already exist.
-
-The controller will require additional informers and listers for `Workload` and `PodGroup` objects. Both `Workload` and `PodGroup` are automatically garbage collected if they were created by the job-controller and the corresponding Job is deleted.
-
-If the `Workload` was created by another actor (i.e. JobSet, User creates a `Workload` with `BasicSchedulingPolicy` 
-to opt-out of gang scheduling), the Job controller respects and uses it and its associated PodGroups if any. It does 
-not treat that as an opt-out. The Job controller uses the discovered `Workload` and PodGroup (if any) when creating pods.
-The Job controller falls back (ignore the discovered `Workload` and `PodGroup`) when the discovered `Workload` 
-has an unsupported structure (for alpha, when the number of `PodGroupTemplates != 1`). In that case, a condition 
-or event should be triggered to inform the user.
+If the `Workload` was created by another actor (e.g., a higher-level controller or a user who
+pre-creates a `Workload`), the Job controller respects and uses it and its associated PodGroups when
+creating pods. The Job controller falls back (ignores the discovered `Workload`/`PodGroup`) when the
+discovered `Workload` has an unsupported structure (for alpha, when the number of `PodGroupTemplates`
+is not 1). In that case, a condition or event should be triggered to inform the user.
 
 #### OwnerReferences Relationship
 
@@ -317,31 +802,81 @@ flowchart BT
     Pod -->|ownerRef| PodGroup
 ```
 
-- The `Workload` object has an ownerReference to the `Job` object with `controller: true` in case it was created by the Job controller
-- The `PodGroup` object has an ownerReference to the `Job` object with `controller: true` in case it was created by the Job controller and another ownerReference to the `Workload` object
-- The `Pod` object has an ownerReference to the `Job` object with `controller: true` and another ownerReference to the `PodGroup` object
+- The `Workload` object has an ownerReference to the `Job` object with `controller: true` in case 
+  it was created by the Job controller.
+- The `PodGroup` object has an ownerReference to the `Job` object with `controller: true` in case 
+  it was created by the Job controller and another ownerReference to the `Workload` object.
+- The `Pod` object has an ownerReference to the `Job` object with `controller: true` and another 
+  ownerReference to the `PodGroup` object
 
 By this ownerReferences relationship, garbage collection will remove objects accordingly that avoids orphaned Pods with a stale PodGroup reference.
+
+#### Defaulting Rules
+
+To ensure backward compatibility and avoid breaking existing pipelines:
+
+- If `Scheduling` is unset or `Policy` is nil, the Job controller defaults to the `Basic` scheduling
+  policy (standard pod-by-pod scheduling).
+- If a user selects `Gang` but leaves `MinCount` unset, the controller injects a context-aware sane
+  default of `MinCount = parallelism` (or `MinCount = completions` when `parallelism` is unset).
+- Users can configure an escape hatch — for example, requesting only topology constraints while
+  keeping the standard `Basic` policy.
 
 #### Object Creation Order
 
 The Job controller creates objects in the following order so that references point to existing objects and to satisfy any API validation that `Workload` exists before `PodGroup` is created. The order is as follows:
-1. `Workload` object which will reference the `Job`
-2. `PodGroup` object which will reference the `Workload` and the `Job`
-3. `Pod` objects which will reference `PodGroup`
+1. `Workload` object which will reference the `Job`.
+2. `PodGroup` object which will reference the `Workload` and the `Job`.
+3. `Pod` objects which will reference `PodGroup`.
 
 The kube-scheduler waits for `PodGroup` when Pods have `schedulingGroup`, so scheduling does not depend on this order, the order is for consistency and API validity.
 
-### Validation for Parallelism Changes
+#### Handling Updates and Mutability
 
-The Job API Validation rejects updates that change `spec.parallelism` when the feature gate is enabled and the Job uses gang scheduling. Since changing this field would require changing `minCount` in the `Workload` object, which is immutable.
+To support dynamic scaling of gang-scheduled workloads (Elastic Jobs), the Job API allows in-flight
+updates to `spec.scheduling.policy.gang.minCount`; all other `spec.scheduling` fields are immutable
+after Job creation, and updates that change them are rejected by API validation. This replaces the
+v1.36 validation that rejected `spec.parallelism` updates for gang Jobs: because the gang size is
+now driven by the mutable `minCount` ([KEP-4671]), `spec.parallelism` is no longer frozen for gang
+Jobs, restoring support for [Elastic Indexed
+Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#elastic-indexed-jobs). API
+validation reuses the `workloadbuilder` library where possible so the accepted configurations stay
+consistent with what the controller actually compiles. The update-validation rules change as follows:
 
-Job API validation uses the same conditions the Job controller uses to create a Workload with gang scheduling. 
-When the feature gate is enabled, validation rejects updates that change `spec.parallelism` if the Job, after the update, 
-satisfies `spec.parallelism > 1`, `spec.completionMode == Indexed`, and `spec.parallelism == spec.completions`. If the controller’s 
-criteria for applying gang scheduling change in the future, this validation logic must be updated to match.
+  * `spec.parallelism` becomes *mutable* again: the v1.36 rule that rejected `spec.parallelism`
+  updates for gang Jobs is removed, restoring Elastic Indexed Jobs.
+  * `spec.scheduling.policy.gang.minCount` is *mutable* in-flight: on change the controller
+  recompiles the `Workload` and re-syncs the `PodGroup` size.
+  * All other `spec.scheduling` fields remain *immutable* after creation, enforced by registry
+  validation, since changing the policy, topology, disruption mode, or resourceClaims would require
+  recreating the `Workload`/`PodGroup`.
 
-This additional validation will be removed in beta since Elastic Indexed Jobs must be supported.
+When `minCount` is omitted it follows `spec.parallelism`, so a `parallelism` update is a valid way to
+scale the gang without ever touching `spec.scheduling`.
+
+#### Reconciliation Flow upon Updates
+
+A user can change the target gang size in one of two ways:
+
+- by setting `spec.scheduling.policy.gang.minCount` directly, when it is set explicitly
+- by setting `spec.parallelism`, when `minCount` is unset (and therefore follows `parallelism`).
+
+In either case, the Job controller reconciles the change as follows:
+
+1. **Detection:** the Job controller's reconcile loop detects the change and fetches the existing
+   `Workload` resource from the API server.
+2. **Workload Compilation:** it builds a fresh single-node `WorkloadNode` tree from the updated
+   `spec.parallelism`/`minCount` and passes it to the `workloadbuilder` library to compile a fresh
+   `Workload` object.
+3. **Workload Update:** the controller applies the newly compiled `Workload` spec to the existing
+   resource on the API server.
+4. **PodGroup Sync:** the controller propagates the updated size to the runtime `PodGroup` so the
+   scheduler targets the newly scaled size.
+
+`minCount` is enforced only during scheduling: per [KEP-4671], updates do not affect
+already-scheduled pods and apply only to pods evaluated in future scheduling cycles. The scheduler
+also operates on an eventually consistent view, so an update may not take effect until the next
+scheduling cycle.
 
 ### Naming Conventions
 
@@ -362,18 +897,18 @@ Following prior-art in [Deployment](https://github.com/kubernetes/kubernetes/blo
   - Truncation of workload name and podGroup name is applied when necessary to respect name length limits.
   - The hash allows multiple PodGroups within a `Workload` and `PodGroupTemplate` to have distinct names. For alpha, the controller creates a single `PodGroup` per Job, however, the pattern still supports future multi-PodGroup cases.
 
-  ### Deletion and Garbage Collection
+### Deletion and Garbage Collection
 
-  The Job controller does not explicitly delete `Workload` or `PodGroup`. However, in the case of the controller 
-  creating them, it sets `ownerReferences` so that garbage collection removes them when the Job is deleted. 
-  No additional controller logic is required for deletion in the current design.
-  
-  The Job controller does not add or adopt ownerReferences on objects it did not create (user-created or higher-level controller-created objects). Users or other controllers may create Workloads/PodGroups with the same ownerReferences as the Job controller would use.
+The Job controller does not explicitly delete `Workload` or `PodGroup`. However, in the case of the controller
+creating them, it sets `ownerReferences` so that garbage collection removes them when the Job is deleted.
+No additional controller logic is required for deletion in the current design.
 
-  To distinguish controller-created objects from user-created ones that may have the same ownerReferences, 
-  the Job controller may set a `managed-by` annotation or equivalent metadata on `Workload` and `PodGroup` objects it creates. 
-  This allows the controller to know which objects it created and is responsible for its lifecycle, 
-  including GC. Similarly, for PodGroups, which is especially important as they may have multiple ownerReferences (Job and `Workload`).
+The Job controller does not add or adopt ownerReferences on objects it did not create (user-created or higher-level controller-created objects). Users or other controllers may create Workloads/PodGroups with the same ownerReferences as the Job controller would use.
+
+To distinguish controller-created objects from user-created ones that may have the same ownerReferences,
+the Job controller may set a `managed-by` annotation or equivalent metadata on `Workload` and `PodGroup` objects it creates.
+This allows the controller to know which objects it created and is responsible for its lifecycle,
+including GC. Similarly, for PodGroups, which is especially important as they may have multiple ownerReferences (Job and `Workload`).
 
 ### Test Plan
 
@@ -385,70 +920,95 @@ to implement this enhancement.
 
 ##### Unit tests
 
-- `k8s.io/kubernetes/pkg/controller/job_controller`: `2026-01-29` - `89.1%`
-- `k8s.io/kubernetes/pkg/apis/batch/validation`:
-- `k8s.io/kubernetes/pkg/registry/batch/job`: 
-- Add test that verifies 
-  - SchedulingPolicy for various Job configurations
-  - `Workload` and `PodGroup` creation for gang-scheduled Jobs only (for alpha, all other Jobs will not have `Workload` and `PodGroup` objects created)
-  - pod creation includes correct `schedulingGroup`
-  - Parallelism change is blocked for gang-scheduled Jobs and allowed for all otherJobs
-  - Job deletion cascades to `Workload` and `PodGroup` deletion
-  - Feature gate disabled: Jobs work without `Workload`/`PodGroup` creation
-  - Jobs with ownerReferences (managed by higher-level controllers) do not create `Workload`/`PodGroup`
+- `k8s.io/kubernetes/pkg/controller/job`: `2026-06-03` - `88.3%`
+- `k8s.io/kubernetes/pkg/apis/batch/validation`: `2026-06-03` - `86.8%`
+- `k8s.io/kubernetes/pkg/registry/batch/job`: `2026-06-03` - `92.2%`
+- Add tests that verify:
+  - Defaulting: an omitted `spec.scheduling` defaults to the `Basic` policy; a `Gang` policy with a
+    nil `MinCount` defaults to `MinCount = parallelism` (or `completions` when parallelism is unset).
+  - `workloadbuilder` compilation: `Basic` vs `Gang` policy, and that topology constraints,
+    disruption mode (single/all), and resourceClaims are mapped into the generated `Workload`/
+    `PodGroup`; that a `Job` builds a flat single-node tree via `MapPodGroupConfig`.
+  - Universal Representation: a `Basic` `Workload`/`PodGroup` IS created for a Job with
+    `spec.scheduling` omitted.
+  - pod creation includes the correct `schedulingGroup`.
+  - Mutability/validation: updates to `spec.scheduling.policy.gang.minCount` are allowed; updates to
+    any other `spec.scheduling` field are rejected.
+  - Feature gate disabled: `spec.scheduling` is dropped on create and no `Workload`/`PodGroup` is
+    created.
+  - Jobs with an `OwnerReference` to a parent workload do not create `Workload`/`PodGroup`.
+  - Job deletion cascades to `Workload` and `PodGroup` deletion.
   - ownerReferences on controller-created `Workload` and `PodGroup` match the expected structure:
-    - `Workload` has controller ownerRef to Job
-    - `PodGroup` has controller ownerRef to Job and non-controller ownerRef to `Workload`
-    - Test naming abbreviations for `Workload` and `PodGroup`
+    - `Workload` has a controller ownerRef to the Job.
+    - `PodGroup` has a controller ownerRef to the Job and a non-controller ownerRef to the `Workload`.
+  - Naming abbreviations for `Workload` and `PodGroup`.
 
 ##### Integration tests
 
-We will add the following integration tests to the Job controller `https://github.com/kubernetes/kubernetes/blob/v1.35.0/test/integration/job/job_test.go`:
-- Gang Scheduling Lifecycle Test (create, update, delete Job, verify `Workload` and `PodGroup` creation, verify pods have `schedulingGroup`, verify Job deletion cascades to `Workload` and `PodGroup` deletion)
-- Failure Recovery Test (create Job with `Workload` API unavailable, verify Job controller retries, verify `Workload` is eventually created)
-- Feature gate disable/enable (Jobs work without `Workload`/`PodGroup` creation (Jobs with ownerReferences managed by higher-level controllers do not create `Workload`/`PodGroup`))
-- Jobs created by CronJob get one `Workload` and one `PodGroup` per Job:
-  - CronJob does not set `schedulingGroup` on the pod template
-  - Verify `Workload`/`PodGroup` creation and GC when the CronJob-created Job completes or is deleted
-- When a Job is suspended, pods are deleted but `Workload` and `PodGroup` remain. For alpha, check that on resume, the same `Workload`/`PodGroup` are used and pods are recreated with correct `schedulingGroup`
-- For a Job using gang scheduling, verify that parallelism change is rejected and all other Jobs are still allowed
-- Verify controller-created `Workload`/`PodGroup` has the correct owner references
+We will add the following integration tests to the Job controller (`test/integration/job/job_test.go`):
+- Lifecycle test for both `Basic` and `Gang` Jobs (create, update, delete Job; verify `Workload`
+  and `PodGroup` are materialized, pods have `schedulingGroup`, and Job deletion cascades to
+  `Workload`/`PodGroup` deletion).
+- Elastic scaling: updating `spec.scheduling.policy.gang.minCount` (or `spec.parallelism` when
+  `minCount` is unset) updates the `Workload` and the runtime `PodGroup`.
+- Passthrough: topology constraints, disruption mode, and resourceClaims declared in
+  `spec.scheduling` appear in the compiled `Workload`/`PodGroup`.
+- Failure Recovery test (create a Job while the `Workload` API is unavailable, verify the controller
+  retries and the `Workload` is eventually created).
+- Feature gate disable/enable (Jobs work without `Workload`/`PodGroup` creation; Jobs with an
+  `OwnerReference` to a parent workload do not create `Workload`/`PodGroup`).
+- Jobs created by CronJob get one `Workload` and one `PodGroup` per Job, and these are GC'd when the
+  Job completes or is deleted.
+- When a Job is suspended, pods are deleted but `Workload`/`PodGroup` remain; on resume the same
+  `Workload`/`PodGroup` are used and pods are recreated with the correct `schedulingGroup`.
+- Verify controller-created `Workload`/`PodGroup` have the correct owner references.
 
 ##### e2e tests
 
-- End-to-end gang scheduling, all pods scheduled together or none
-- Mixed workloads, gang and basic Jobs coexist
-- Failure scenarios, i.e., insufficient resources for gang, partial failures
+- End-to-end gang scheduling: all pods are scheduled together or none.
+- `Basic` Jobs schedule pod-by-pod while still producing a `Workload`/`PodGroup`.
+- Elastic gang resize via `minCount` update.
+- Mixed workloads: gang and basic Jobs coexist.
+- Failure scenarios, e.g., insufficient resources for a gang, partial failures.
 
 ### Graduation Criteria
 
 #### Alpha (v1.36)
 
-- Feature is implemented behind feature gate `WorkloadWithJob` (default: disabled)
-- Job controller creates `Workload` and `PodGroup` objects for Jobs when feature gate is enabled
-- Gang scheduling policy applied to indexed parallel Jobs (`parallelism > 1`, `completions = parallelism`, `completionMode: Indexed`)
-- non-gang scheduling Jobs will not have `Workload` and `PodGroup` objects created
-- Jobs managed by higher-level controllers skip `Workload`/`PodGroup` creation
-- API validation rejects updates that change `spec.parallelism` for gang scheduling Jobs
-- Unit tests for all new Job controller logic
-- Integration tests for `Workload`/`PodGroup` creation flow
-- Documentation for enabling and using the feature
+The first alpha (the automatic, type-based model) delivered:
+- Feature implemented behind the `WorkloadWithJob` feature gate (default: disabled).
+- Job controller creates `Workload`/`PodGroup` objects when the feature gate is enabled.
+- Gang scheduling policy applied to indexed parallel Jobs (`parallelism > 1`, `completions = parallelism`, `completionMode: Indexed`).
+- Non-gang scheduling Jobs do not have `Workload`/`PodGroup` objects created.
+- Jobs managed by higher-level controllers skip `Workload`/`PodGroup` creation.
+- API validation rejects updates that change `spec.parallelism` for gang scheduling Jobs.
+- Unit and integration tests for the `Workload`/`PodGroup` creation flow.
+
+#### Alpha (v1.37)
+
+This second alpha replaces the automatic model with the user-facing API:
+- New `spec.scheduling` (`JobSchedulingConfiguration`) field added to `batch/v1`, gated by the
+  existing `WorkloadWithJob` feature gate (still default-disabled).
+- The Job controller compiles `spec.scheduling` into `Workload`/`PodGroup` via the shared
+  `workloadbuilder` library, defaulting to `Basic` and materializing a `Workload`/`PodGroup` for
+  every eligible Job (Universal Representation).
+- `Gang` opt-in with `minCount` defaulting to `parallelism`, plus support for mutable `minCount`
+  (elastic scaling) and passthrough of topology constraints, disruption mode, and resourceClaims.
+- API validation makes `spec.scheduling` fields immutable except `gang.minCount`; the v1.36
+  `spec.parallelism`-rejection validation is removed.
+- Jobs owned by a higher-level controller (via `OwnerReference`) skip `Workload`/`PodGroup` creation.
+- Unit and integration tests for the new API, defaulting, mutability, and `workloadbuilder`
+  compilation; user-facing documentation for the new API.
 
 #### Beta
 
-- Before beta, the Job API must clearly define: 
-  - How users opt-in or opt-out of gang scheduling. Disable gang scheduling must not rely on turning off the feature gate
-  - When and how `Workload` and `PodGroup` are created/updated (i.e., only at creation vs. also when scaling)
-  - Define the scaling up/down mechanism for gang scheduling Jobs (elastic indexed jobs are not supported)
-- Evaluate whether the Job controller’s [current batch-create](https://github.com/kubernetes/kubernetes/blob/2023f445eca52e6baa72139e56c6e4e01be0ee97/pkg/controller/job/job_controller.go#L1780-L1838) pods should be changed when gang scheduling is active (it slows down the pod creations), and document the decision.
-- Elastic Indexed Jobs must be supported (beta blocker)
-- The controller needs a mechanism to delete `PodGroup`/`Workload` in the case of suspended Jobs and recreate on resume.
-- Create `Workload` and `PodGroup` objects for all non-gang scheduling Jobs with `BasicSchedulingPolicy`
-- Feature gate `WorkloadWithJob` is enabled by default
-- Address feedback from alpha
-- E2e tests covering gang scheduling scenarios
-- Metrics for monitoring `Workload`/`PodGroup` creation and scheduling outcomes
-- Performance testing to validate no significant impact on Job creation latency
+- Promote the `WorkloadWithJob` feature gate to enabled by default.
+- Evaluate whether the Job controller's [current batch-create](https://github.com/kubernetes/kubernetes/blob/2023f445eca52e6baa72139e56c6e4e01be0ee97/pkg/controller/job/job_controller.go#L1780-L1838) of pods should change when gang scheduling is active (it slows pod creation), and document the decision.
+- The controller needs a mechanism to delete `PodGroup`/`Workload` for suspended Jobs and recreate on resume.
+- Address feedback from alpha and confirm the `spec.scheduling` API shape and defaulting are stable.
+- E2e tests covering gang, topology, disruption, and elastic-scaling scenarios.
+- Metrics for monitoring `Workload`/`PodGroup` creation and scheduling outcomes.
+- Performance testing to validate no significant impact on Job creation latency.
 
 #### GA
 
@@ -461,44 +1021,64 @@ N/A for alpha release
 ### Upgrade / Downgrade Strategy
 
 - **Upgrade:**
-  1. Upgrade kube-apiserver
-  2. Enable feature gate and upgrade kube-controller-manager
-  3. New Jobs automatically get `Workload`/`PodGroup` objects
-  4. Existing Jobs continue to work (no `Workload` created for them)
+  1. Upgrade kube-apiserver first, so it can serve `scheduling.k8s.io/v1alpha3` and accept 
+    the new `spec.scheduling` field.
+  2. Enable the `WorkloadWithJob` feature gate and upgrade kube-controller-manager.
+  3. New or reconciled Jobs get a `Workload`/`PodGroup` compiled from their `spec.scheduling`,
+     defaulting to `Basic` when the field is omitted.
 
 - **Downgrade:**
-  1. Disable feature gate and downgrade kube-controller-manager
-  2. New Jobs no longer get `Workload`/`PodGroup` objects
-  3. Existing `Workload` and `PodGroup` objects remain
-  4. Jobs with `schedulingGroup.podGroupName` on pods continue to run (field ignored)
-  5. New Pods for Jobs will not have `schedulingGroup.podGroupName` set
+  1. Disable the feature gate and downgrade kube-controller-manager.
+  2. The API server clears `spec.scheduling` on writes (preserving an already-set value on the stored
+     object), and the controller stops compiling `Workload`/`PodGroup`.
+  3. Existing `Workload` and `PodGroup` objects remain.
+  4. Jobs with `schedulingGroup.podGroupName` on their pods continue to run (the field is ignored).
+  5. New pods will not have `schedulingGroup.podGroupName` set.
+
+- **Behavior change between alphas:** in v1.36, indexed fully-parallel Jobs were automatically
+  gang-scheduled; in v1.37 those same Jobs default to `Basic` unless the user sets
+  `spec.scheduling.policy.gang`. Gang scheduling is now an explicit opt-in. Operators upgrading
+  between alphas should be aware that previously auto-gang'd Jobs will schedule pod-by-pod unless
+  updated.
 
 - **Migration for Existing Jobs:**
-  - Existing Jobs before upgrade do not automatically get `Workload` objects
-  - To add gang scheduling to existing Jobs, delete and recreate them
-  - Jobs who do not have pods running yet get `Workload`/`PodGroup` objects created for them.
+  - Existing Jobs created before the upgrade get a `Workload`/`PodGroup` (defaulting to `Basic`) on
+    their next reconciliation if they do not yet have running pods.
+  - To request gang or topology for an existing Job, set `spec.scheduling`. Note that all
+    `spec.scheduling` fields except `gang.minCount` are immutable, so changing them on an existing
+    Job requires recreating it.
 
-- **Controller restarts and upgrades:** 
-  - The Job controller only creates `Workload`/`PodGroup` when the Job has no pods
-  - If the controller restarts or is upgraded after creating `Workload` but before creating `PodGroup` or pods, on 
-  the next sync it will discover the existing `Workload` (and `PodGroup` if present) via informers/listers and continue without creating duplicates. 
+- **Controller restarts and upgrades:**
+  - The Job controller only creates `Workload`/`PodGroup` when the Job has no pods.
+  - If the controller restarts or is upgraded after creating the `Workload` but before creating the
+    `PodGroup` or pods, on the next sync it discovers the existing objects via informers/listers and
+    continues without creating duplicates.
   - No special handling is required for in-flight Jobs during controller upgrade or restart.
 
 ### Version Skew Strategy
 
-Gang scheduling only occurs when:
-- The API server can serve the `Workload` and `PodGroup` APIs
-- The Job controller is able to create `Workload`/`PodGroup` and sets `schedulingGroup` on pods
-- The scheduler supports `Workload`/`PodGroup`
+Workload-aware scheduling for a Job only takes effect when:
+- The API server can serve the `Workload`/`PodGroup` APIs and accept `spec.scheduling`.
+- The Job controller compiles `Workload`/`PodGroup` and sets `schedulingGroup` on pods.
+- The scheduler supports `Workload`/`PodGroup`.
 
 Therefore, for a safe rollout:
-- kube-apiserver must be upgraded first so it can serve the `Workload` and `PodGroup` APIs.
-- kube-controller-manager can be upgraded before or after the scheduler
-- kube-scheduler should be upgraded before or together with kube-controller-manager. Gang semantics will not apply until the scheduler is upgraded.
+- kube-apiserver must be upgraded first so it can serve `scheduling.k8s.io/v1alpha3` and persist the
+  new `spec.scheduling` field.
+- kube-controller-manager can be upgraded before or after the scheduler.
+- kube-scheduler should be upgraded before or together with kube-controller-manager; gang/topology
+  semantics will not apply until the scheduler is upgraded.
 
-There are different Skew scenarios involving the kube-scheduler:
-- kube-controller-manager new, kube-scheduler old: The controller creates `Workload` and `PodGroup` and sets `schedulingGroup` on pods but the scheduler does not understand these objects and ignores `schedulingGroup`. In this case, pods are scheduled normally (pod-by-pod) with no gang scheduling benefit until the scheduler is upgraded.
-- kube-controller-manager old, kube-scheduler new: The controller does not create `Workload`/`PodGroup` and does not set `schedulingGroup` on pods. The scheduler has no workload information for those Jobs. Pods are scheduled normally with no gang scheduling benefit.
+Skew scenarios:
+- **kube-controller-manager new, kube-scheduler old:** the controller compiles `Workload` 
+  and `PodGroup` and sets `schedulingGroup` on pods, but the scheduler ignores them, 
+  so pods schedule pod-by-pod with no gang/topology benefit until the scheduler is upgraded.
+- **kube-controller-manager old, kube-scheduler new:** the controller does not compile `Workload` 
+  or `PodGroup` and does not set `schedulingGroup`, so the scheduler has no workload information 
+  information and pods schedule pod-by-pod.
+- **kube-apiserver ahead of kube-controller-manager:** the API server may persist `spec.scheduling`
+  on a Job, but an older controller that does not understand the field simply ignores it (no
+  `Workload` or `PodGroup` is compiled) until the controller is upgraded.
 
 ## Production Readiness Review Questionnaire
 
@@ -521,22 +1101,33 @@ There are different Skew scenarios involving the kube-scheduler:
 ###### Does enabling the feature change any default behavior?
 Yes. When the feature gate is enabled:
 
-1. The Job controller creates `Workload` and `PodGroup` objects for all qualified gang scheduling Jobs (`parallelism > 1`, `completions = parallelism`, `completionMode: Indexed`) before creating pods.
-2. Jobs that match the gang scheduling criteria (`parallelism > 1`, `completions = parallelism`, `completionMode: Indexed`) use gang scheduling, meaning all pods must be scheduled together or none are scheduled.
-3. Updates to `Job.spec.parallelism` are rejected for Jobs using gang scheduling.
+1. The `batch/v1` `spec.scheduling` field becomes available; the API server persists it and defaults
+   it to the `Basic` policy when omitted.
+2. The Job controller compiles `spec.scheduling` into a `Workload` and `PodGroup` for every eligible Job
+   (one not owned by a higher-level controller) before creating pods — including `Basic` Jobs
+   (Universal Representation).
+3. Jobs that set `spec.scheduling.policy.gang` use gang scheduling, meaning all `minCount` pods must
+   be scheduled together or none are scheduled.
 4. The binding of pods referencing a `PodGroup` is delayed until the `PodGroup` object exists.
+
+Note this differs from the v1.36 alpha, where indexed fully-parallel Jobs were gang-scheduled
+automatically. In v1.37 gang scheduling is an explicit opt-in via `spec.scheduling`; absent the
+field, Jobs default to `Basic`.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes. The feature can be disabled (`WorkloadWithJob: false`).
+Yes. The feature can be disabled (`WorkloadWithJob: false`). The API server then clears
+`spec.scheduling` on writes (preserving an already-stored value), and the controller stops compiling
+`Workload` and `PodGroup`.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
 When the feature is re-enabled:
-- New Jobs will have `Workload` and `PodGroup` objects created
-- Existing Jobs that don't have running pods will have `Workload` and `PodGroup` objects created on their next reconciliation cycle
-- Jobs that were running without gang scheduling will be evaluated again, if they match gang scheduling criteria and have no running pods, a `Workload` with gang policy will be created.
-- Jobs that have running pods are not affected since gang scheduling only applies to newly created Jobs/Pods
+- New and reconciled Jobs without running pods get `Workload` and `PodGroup` compiled from their
+  `spec.scheduling` (defaulting to `Basic`) on their next reconciliation cycle.
+- Jobs that already have running pods are not affected, since scheduling policy only applies to
+  pods evaluated in future scheduling cycles.
+- A previously stored `spec.scheduling` value on a Job is honored again once the gate is on.
 
 ###### Are there any tests for feature enablement/disablement?
 
@@ -547,17 +1138,23 @@ Yes. We will add unit tests and integration tests for feature enablement/disable
 
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-- If the API server doesn't support `Workload` and `PodGroup` APIs, the Job controller will fail to create Jobs (error creating `Workload`). Jobs will be requeued until the API server is upgraded.
-- If the scheduler doesn't have gang scheduling feature enabled, pods are scheduled normally in pod-by-pod manner.
-- Already running Jobs are not affected by enabling the feature. Pods that are already scheduled and running continue to run. New Jobs or Jobs being reconciled will be affected.
-- For the rollback, disabling the feature gate allows Jobs to work without `Workload` and `PodGroup` creation. `Workload` and `PodGroup` objects don't cause issues; they're ignored when the feature is disabled
+- If the API server doesn't serve the `Workload` and `PodGroup` APIs, the Job controller fails 
+  to compile the `Workload` and requeues the Job until the API server is upgraded.
+- If the scheduler does not support `Workload` and `PodGroup`, pods are scheduled pod-by-pod 
+  with no gang/topology benefit.
+- Already running Jobs are not affected by enabling the feature; pods already scheduled and 
+  running continue to run. New Jobs or Jobs being reconciled are affected.
+- On rollback, disabling the feature gate lets Jobs run without `Workload` or `PodGroup` compilation. 
+  Existing objects are harmless; they are ignored while the feature is disabled.
 
 ###### What specific metrics should inform a rollback?
 
 The following metrics should be monitored:
 
-- `job_sync_duration_seconds`: If Job sync duration increases significantly, it may indicate issues with `Workload`/`PodGroup` creation
-- `job_pods_creation_total`: A drop in pod creation rate may indicate a problem in the Job controller’s `Workload`/`PodGroup` flow 
+- `job_sync_duration_seconds`: If Job sync duration increases significantly, it may indicate 
+  issues with `Workload` and `PodGroup` creation.
+- `job_pods_creation_total`: A drop in pod creation rate may indicate a problem in the Job 
+  controller’s `Workload` and `PodGroup` flow.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
@@ -603,20 +1200,23 @@ No.
 
 ### Dependencies
 
-
 ###### Does this feature depend on any specific services running in the cluster?
 
-- `scheduling.k8s.io/v1alpha1` for `Workload` and `PodGroup` APIs
-- `kube-scheduler` with gang scheduling feature enabled
+- `scheduling.k8s.io/v1alpha3` for the `Workload` and `PodGroup` APIs ([KEP-6089]).
+- The shared `workloadbuilder` library that compiles user intent into `Workload`/`PodGroup` objects.
+- `kube-scheduler` with `Workload`/`PodGroup` (gang/topology) support enabled.
 
 ### Scalability
 
-
 ###### Will enabling / using this feature result in any new API calls?
 
-Yes. The Job controller uses informers and listers for `Workload` and `PodGroup` for lookups and watches. The following additional API calls are made when this feature is enabled:
+Yes. The Job controller uses informers and listers for `Workload` and `PodGroup` for lookups 
+and watches. The following additional API calls are made when this feature is enabled, for 
+every eligible Job (one not owned by a higher-level controller), including `Basic` Jobs due 
+to Universal Representation:
 - `CREATE Workload` - 1 per Job creation
 - `CREATE PodGroup` - 1 per Job creation
+- `UPDATE Workload`/`PodGroup` - on `gang.minCount` (or `parallelism`-driven) elastic resize
 
 ###### Will enabling / using this feature result in introducing new API types?
 
@@ -628,9 +1228,11 @@ No.
 
 ###### Will enabling / using this feature result in increasing size or count of the existing API objects?
 
-Yes. Jobs that match the gang scheduling criteria create 1 `Workload`(~500 bytes) and 1 `PodGroup`(~500 bytes) object. In addition to Each Pod gains a `schedulingGroup` field (~100 bytes).
+Yes. Because of Universal Representation, every eligible Job (both `Gang` and `Basic`) creates 1 
+`Workload` (~500 bytes) and 1 `PodGroup` (~500 bytes), and each Pod gains a `schedulingGroup` 
+field (~100 bytes).
 
-For a cluster with 10,000 gang scheduling Jobs, this adds approximately:
+For a cluster with 10,000 eligible Jobs, this adds approximately:
 - 10,000 `Workload` objects
 - 10,000 `PodGroup` objects
 - ~10MB additional etcd storage
@@ -673,12 +1275,24 @@ No. This feature is purely control-plane and does not affect node resources.
 ## Implementation History
 - 2026-01-29: KEP created
 - 2026-02-10: KEP updated according to final API design for `Workload` and `PodGroup`
+- 2026-06-03: KEP reworked for a second alpha (v1.37) to replace the automatic, type-based gang
+  selection with the explicit user-facing `spec.scheduling` API from [KEP-6089], adopting the
+  shared `workloadbuilder` library, Universal Representation, and mutable `gang.minCount` for
+  elastic scaling.
 
 ## Drawbacks
 
 ## Alternatives
 
-
 ## Infrastructure Needed (Optional)
 
-[^1]: The Kubernetes community uses the term "gang scheduling" to mean "all-or-nothing scheduling of a set of pods" [1,2,3,4,5,6,7,8,9,10,11,12,13]. In the Kubernetes context, it does not imply time-multiplexing (in contrast to prior academic work such as [Feitelson and Rudolph](https://doi.org/10.1016/0743-7315(92)90014-E), and in contrast to [Slurm Gang Scheduling](https://slurm.schedmd.com/gang_scheduling.html). ↩
+[^1]: The Kubernetes community uses the term "gang scheduling" to mean "all-or-nothing 
+scheduling of a set of pods" [1,2,3,4,5,6,7,8,9,10,11,12,13]. In the Kubernetes context, 
+it does not imply time-multiplexing (in contrast to prior academic work such as 
+[Feitelson and Rudolph](https://doi.org/10.1016/0743-7315(92)90014-E), and in contrast 
+to [Slurm Gang Scheduling](https://slurm.schedmd.com/gang_scheduling.html).
+
+[KEP-4671]: https://kep.k8s.io/4671
+[KEP-5710]: https://kep.k8s.io/5710
+[KEP-5732]: https://kep.k8s.io/5732
+[KEP-6089]: https://kep.k8s.io/6089

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -129,8 +129,7 @@ gaps of the initial alpha.
   pods proceed to binding). Following the [KEP-6089], the controller still materializes a `Basic`
   `Workload`/`PodGroup`, which routes these pods through the Workload Scheduling Cycle 
   (batched scheduling and workload-aware preemption) without enforcing minCount.
-- Let users opt in to `Gang` scheduling, with `minCount` defaulting to `parallelism` (or
-  `completions` when parallelism is unset) when omitted.
+- Let users opt in to `Gang` scheduling, with `minCount` defaulting to `parallelism` when omitted.
 - Compile `spec.scheduling` into `Workload`/`PodGroup` objects via the shared `workloadbuilder`
   library instead of bespoke controller logic.
 - Support mutable `spec.scheduling.policy.gang.minCount` for elastic scaling, while keeping all
@@ -147,7 +146,7 @@ gaps of the initial alpha.
 ### Non-Goals
 
 - Multi-level / nested composite (`CompositePodGroup`) structures, since this KEP covers 
-  single-level, flat `Job` workloads only.
+single-level, flat `Job` workloads only.
 - Implementing the integration in composite controllers (`JobSet`, `LWS`, `TrainJob`). Those 
   are pursued independently in their own repositories.
 - Defining the `scheduling.k8s.io` building-block API or the `workloadbuilder` library 
@@ -170,16 +169,19 @@ through a new `spec.scheduling` field.
 
 The key design principles for this alpha are:
 
-- One `Job` maps to one `PodGroup` representing a single homogeneous group of pods (a flat,
-  single-level structure). For a root Job, the controller also compiles the enclosing `Workload`;
-  for a non-root Job whose parent owns the `Workload`, that single `PodGroup` instead attaches to
-  the parent's compiled `Workload`/`CompositePodGroup`.
+- One `Job` maps to one `PodGroup` representing a single group of pods. The `PodGroup` 
+always links to a `Workload` via a `PodGroupTemplate`:
+  * For a root Job the controller compiles the `Workload` itself
+  * For a non-root Job the `PodGroup` links to the parent-owned `Workload`
+  * The `PodGroup` links to a parent `CompositePodGroup` instance only when the parent 
+  supplies the `scheduling.k8s.io/parent-composite-podgroup` annotation
 - The scheduling policy comes from the user's `spec.scheduling`, not from the Job's type. When
   `spec.scheduling` is omitted, the controller defaults to the `Basic` policy.
-- Following the [KEP-6089], the controller always materializes a `Workload`/`PodGroup` for an 
-  eligible Job, even for `Basic` scheduling policy.
-- For `Gang`, an omitted `minCount` defaults to the Job's `parallelism` (or `completions` when
-  parallelism is unset). `minCount` is mutable to support elastic scaling; all other
+- Following the [KEP-6089], the controller always materializes scheduling objects (a `Workload`
+  and/or `PodGroup`) for an *eligible* Job — a Job the controller is responsible for when the gate is
+  on: a standalone/root Job, or a non-root Job whose parent delegates the `PodGroup` (a Job whose
+  parent owns both objects is skipped). This holds even for the `Basic` scheduling policy.
+- For `Gang`, an omitted `minCount` defaults to the Job's `parallelism`. `minCount` is mutable to support elastic scaling; all other
   `spec.scheduling` fields are immutable after creation.
 - The Job controller does not create a `Workload` when the Job carries an `OwnerReference` to a
   parent controller that compiles and owns the `Workload` (e.g., `JobSet`). Such controllers set
@@ -356,7 +358,7 @@ spec:
 #### Example 3: CronJob with Gang Scheduling
 
 A `CronJob` that periodically runs a gang-scheduled training Job. Each `Job` created by the
-`CronJob` is treated as standalone.`CronJob` does not create or manage `Workload` objects,
+`CronJob` is treated as standalone. `CronJob` does not create or manage `Workload` objects,
 the Job controller creates a separate `Workload` and `PodGroup` per `Job`. These objects are
 garbage-collected when each `Job` completes or is deleted.
 
@@ -441,11 +443,11 @@ outcome matches a standard Job, while a `Basic` `Workload`/`PodGroup` is still m
   the `Job` share a single scheduling policy. Elastic scaling is supported through the mutable `gang.minCount`.
 - `spec.scheduling.policy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
   other `spec.scheduling` fields are immutable after creation.
-- Opting out of `Workload` creation happens implicitly in two ways: omitting `spec.scheduling`
-  still yields a controller-owned `Basic` `Workload`/`PodGroup`, while a Job whose parent owns the
-  `Workload` does not create its own `Workload`. In the latter case, the Job controller still
-  creates the runtime `PodGroup` when the parent delegates it via annotation ([KEP-6089]), and 
-  skips the `PodGroup` too only when the parent owns both objects.
+- The Job controller creates `Workload`/`PodGroup` objects for every eligible Job, including  
+`Basic` scheduling, the only way to avoid the objects entirely is to disable the feature gate. 
+What is opt-in is the scheduling behavior (gang-scheduling, topology constraints, disruption 
+modes, etc.) are requested explicitly via `spec.scheduling`. By default, an end user gets 
+the original scheduling outcome even though a `Basic` `Workload`/`PodGroup` is still created.
 
 ### Risks and Mitigations
 
@@ -494,11 +496,10 @@ single-level `Job`:
   the delegated case the Job controller creates and manages the `PodGroup` for its own 
   pods even though it does not own the `Workload`.
 - **Universal Representation.** Standard pod-by-pod scheduling is a first-class policy (`Basic`).
-  The controller always emits a `Workload`/`PodGroup` for an eligible Job, using `Basic` as the
-  backward-compatible default. `Basic` keeps the standard scheduling outcome, while still 
-  participating in the Workload Scheduling Cycle, without enforcing minCount.
-- **Sane Defaults and Escape Hatches.** A `Job` defaults to `Basic`. Users can opt in to `Gang`,
-  request topology constraints, and configure disruption modes.
+  The controller always emits a `Workload`/`PodGroup` for an eligible Job, using `Basic` as the 
+  backward-compatible default. `Basic` keeps the standard scheduling outcome, 
+  while still participating in the Workload Scheduling Cycle, without enforcing minCount.
+- **Sane Defaults and Escape Hatches.** A `Job` defaults to `Basic`.
 
 ### Job API Changes
 
@@ -545,7 +546,8 @@ type JobSchedulingConfiguration struct {
 The `Scheduling` field is gated by the existing `WorkloadWithJob` feature gate. Standard alpha
 field-gating semantics apply: when the gate is disabled, the API server clears `spec.scheduling` on
 create and ignores it on update (preserving an already-set value on the stored object), and the
-field's defaulting, validation, and controller compilation only run when the gate is enabled.
+field's validation and the controller's compilation (including its compile-time resolution of unset
+fields; the api-server does not default `spec.scheduling`) only run when the gate is enabled.
 
 This typed, user-facing field replaces the v1.36 alpha's implicit mechanisms: the type-based
 automatic policy inference and the `spec.template.spec.schedulingGroup`-based opt-out are no longer
@@ -592,7 +594,7 @@ The controller's `generateWorkload` helper performs four steps:
   create/update and must be self-contained (no dependency on cluster state or other 
   live objects). It checks:
    * exactly one scheduling policy is set (`basic` xor `gang`).
-   * `gang.minCount`, when set, is `>= 1`and does not exceed `spec.parallelism`. A gang 
+   * `gang.minCount`, when set, is `>= 1` and does not exceed `spec.parallelism`. A gang 
    larger than the pod count can never be satisfied and the Job would stall indefinitely 
    with pending pods, so this faulty state is rejected at admission rather than left to 
    surface only at runtime. An elastic scale-up that sets `spec.parallelism` and 
@@ -601,8 +603,7 @@ The controller's `generateWorkload` helper performs four steps:
    * on update, every `spec.scheduling` field is immutable **except** `gang.minCount`.
 2. **`workloadbuilder` semantic validation** owns the *consistency* rules. The API server calls the
    library's `Validate` entrypoint, which performs the same configuration resolution and policy
-   validation that `Build` runs — resolving `DefaultConfig` + `DefaultGangMinCount` + `UserConfig`
-   and validating the resulting policies and constraints — and returns aggregated field errors. This
+   validation that `Build` runs and returns aggregated field errors. This
    guarantees that any configuration the API server accepts is one the controller can compile into a
    valid `Workload`, rejecting combinations that are structurally legal but semantically invalid
    (e.g. an unsupported disruption mode, or a policy/constraint pairing the builder cannot translate)
@@ -627,11 +628,11 @@ keys on for gang/topology behavior.
 #### Reconcile Integration and Error Handling
 
 `generateWorkload`/`instantiatePodGroup` are invoked from the Job reconcile loop, gated on the
-`WorkloadWithJob` feature gate and only when the Job has no pods yet. The integration is 
-designed to be idempotent and crash-safe:
+  `WorkloadWithJob` feature gate and only when the Job has no pods yet. The integration is 
+  designed to be idempotent and crash-safe:
 
 - **Discovery first:** the controller looks up an existing `Workload`/`PodGroup` (via
-  `spec.controllerRef` / `spec.podGroupTemplateReference`) before compiling, so a restart between
+  `spec.controllerRef` / `spec.podGroupTemplateRef`) before compiling, so a restart between
   creating the `Workload` and the `PodGroup` does not produce duplicates.
 - **Ordering:** `Workload` is created (or found) before the `PodGroup`, and both before pods, so
   references always resolve.
@@ -664,7 +665,7 @@ A `Workload` is considered the Workload for this Job object if:
 
 Similarly, a `PodGroup` is considered the `PodGroup` for this Job if:
 - The `PodGroup` is in the Job’s namespace
-- Its `spec.podGroupTemplateReference.workload.workloadName` equals the name of the `Workload` for this Job. 
+- Its `spec.podGroupTemplateRef.workload.workloadName` equals the name of the `Workload` for this Job. 
 
 #### Controller Workflow
 
@@ -682,10 +683,10 @@ The controller discovers or creates `Workload` and `PodGroup` as follows:
 It then branches on whether the parent delegates `PodGroup` management, detected via the 
 `scheduling.k8s.io/podgroup-template` annotation on the Job:
    - **Annotation present (PodGroup delegated):** the parent owns the `Workload` but expects the Job
-     to manage its own runtime `PodGroup`. Proceed to step 5, creating the `PodGroup` mapped to the
-     parent's named `PodGroupTemplate` (annotation value) and attaching it to the parent instance
-     named by `scheduling.k8s.io/parent-composite-podgroup`. The `PodGroup` gets a controller
-     `ownerReference` to the Job.
+     to manage its own runtime `PodGroup`. Proceed to step 5, creating the `PodGroup` linked to the
+     parent-owned `Workload` via the parent's named `PodGroupTemplate` (the annotation value) and when
+     the annotation is also present, additionally link it to that parent 
+     `CompositePodGroup` instance. The `PodGroup` gets a controller `ownerReference` to the Job.
    - **Annotation absent (both delegated):** the parent owns both the `Workload` and the `PodGroup`.
      The Job controller skips creation entirely, discovers any existing objects, and uses them when
      creating pods.
@@ -706,9 +707,9 @@ It then branches on whether the parent delegates `PodGroup` management, detected
    associated with the target `PodGroupTemplate` for this Job. For a root Job that template lives in
    the Job-owned `Workload` while a delegated non-root Job (step 1, annotation present) it is the
    parent's `PodGroupTemplate`.
-  - If none found, create a `PodGroup` with a controller `ownerReference` to the `Job`. For a root
-    Job, also add an `ownerReference` to the Job-owned `Workload`; for a delegated Job, link it to
-    the parent instance named by `scheduling.k8s.io/parent-composite-podgroup` instead.
+  - If none found, create a `PodGroup` with a controller `ownerReference` to the `Job`. 
+  The Job-owned `Workload` for a root Job, the parent-owned `Workload` for a delegated Job. 
+  When the annotation is present, link it to that parent `CompositePodGroup` instance.
   - If exactly one, that is the `PodGroup` for this Job; no changes to its `ownerReference`.
   - If multiple PodGroups, fall back as that is not supported in alpha.
 6. Execute the existing pod-management logic to create pods, including `schedulingGroup.podGroupName`
@@ -759,13 +760,16 @@ By this ownerReferences relationship, garbage collection will remove objects acc
 
 #### Defaulting Rules
 
-- **`Scheduling` unset → `Basic`.** Existing Jobs and users that do not opt into WAS carry no 
-`spec.scheduling`. Defaulting the whole field to a `Basic` policy preserves their behavior.
+These rules are applied by the controller when it compiles the
+`Workload`/`PodGroup`; they are not api-server field defaulting. 
+This is a controller-side resolution that is required to resolve the unset case anyway.
+
+- **`Scheduling` unset → `Basic`.** Existing and non-WAS Jobs carry no `spec.scheduling`, the
+  controller resolves the absent policy to `Basic`, preserving their behavior.
 - **`Scheduling` set but `Policy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
-discriminated union for which the compiled `PodGroup` must carry exactly one concrete policy 
-where a nil `Policy` has no valid compiled form.
-- **`Gang` with `MinCount` unset → `MinCount = parallelism`** (or `MinCount = completions` when
-  `parallelism` is unset): a context-aware sane default for the gang size.
+  discriminated union for which the compiled `PodGroup` must carry exactly one concrete policy, so a
+  nil `Policy` is resolved to `Basic`.
+- **`Gang` with `MinCount` unset → `MinCount = parallelism`.** a context-aware sane gang size supplied via `DefaultGangMinCount`.
 
 Optional modifiers (`DisruptionMode`, `Constraints`, `ResourceClaims`) are deliberately not
 defaulted. Unlike `Policy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `Constraints`
@@ -796,7 +800,7 @@ consistent with what the controller actually compiles. The update-validation rul
   updates for gang Jobs is removed, restoring Elastic Indexed Jobs.
   * `spec.scheduling.policy.gang.minCount` is *mutable* in-flight: on change the controller
   recompiles the `Workload` and re-syncs the `PodGroup` size.
-  * All other `spec.scheduling` fields remain *immutable* after creation, enforced by registry
+  * All other `spec.scheduling` fields remain *immutable* after creation, enforced by api-server
   validation, since changing the policy, topology, disruption mode, or resourceClaims would require
   recreating the `Workload`/`PodGroup`.
 
@@ -808,7 +812,7 @@ scale the gang without ever touching `spec.scheduling`.
 A user can change the target gang size in one of two ways:
 
 - by setting `spec.scheduling.policy.gang.minCount` directly, when it is set explicitly
-- by setting `spec.parallelism`, when `minCount` is unset (and therefore follows `parallelism`).
+- by setting `spec.parallelism`, when `minCount` is unset.
 
 In either case, the Job controller reconciles the change as follows:
 
@@ -830,7 +834,8 @@ scheduling cycle.
 ### Interaction with BYO Workload/PodGroup
 
 The reconciliation above applies only to a `Workload`/`PodGroup` that the Job controller created
-and owns. There is another case where the `Workload` and/or `PodGroup` is pre-created by a user or a higher-level:
+and owns. There is another case where the `Workload` and/or `PodGroup` is pre-created by a user or a
+higher-level controller:
 
 - **BYO `Workload`:** the user pre-creates a `Workload` whose `spec.controllerRef` points to 
 the `Job` and still expects the `Job` controller to create the runtime `PodGroup`(s) from 
@@ -897,8 +902,9 @@ to implement this enhancement.
 - `k8s.io/kubernetes/pkg/apis/batch/validation`: `2026-06-03` - `86.8%`
 - `k8s.io/kubernetes/pkg/registry/batch/job`: `2026-06-03` - `92.2%`
 - Add tests that verify:
-  - Defaulting: an omitted `spec.scheduling` defaults to the `Basic` policy; a `Gang` policy with a
-    nil `MinCount` defaults to `MinCount = parallelism` (or `completions` when parallelism is unset).
+  - An omitted `spec.scheduling` is resolved by the controller to the `Basic` 
+  policy, and a `Gang` policy with a nil `MinCount` is resolved to `MinCount = parallelism` 
+  without the api-server writing these values back into the Job's `spec.scheduling`.
   - `workloadbuilder` compilation: `Basic` vs `Gang` policy, and that topology constraints,
     disruption mode (single/all), and resourceClaims are mapped into the generated `Workload`/
     `PodGroup`; that a `Job` builds a flat single-node tree via `MapPodGroupConfig`.
@@ -914,14 +920,13 @@ to implement this enhancement.
     no annotation creates neither `Workload` nor `PodGroup`.
   - Parent-owned `Workload`, `PodGroup` delegated: a Job with an `OwnerReference` to a parent
     workload and the annotation present does not create a `Workload`, but does create a `PodGroup` 
-    mapped to the parent's named `PodGroupTemplate` and linked to the
-    parent instance from `scheduling.k8s.io/parent-composite-podgroup`.
+    linked to the parent-owned `Workload`.
   - Job deletion cascades to `Workload` and `PodGroup` deletion.
   - ownerReferences on controller-created objects match the expected structure:
     - Root Job: `Workload` has a controller ownerRef to the Job; `PodGroup` has a controller ownerRef
       to the Job and a non-controller ownerRef to the `Workload`.
-    - Delegated Job: `PodGroup` has a controller ownerRef to the Job and links to the parent-owned
-      `Workload`/`CompositePodGroup` (no Job-owned `Workload` exists).
+    - Delegated Job: `PodGroup` has a controller ownerRef to the Job and links to the parent-owned 
+    `Workload`/`CompositePodGroup` (no Job-owned `Workload` exists).
   - Naming abbreviations for `Workload` and `PodGroup`.
 
 ##### Integration tests
@@ -995,9 +1000,13 @@ This second alpha replaces the automatic model with the user-facing API:
 
 - Promote the `WorkloadWithJob` feature gate to enabled by default.
 - Evaluate whether the Job controller's [current batch-create](https://github.com/kubernetes/kubernetes/blob/2023f445eca52e6baa72139e56c6e4e01be0ee97/pkg/controller/job/job_controller.go#L1780-L1838) of pods should change when gang scheduling is active (it slows pod creation), and document the decision.
-- The controller must delete `PodGroup`/`Workload` when a Job is suspended and recreate them on
-  resume, so that resources (including DRA claims) are properly released and the scheduler can
-  make fresh placement decisions.
+- Decide which objects (`PodGroup` and/or `Workload`) the controller should delete when a Job is
+  suspended and recreate on resume, so that resources are properly released and the scheduler 
+  can make fresh placement decisions.
+- Revisit the handling of ambiguous/malformed discovery (more than one `Workload`, or more than one
+  `PodGroup`, associated with a Job). In alpha the controller falls back and surfaces a condition/event;
+  for Beta, decide on stronger handling and define the condition type/reason. This applies to both 
+  `Workload` and `PodGroup`.
 - Address feedback from alpha and confirm the `spec.scheduling` API shape and defaulting are stable.
 - E2e tests covering gang, topology, disruption, and elastic-scaling scenarios.
 - Metrics for monitoring `Workload`/`PodGroup` creation and scheduling outcomes.
@@ -1021,12 +1030,15 @@ N/A for alpha release
      defaulting to `Basic` when the field is omitted.
 
 - **Downgrade:**
-  1. Disable the feature gate and downgrade kube-controller-manager.
-  2. The API server clears `spec.scheduling` on writes (preserving an already-set value on the stored
-     object), and the controller stops compiling `Workload`/`PodGroup`.
-  3. Existing `Workload` and `PodGroup` objects remain.
-  4. Jobs with `schedulingGroup.podGroupName` on their pods continue to run (the field is ignored).
-  5. New pods will not have `schedulingGroup.podGroupName` set.
+  Disable the feature gate on both kube-controller-manager and kube-apiserver. With the gate 
+  disabled on kube-apiserver, it clears `spec.scheduling` on create and ignores it on update. 
+  With the gate disabled on kube-controller-manager, the controller stops compiling 
+  `Workload`/`PodGroup`. If the gate is left enabled on kube-apiserver, 
+  `spec.scheduling` is still served and accepted even though no controller acts on it.
+  
+  Existing `Workload` and `PodGroup` objects remain and Jobs with 
+  `schedulingGroup.podGroupName` on their pods continue to run and new pods will not 
+  have `schedulingGroup.podGroupName` set.
 
 - **Behavior change between alphas:** in v1.36, indexed fully-parallel Jobs were automatically
   gang-scheduled; in v1.37 those same Jobs default to `Basic` unless the user sets
@@ -1056,11 +1068,12 @@ Workload-aware scheduling for a Job only takes effect when:
 - The scheduler supports `Workload`/`PodGroup`.
 
 Therefore, for a safe rollout:
-- kube-apiserver must be upgraded first so it can serve `scheduling.k8s.io/v1alpha3` and persist the
-  new `spec.scheduling` field.
-- kube-controller-manager can be upgraded before or after the scheduler.
-- kube-scheduler should be upgraded before or together with kube-controller-manager; gang/topology
-  semantics will not apply until the scheduler is upgraded.
+- kube-apiserver must be upgraded first so it includes the v1.37 `batch/v1` Job API changes and can
+  accept and persist the new `spec.scheduling` field.
+- kube-controller-manager and kube-scheduler can be upgraded in either order relative to each other;
+  both orders are safe. Gang/topology semantics simply do not take effect until *both* are upgraded:
+  until the scheduler is upgraded it ignores `schedulingGroup`, and until the controller is upgraded
+  no `Workload`/`PodGroup` is compiled for the scheduler to act on.
 
 Skew scenarios:
 - **kube-controller-manager new, kube-scheduler old:** the controller compiles `Workload` 
@@ -1092,15 +1105,8 @@ Skew scenarios:
     of a node?
 
 ###### Does enabling the feature change any default behavior?
-Yes. When the feature gate is enabled:
-
-1. The `batch/v1` `spec.scheduling` field becomes available; the API server persists it and defaults
-   it to the `Basic` policy when omitted.
-2. The Job controller compiles `spec.scheduling` into a `Workload` and `PodGroup` for every root Job
-   (one that owns its `Workload`) before creating pods — including `Basic` Jobs.
-3. Jobs that set `spec.scheduling.policy.gang` use gang scheduling, meaning all `minCount` pods must
-   be scheduled together or none are scheduled.
-4. The binding of pods referencing a `PodGroup` is delayed until the `PodGroup` object exists.
+Yes. The core change is that `Workload`/`PodGroup` objects are now created and managed for 
+each eligible Job, including `Basic` (default) Jobs.
 
 Note this differs from the v1.36 alpha, where indexed fully-parallel Jobs were gang-scheduled
 automatically. In v1.37 gang scheduling is an explicit opt-in via `spec.scheduling`; absent the
@@ -1108,17 +1114,21 @@ field, Jobs default to `Basic`.
 
 ###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
 
-Yes. The feature can be disabled (`WorkloadWithJob: false`). The API server then clears
-`spec.scheduling` on writes (preserving an already-stored value), and the controller stops compiling
-`Workload` and `PodGroup`.
+Yes. With the gate disabled on kube-apiserver, it clears `spec.scheduling` on creations; with the 
+gate disabled on kube-controller-manager, the controller stops compiling `Workload` and `PodGroup`.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
 When the feature is re-enabled:
 - New and reconciled Jobs without running pods get `Workload` and `PodGroup` compiled from their
   `spec.scheduling` (defaulting to `Basic`) on their next reconciliation cycle.
-- Jobs that already have running pods are not affected, since scheduling policy only applies to
-  pods evaluated in future scheduling cycles.
+- Jobs that already have a `Workload`/`PodGroup` from before the rollback are not recreated or
+  recompiled: on reconcile the controller discovers the existing objects and reuses them. If only a
+  partial set exists — e.g., a `Workload` but no `PodGroup`, left by a controller that was disabled
+  mid-creation, the controller completes the missing object on its next sync, provided the Job has
+  no pods yet.
+- Jobs that already have running pods are not affected, their existing `Workload`/`PodGroup` remain in
+  use, and scheduling policy only applies to pods evaluated in future scheduling cycles.
 - A previously stored `spec.scheduling` value on a Job is honored again once the gate is on.
 
 ###### Are there any tests for feature enablement/disablement?
@@ -1136,8 +1146,11 @@ Yes. We will add unit tests and integration tests for feature enablement/disable
   with no gang/topology benefit.
 - Already running Jobs are not affected by enabling the feature; pods already scheduled and 
   running continue to run. New Jobs or Jobs being reconciled are affected.
-- On rollback, disabling the feature gate lets Jobs run without `Workload` or `PodGroup` compilation. 
-  Existing objects are harmless; they are ignored while the feature is disabled.
+- On rollback, disabling the feature gate stops the Job controller from compiling new
+  `Workload`/`PodGroup` objects and from setting `schedulingGroup.podGroupName` on newly created 
+  pods. It does not disable gang-scheduling in the scheduler. Existing `Workload`/`PodGroup` 
+  objects therefore remain active, and pods that already reference a `PodGroup` continue to be 
+  gang-scheduled.
 
 ###### What specific metrics should inform a rollback?
 
@@ -1194,9 +1207,7 @@ No.
 
 ###### Does this feature depend on any specific services running in the cluster?
 
-- `scheduling.k8s.io/v1alpha3` for the `Workload` and `PodGroup` APIs ([KEP-6089]).
-- The shared `workloadbuilder` library that compiles user intent into `Workload`/`PodGroup` objects.
-- `kube-scheduler` with `Workload`/`PodGroup` (gang/topology) support enabled.
+No.
 
 ### Scalability
 
@@ -1223,11 +1234,12 @@ No.
 
 ###### Will enabling / using this feature result in increasing size or count of the existing API objects?
 
-Yes. Because of Universal Representation, every eligible Job (both `Gang` and `Basic`) creates 1 
+Yes. Because of Universal Representation, every root Job (both `Gang` and `Basic`) creates 1 
 `Workload` (~500 bytes) and 1 `PodGroup` (~500 bytes), and each Pod gains a `schedulingGroup` 
-field (~100 bytes).
+field (~100 bytes). A delegated non-root Job adds only a `PodGroup`, and a fully-delegated Job
+(parent owns both objects) adds neither.
 
-For a cluster with 10,000 eligible Jobs, this adds approximately:
+For a cluster with 10,000 root Jobs, this adds approximately:
 - 10,000 `Workload` objects
 - 10,000 `PodGroup` objects
 - ~10MB additional etcd storage

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -10,6 +10,7 @@
   - [Job Integration - API Usage Examples](#job-integration---api-usage-examples)
     - [Example 1: Gang scheduling with zone topology and atomic disruption](#example-1-gang-scheduling-with-zone-topology-and-atomic-disruption)
     - [Example 2: Backward Compatibility and Sane Defaulting (Implicit Opt-Out)](#example-2-backward-compatibility-and-sane-defaulting-implicit-opt-out)
+    - [Example 3: CronJob with Gang Scheduling](#example-3-cronjob-with-gang-scheduling)
   - [User Stories](#user-stories)
     - [ML Training Job with Gang Scheduling](#ml-training-job-with-gang-scheduling)
     - [Standard Batch Job with Workload Tracking](#standard-batch-job-with-workload-tracking)
@@ -77,7 +78,7 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
 - [ ] (R) Graduation criteria is in place
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
 - [x] (R) Production readiness review completed
-- [ ] (R) Production readiness review approved
+- [x] (R) Production readiness review approved
 - [x] "Implementation History" section is up-to-date for milestone
 - [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
 - [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
@@ -343,7 +344,44 @@ spec:
     basic: {}
 ```
 
-In both cases, the Job controller then creates the pods and sets the `schedulingGroup` field so the
+#### Example 3: CronJob with Gang Scheduling
+
+A `CronJob` that periodically runs a gang-scheduled training Job. Each `Job` created by the
+`CronJob` is treated as standalone. `CronJob` is *not* a registered parent workload, so the Job
+controller creates a separate `Workload` and `PodGroup` per `Job`. These objects are
+garbage-collected when each `Job` completes or is deleted.
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: periodic-training
+  namespace: training
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      parallelism: 4
+      completions: 4
+      completionMode: Indexed
+      scheduling:
+        policy:
+          gang: {}            # minCount defaults to parallelism (4) per Job
+      template:
+        spec:
+          containers:
+          - name: trainer
+            image: training-image:latest
+            resources:
+              limits:
+                nvidia.com/gpu: 1
+```
+
+Each `Job` created by this `CronJob` produces its own `Workload` and `PodGroup`, compiled from
+the Job's `spec.scheduling`.
+If the `CronJob`'s `jobTemplate` omits the `scheduling` block, each `Job` defaults to `Basic`.
+
+In all cases, the Job controller then creates the pods and sets the `schedulingGroup` field so the
 scheduler can associate each pod with its `PodGroup`:
 
 ```yaml
@@ -970,6 +1008,8 @@ We will add the following integration tests to the Job controller (`test/integra
 - Elastic gang resize via `minCount` update.
 - Mixed workloads: gang and basic Jobs coexist.
 - Failure scenarios, e.g., insufficient resources for a gang, partial failures.
+- CronJob with gang scheduling: each Job created by the CronJob gets its own `Workload`/`PodGroup`,
+  and completed Jobs clean up their scheduling objects via GC.
 
 ### Graduation Criteria
 
@@ -1004,7 +1044,9 @@ This second alpha replaces the automatic model with the user-facing API:
 
 - Promote the `WorkloadWithJob` feature gate to enabled by default.
 - Evaluate whether the Job controller's [current batch-create](https://github.com/kubernetes/kubernetes/blob/2023f445eca52e6baa72139e56c6e4e01be0ee97/pkg/controller/job/job_controller.go#L1780-L1838) of pods should change when gang scheduling is active (it slows pod creation), and document the decision.
-- The controller needs a mechanism to delete `PodGroup`/`Workload` for suspended Jobs and recreate on resume.
+- The controller must delete `PodGroup`/`Workload` when a Job is suspended and recreate them on
+  resume, so that resources (including DRA claims) are properly released and the scheduler can
+  make fresh placement decisions.
 - Address feedback from alpha and confirm the `spec.scheduling` API shape and defaulting are stable.
 - E2e tests covering gang, topology, disruption, and elastic-scaling scenarios.
 - Metrics for monitoring `Workload`/`PodGroup` creation and scheduling outcomes.

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -35,6 +35,7 @@
     - [Object Creation Order](#object-creation-order)
     - [Handling Updates and Mutability](#handling-updates-and-mutability)
     - [Reconciliation Flow upon Updates](#reconciliation-flow-upon-updates)
+  - [Interaction with BYO Workload/PodGroup](#interaction-with-byo-workloadpodgroup)
   - [Naming Conventions](#naming-conventions)
   - [Deletion and Garbage Collection](#deletion-and-garbage-collection)
   - [Test Plan](#test-plan)
@@ -724,7 +725,9 @@ If the `Workload` was created by another actor (e.g., a higher-level controller 
 pre-creates a `Workload`), the Job controller respects and uses it and its associated PodGroups when
 creating pods. The Job controller falls back (ignores the discovered `Workload`/`PodGroup`) when the
 discovered `Workload` has an unsupported structure (for alpha, when the number of `PodGroupTemplates`
-is not 1). In that case, a condition or event should be triggered to inform the user.
+is not 1). In that case, a condition or event should be triggered to inform the user. See
+[Interaction with BYO `Workload`/`PodGroup`](#interaction-with-byo-workloadpodgroup) for how
+`spec.scheduling` behaves in this case and why such objects are never mutated by the controller.
 
 #### OwnerReferences Relationship
 
@@ -756,14 +759,17 @@ By this ownerReferences relationship, garbage collection will remove objects acc
 
 #### Defaulting Rules
 
-To ensure backward compatibility and avoid breaking existing pipelines:
+- **`Scheduling` unset → `Basic`.** Existing Jobs and users that do not opt into WAS carry no 
+`spec.scheduling`. Defaulting the whole field to a `Basic` policy preserves their behavior.
+- **`Scheduling` set but `Policy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
+discriminated union for which the compiled `PodGroup` must carry exactly one concrete policy 
+where a nil `Policy` has no valid compiled form.
+- **`Gang` with `MinCount` unset → `MinCount = parallelism`** (or `MinCount = completions` when
+  `parallelism` is unset): a context-aware sane default for the gang size.
 
-- If `Scheduling` is unset or `Policy` is nil, the Job controller defaults to the `Basic` scheduling
-  policy (standard pod-by-pod scheduling).
-- If a user selects `Gang` but leaves `MinCount` unset, the controller injects a context-aware sane
-  default of `MinCount = parallelism` (or `MinCount = completions` when `parallelism` is unset).
-- Users can configure an escape hatch — for example, requesting only topology constraints while
-  keeping the standard `Basic` policy.
+Optional modifiers (`DisruptionMode`, `Constraints`, `ResourceClaims`) are deliberately not
+defaulted. Unlike `Policy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `Constraints`
+means no topology co-location, and a nil `ResourceClaims` means no shared claims.
 
 #### Object Creation Order
 
@@ -820,6 +826,30 @@ In either case, the Job controller reconciles the change as follows:
 already-scheduled pods and apply only to pods evaluated in future scheduling cycles. The scheduler
 also operates on an eventually consistent view, so an update may not take effect until the next
 scheduling cycle.
+
+### Interaction with BYO Workload/PodGroup
+
+The reconciliation above applies only to a `Workload`/`PodGroup` that the Job controller created
+and owns. There is another case where the `Workload` and/or `PodGroup` is pre-created by a user or a higher-level:
+
+- **BYO `Workload`:** the user pre-creates a `Workload` whose `spec.controllerRef` points to 
+the `Job` and still expects the `Job` controller to create the runtime `PodGroup`(s) from 
+that `Workload` template.
+- **BYO `PodGroup`:** the user manages the `PodGroup` themselves and wires pods to it by setting
+  `pod.spec.schedulingGroup.podGroupName` directly via the `PodTemplate`. Here the controller does
+  not create or own the `PodGroup` at all.
+
+In both cases the `Job` controller treats the discovered object as the source of truth and does not
+take ownership of it and it adds no controller `ownerReference`, never mutates it on `Job` spec 
+changes, and does not delete it.
+
+How the new `spec.scheduling` fields interact with BYO objects:
+
+- When an authoritative BYO `Workload`/`PodGroup` is present for the `Job`, the controller uses it 
+as-is and does not translate `spec.scheduling` into it or reconcile the two. This avoids a split-brain where the controller would fight the object's owner or over reconcile the two.
+- `minCount` is not synced into a BYO `PodGroup` [KEP-4671].
+- If a discovered `Workload` has an unsupported shape for alpha, the controller ignores it and 
+surfaces a condition or event.
 
 ### Naming Conventions
 
@@ -910,6 +940,10 @@ We will add the following integration tests to the Job controller (`test/integra
 - A Job owned by a parent workload skips `Workload` creation and skips `PodGroup`
   creation when no annotation is set, but creates a `PodGroup`
   mapped to the parent's `PodGroupTemplate` when the annotation is present.
+- The controller discovers and uses a pre-created `Workload`/`PodGroup`,
+  does not take ownership, and does not mutate it on Job spec changes — in particular, updating
+  `spec.scheduling.policy.gang.minCount` leaves a BYO `PodGroup`'s `minCount` untouched, and 
+  the BYO object is not GC'd when the Job is deleted.
 - Jobs created by CronJob get one `Workload` and one `PodGroup` per Job, and these are GC'd when the
   Job completes or is deleted.
 - When a Job is suspended, pods are deleted but `Workload`/`PodGroup` remain; on resume the same

--- a/keps/sig-apps/5547-integrate-workload-with-job/kep.yaml
+++ b/keps/sig-apps/5547-integrate-workload-with-job/kep.yaml
@@ -17,19 +17,22 @@ approvers:
   - "@dom4ha"
 
 see-also:
+  - "/keps/sig-scheduling/6089-was-controller-apis"
   - "/keps/sig-scheduling/4671-gang-scheduling"
   - "/keps/sig-scheduling/5832-decouple-podgroup-api"
+  - "/keps/sig-scheduling/5710-workload-aware-preemption"
+  - "/keps/sig-scheduling/5732-topology-aware-workload-scheduling"
   - "/keps/sig-apps/2232-suspend-jobs"
   - "/keps/sig-scheduling/2926-job-mutable-scheduling-directives"
 
 stage: alpha
 
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 milestone:
-  alpha: "v1.36"
-  beta: "v1.37"
-  stable: "v1.39"
+  alpha: "v1.37"
+  beta: "v1.38"
+  stable: "v1.40"
 
 feature-gates:
   - name: WorkloadWithJob

--- a/keps/sig-apps/5547-integrate-workload-with-job/kep.yaml
+++ b/keps/sig-apps/5547-integrate-workload-with-job/kep.yaml
@@ -30,9 +30,7 @@ stage: alpha
 latest-milestone: "v1.37"
 
 milestone:
-  alpha: "v1.37"
-  beta: "v1.38"
-  stable: "v1.40"
+  alpha: "v1.36"
 
 feature-gates:
   - name: WorkloadWithJob


### PR DESCRIPTION
- One-line PR description: Update Job integration Kep for alpha2 to include the https://github.com/kubernetes/enhancements/issues/6089 and `minCount` mutability in https://github.com/kubernetes/enhancements/issues/4671 .

- Issue link: https://github.com/kubernetes/enhancements/issues/5547

- Other comments: