### PR TITLE
KEP-5978: DRA ClusterResourceClaimTemplate

### DIFF
--- a/keps/prod-readiness/sig-node/5978.yaml
+++ b/keps/prod-readiness/sig-node/5978.yaml
@@ -1,0 +1,3 @@
+kep-number: 5978
+alpha:
+  approver: "@johnbelamaric"

--- a/keps/sig-node/5978-cluster-resource-claim-template/README.md
+++ b/keps/sig-node/5978-cluster-resource-claim-template/README.md
@@ -67,6 +67,8 @@ SIG Architecture for cross-cutting KEPs).
 -->
 # KEP-5978: DRA: ClusterResourceClaimTemplate
 
+**NOTE:** This KEP was withdrawn in favor of [the Out-of-Tree Synchronization Controller alternative](#out-of-tree-alternative).
+
 <!--
 This is the title of your KEP. Keep it short, simple, and descriptive. A good
 title can help communicate what the KEP is and should be considered as part of
@@ -1094,6 +1096,7 @@ Major milestones might include:
 -->
 
 - **2026-06-02**: Initial KEP drafted and proposed targeting v1.37 Alpha.
+- **2026-06-16**: KEP withdrawn in favor of an out-of-tree controller solution.
 
 ## Drawbacks
 
@@ -1121,6 +1124,29 @@ information to express the idea and why it was not acceptable.
     silently override/shadow the cluster-scoped template, changing Pod
     provisioning paths without explicit audit trails. Dedicated fields make
     references completely explicit and easily auditable.
+
+<a id="out-of-tree-alternative"></a>
+- **Out-of-Tree Synchronization Controller / CRD**: Create an out-of-tree
+  controller (for example, in a `kubernetes-sigs` repository) that automatically
+  generates namespaced `ResourceClaimTemplate` objects in target namespaces. This
+  could be driven either by a `ClusterResourceClaimTemplate` CRD or by publishing
+  master `ResourceClaimTemplate` objects in a centralized controller namespace
+  using a special naming convention or annotation mapping. Pods would then
+  refer to the generated namespaced templates by name.
+  - *Trade-offs / Motivation for Withdrawal*: While this approach involves certain
+    trade-offs compared to an in-tree API:
+    - **Race Conditions**: When a new namespace is created, Pods referencing the
+      template might be rejected or fail to deploy if they are created before the
+      out-of-tree controller finishes copying the template into the new namespace.
+    - **Resource Proliferation and Overhead**: Duplicating identical template
+      objects across tens or hundreds of namespaces creates unnecessary `etcd`
+      storage overhead and additional API server load.
+
+    Despite these trade-offs, the SIG decided to withdraw this KEP in favor of this
+    out-of-tree controller approach. The alternative is considered good enough to
+    fulfill the target use cases, and implementing an in-tree solution does not
+    justify the required engineering effort and the expansion of the core
+    Kubernetes API surface.
 
 ## Infrastructure Needed (Optional)
 

--- a/keps/sig-node/5978-cluster-resource-claim-template/README.md
+++ b/keps/sig-node/5978-cluster-resource-claim-template/README.md
@@ -1,0 +1,1102 @@
+<!--
+**Note:** When your KEP is complete, all of these comment blocks should be removed.
+
+Follow the guidelines of the [documentation style guide].
+In particular, wrap lines to a reasonable length, to make it
+easier for reviewers to cite specific portions, and to minimize diff churn on
+updates.
+
+[documentation style guide]: https://github.com/kubernetes/community/blob/master/contributors/guide/style-guide.md
+
+To get started with this template:
+
+- [ ] **Pick a hosting SIG.**
+  Make sure that the problem space is something the SIG is interested in taking
+  up. KEPs should not be checked in without a sponsoring SIG.
+- [ ] **Create an issue in kubernetes/enhancements**
+  When filing an enhancement tracking issue, please make sure to complete all
+  fields in that template. One of the fields asks for a link to the KEP. You
+  can leave that blank until this KEP is filed, and then go back to the
+  enhancement and add the link.
+- [ ] **Make a copy of this template directory.**
+  Copy this template into the owning SIG's directory and name it
+  `NNNN-short-descriptive-title`, where `NNNN` is the issue number (with no
+  leading-zero padding) assigned to your enhancement above.
+- [ ] **Fill out as much of the kep.yaml file as you can.**
+  At minimum, you should fill in the "Title", "Authors", "Owning-sig",
+  "Status", and date-related fields.
+- [ ] **Fill out this file as best you can.**
+  At minimum, you should fill in the "Summary" and "Motivation" sections.
+  These should be easy if you've preflighted the idea of the KEP with the
+  appropriate SIG(s).
+- [ ] **Create a PR for this KEP.**
+  Assign it to people in the SIG who are sponsoring this process.
+- [ ] **Merge early and iterate.**
+  Avoid getting hung up on specific details and instead aim to get the goals of
+  the KEP clarified and merged quickly. The best way to do this is to just
+  start with the high-level sections and fill out details incrementally in
+  subsequent PRs.
+
+Just because a KEP is merged does not mean it is complete or approved. Any KEP
+marked as `provisional` is a working document and subject to change. You can
+denote sections that are under active debate as follows:
+
+```
+<<[UNRESOLVED optional short context or usernames ]>>
+Stuff that is being argued.
+<<[/UNRESOLVED]>>
+```
+
+When editing KEPS, aim for tightly-scoped, single-topic PRs to keep discussions
+focused. If you disagree with what is already in a document, open a new PR
+with suggested changes.
+
+One KEP corresponds to one "feature" or "enhancement" for its whole lifecycle.
+You do not need a new KEP to move from beta to GA, for example. If
+new details emerge that belong in the KEP, edit the KEP. Once a feature has become
+"implemented", major changes should get new KEPs.
+
+The canonical place for the latest set of instructions (and the likely source
+of this file) is [here](/keps/NNNN-kep-template/README.md).
+
+**Note:** Any PRs to move a KEP to `implementable`, or significant changes once
+it is marked `implementable`, must be approved by each of the KEP approvers.
+If none of those approvers are still appropriate, then changes to that list
+should be approved by the remaining approvers and/or the owning SIG (or
+SIG Architecture for cross-cutting KEPs).
+-->
+# KEP-5978: DRA: ClusterResourceClaimTemplate
+
+<!--
+This is the title of your KEP. Keep it short, simple, and descriptive. A good
+title can help communicate what the KEP is and should be considered as part of
+any review.
+-->
+
+<!--
+A table of contents is helpful for quickly jumping to sections of a KEP and for
+highlighting any additional information provided beyond the standard KEP
+template.
+
+Ensure the TOC is wrapped with
+  <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
+tags, and then generate with `hack/update-toc.sh`.
+-->
+
+<!-- toc -->
+- [Release Signoff Checklist](#release-signoff-checklist)
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1: Exposing and Consuming Specialized Hardware Cluster-Wide](#story-1-exposing-and-consuming-specialized-hardware-cluster-wide)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [API Changes](#api-changes)
+  - [<code>ResourceClaim</code> Controller Changes](#resourceclaim-controller-changes)
+  - [Admission &amp; Validation](#admission--validation)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+      - [Unit tests](#unit-tests)
+      - [Integration tests](#integration-tests)
+      - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
+    - [GA](#ga)
+  - [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy)
+  - [Version Skew Strategy](#version-skew-strategy)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Rollout, Upgrade and Rollback Planning](#rollout-upgrade-and-rollback-planning)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Dependencies](#dependencies)
+  - [Scalability](#scalability)
+  - [Troubleshooting](#troubleshooting)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
+<!-- /toc -->
+
+## Release Signoff Checklist
+
+<!--
+**ACTION REQUIRED:** In order to merge code into a release, there must be an
+issue in [kubernetes/enhancements] referencing this KEP and targeting a release
+milestone **before the [Enhancement Freeze](https://git.k8s.io/sig-release/releases)
+of the targeted release**.
+
+For enhancements that make changes to code or processes/procedures in core
+Kubernetes—i.e., [kubernetes/kubernetes], we require the following Release
+Signoff checklist to be completed.
+
+Check these off as they are completed for the Release Team to track. These
+checklist items _must_ be updated for the enhancement to be released.
+-->
+
+Items marked with (R) are required *prior to targeting to a milestone / release*.
+
+- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [ ] (R) Design details are appropriately documented
+- [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
+  - [ ] e2e Tests for all Beta API Operations (endpoints)
+  - [ ] (R) Ensure GA e2e tests meet requirements for [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md)
+  - [ ] (R) Minimum Two Week Window for GA e2e tests to prove flake free
+- [ ] (R) Graduation criteria is in place
+  - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
+- [ ] (R) Production readiness review completed
+- [ ] (R) Production readiness review approved
+- [ ] "Implementation History" section is up-to-date for milestone
+- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+
+<!--
+**Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
+-->
+
+[kubernetes.io]: https://kubernetes.io/
+[kubernetes/enhancements]: https://git.k8s.io/enhancements
+[kubernetes/kubernetes]: https://git.k8s.io/kubernetes
+[kubernetes/website]: https://git.k8s.io/website
+
+## Summary
+
+<!--
+This section is incredibly important for producing high-quality, user-focused
+documentation such as release notes or a development roadmap. It should be
+possible to collect this information before implementation begins, in order to
+avoid requiring implementors to split their attention between writing release
+notes and implementing the feature itself. KEP editors and SIG Docs
+should help to ensure that the tone and content of the `Summary` section is
+useful for a wide audience.
+
+A good summary is probably at least a paragraph in length.
+-->
+
+We propose introducing a new cluster-scoped API resource,
+`ClusterResourceClaimTemplate`, to allow cluster administrators to define
+standard Dynamic Resource Allocation (DRA) templates once at the cluster level.
+Any workload in any namespace can reference these templates. During Pod
+scheduling/admission, the control plane's resource claim controller resolves the
+cluster template and automatically generates a namespace-local `ResourceClaim`
+under the Pod's namespace.
+
+## Motivation
+
+<!--
+This section is for explicitly listing the motivation, goals, and non-goals of
+this KEP.  Describe why the change is important and the benefits to users. The
+motivation section can optionally provide links to [experience reports] to
+demonstrate the interest in a KEP within the wider Kubernetes community.
+
+[experience reports]: https://github.com/golang/go/wiki/ExperienceReports
+-->
+
+Currently, `ResourceClaimTemplate` is namespace-scoped. Administrators managing
+clusters with specialized hardware (GPUs, FPGAs, high-performance network
+devices) must deploy and synchronize identical `ResourceClaimTemplate` resources
+across all active namespaces. This namespace pollution makes cluster management
+complex, especially in dynamic, multi-tenant clusters. Cluster-scoped templates
+solve this by allowing a single central template definition.
+
+### Goals
+
+<!--
+List the specific goals of the KEP. What is it trying to achieve? How will we
+know that this has succeeded?
+-->
+
+- Introduce a new cluster-scoped API resource: `ClusterResourceClaimTemplate`.
+- Support referencing `ClusterResourceClaimTemplate` inside `PodResourceClaim`.
+- Automatically generate namespaced `ResourceClaim` resources on behalf of Pods
+  referencing the cluster-scoped template.
+- Ensure referencing a cluster-scoped template behaves consistently with
+  namespaced templates and does not introduce new privilege escalation vectors.
+
+### Non-Goals
+
+<!--
+What is out of scope for this KEP? Listing non-goals helps to focus discussion
+and make progress.
+-->
+
+- Changing how namespace-local `ResourceClaimTemplate` behaves.
+- Dynamically shadowing namespaced templates with cluster templates (resolution
+  must be explicit).
+- Direct cluster-wide sharing of a single namespaced `ResourceClaim` instance
+  (claims remain isolated per namespace).
+
+## Proposal
+
+<!--
+This is where we get down to the specifics of what the proposal actually is.
+This should have enough detail that reviewers can understand exactly what
+you're proposing, but should not include things like API designs or
+implementation. What is the desired outcome and how do we measure success?.
+The "Design Details" section below is for the real
+nitty-gritty.
+-->
+
+We propose introducing a new cluster-scoped API resource,
+`ClusterResourceClaimTemplate`, which serves as a cluster-wide template for
+generating `ResourceClaims`. Along with this, we propose adding a new
+`clusterResourceClaimTemplateName` field to `PodResourceClaim` alongside the
+existing `resourceClaimName` and `resourceClaimTemplateName` fields. 
+
+When `clusterResourceClaimTemplateName` is populated in a Pod specification, the
+`ResourceClaim` controller fetches the referenced `ClusterResourceClaimTemplate`
+and generates a corresponding `ResourceClaim` in the Pod's namespace,
+maintaining standard resource ownership and garbage collection semantics.
+
+### User Stories (Optional)
+
+<!--
+Detail the things that people will be able to do if this KEP is implemented.
+Include as much detail as possible so that people can understand the "how" of
+the system. The goal here is to make this feel real for users without getting
+bogged down.
+-->
+
+#### Story 1: Exposing and Consuming Specialized Hardware Cluster-Wide
+As a cluster administrator of an AI training platform, I want to expose
+high-performance GPUs (e.g., NVIDIA H100) to all research groups across the
+cluster without managing templates in every individual namespace.
+
+1. The administrator defines a single `ClusterResourceClaimTemplate` named
+   `nvidia-h100-80gb` at the cluster scope.
+2. A developer/researcher in a newly provisioned namespace (e.g.,
+   `project-alpha`) creates a Pod that references this template. The ephemeral
+   resource claim controller automatically generates the namespaced
+   `ResourceClaim` in `project-alpha` with the spec defined in
+   `nvidia-h100-80gb`:
+
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-pod
+  namespace: project-alpha
+spec:
+  containers:
+  - name: training
+    image: my-training-image
+    resources:
+      claims:
+        - name: gpu
+  resourceClaims:
+  - name: gpu
+    clusterResourceClaimTemplateName: nvidia-h100-80gb
+```
+
+### Notes/Constraints/Caveats (Optional)
+
+<!--
+What are the caveats to the proposal?
+What are some important details that didn't come across above?
+Go in to as much detail as necessary here.
+This might be a good place to talk about core concepts and how they relate.
+-->
+
+### Risks and Mitigations
+
+<!--
+What are the risks of this proposal, and how do we mitigate? Think broadly.
+For example, consider both security and how this will impact the larger
+Kubernetes ecosystem.
+
+How will security be reviewed, and by whom?
+
+How will UX be reviewed, and by whom?
+
+Consider including folks who also work outside the SIG or subproject.
+-->
+
+## Design Details
+
+<!--
+This section should contain enough information that the specifics of your
+change are understandable. This may include API specs (though not always
+required) or even code snippets. If there's any ambiguity about HOW your
+proposal will be implemented, this is the place to discuss them.
+-->
+
+### API Changes
+
+We will introduce a new cluster-scoped resource `ClusterResourceClaimTemplate`
+in `resource.k8s.io`:
+
+```go
+// ClusterResourceClaimTemplate is used to produce ResourceClaim objects.
+// Cluster scoped.
+type ClusterResourceClaimTemplate struct {
+	metav1.TypeMeta   `json:""`
+  // Standard object metadata
+  // +optional
+  metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+  // Describes the ResourceClaim that is to be generated.
+  //
+  // This field is immutable. A ResourceClaim will get created by the
+  // control plane for a Pod when needed and then not get updated
+  // anymore.
+  // +optional
+  Spec ClusterResourceClaimTemplateSpec `json:"spec" protobuf:"bytes,2,name=spec"`
+}
+
+// ClusterResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.
+type ClusterResourceClaimTemplateSpec struct {
+  // ObjectMeta may contain labels and annotations that will be copied into the ResourceClaim
+  // when creating it. No other fields are allowed and will be rejected during validation.
+  // +optional
+  metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+  // Spec for the ResourceClaim. The entire content is copied unchanged
+  // into the ResourceClaim that gets created from this template. The
+  // same fields as in a ResourceClaim are also valid here.
+  // +optional
+  Spec ResourceClaimSpec `json:"spec" protobuf:"bytes,2,name=spec"`
+}
+```
+
+We will add `ClusterResourceClaimTemplateName` to `PodResourceClaim` in `k8s.io/api/core/v1`:
+
+```go
+type PodResourceClaim struct {
+  Name string `json:"name" protobuf:"bytes,1,name=name"`
+  ResourceClaimName *string `json:"resourceClaimName,omitempty" protobuf:"bytes,3,opt,name=resourceClaimName"`
+  ResourceClaimTemplateName *string `json:"resourceClaimTemplateName,omitempty" protobuf:"bytes,4,opt,name=resourceClaimTemplateName"`
+
+  // ClusterResourceClaimTemplateName is the name of a ClusterResourceClaimTemplate
+  // object in the cluster.
+  //
+  // The template will be used to create a new ResourceClaim in the same
+  // namespace as the Pod, which will be bound to this Pod. Except for the
+  // cluster scope, it behaves identically to ResourceClaimTemplateName.
+  //
+  // This field is immutable and no changes will be made to the
+  // corresponding ResourceClaim by the control plane after creating the
+  // ResourceClaim.
+  //
+  // Exactly one of ResourceClaimName, ResourceClaimTemplateName, and
+  // ClusterResourceClaimTemplateName must be set.
+  ClusterResourceClaimTemplateName *string `json:"clusterResourceClaimTemplateName,omitempty" protobuf:"bytes,5,opt,name=clusterResourceClaimTemplateName"`
+}
+```
+
+### `ResourceClaim` Controller Changes
+
+`ResourceClaimController` will be updated to:
+- Fetch `ClusterResourceClaimTemplate` resources using a cluster-level template
+  informer.
+- When a `PodResourceClaim` references a `ClusterResourceClaimTemplateName`,
+  create a namespaced `ResourceClaim` in the Pod's namespace using
+  `template.Spec.Spec`, and attach standard OwnerReferences mapping it to the
+  Pod.
+
+### Admission & Validation
+
+A Pod reference to a cluster-scoped template does not require explicit reference
+authorization checks (such as `SubjectAccessReview`) during Pod admission. This
+is consistent with other cluster-scoped templates and class resources like
+`StorageClass` or `RuntimeClass`.
+
+Because a `ClusterResourceClaimTemplate` is a template containing a declarative
+`ResourceClaimSpec` and does not grant any special capabilities on its own, a
+user could always copy the template's content and create an equivalent
+namespaced `ResourceClaimTemplate` or inline `ResourceClaim`. Enforcing access
+control on the actual underlying hardware or scheduling resources must be done
+at the resource driver level or via namespace resource quotas/limits.
+
+During admission, the API server will perform standard structural validation on
+the `clusterResourceClaimTemplateName` field (e.g. checking that only one of the
+template/claim name fields is populated).
+
+### Test Plan
+
+<!--
+**Note:** *Not required until targeted at a release.*
+The goal is to ensure that we don't accept enhancements with inadequate testing.
+
+All code is expected to have adequate tests (eventually with coverage
+expectations). Please adhere to the [Kubernetes testing guidelines][testing-guidelines]
+when drafting this test plan.
+
+[testing-guidelines]: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+<!--
+Based on reviewers feedback describe what additional tests need to be added prior
+implementing this enhancement to ensure the enhancements have also solid foundations.
+-->
+
+None.
+
+##### Unit tests
+<!--
+In principle every added code should have complete unit test coverage, so providing
+the exact set of tests will not bring additional value.
+However, if complete unit test coverage is not possible, explain the reason of it
+together with explanation why this is acceptable.
+-->
+
+<!--
+Additionally, for Alpha try to enumerate the core package you will be touching
+to implement this enhancement and provide the current unit coverage for those
+in the form of:
+- <package>: <date> - <current test coverage>
+The data can be easily read from:
+https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
+
+This can inform certain test coverage improvements that we want to do before
+extending the production code to implement this enhancement.
+-->
+
+- `k8s.io/kubernetes/pkg/apis/core/validation`: `85.5%`
+- `k8s.io/kubernetes/pkg/apis/resource/validation`: `96.6%`
+- `k8s.io/kubernetes/pkg/controller/resourceclaim`: `75.0%`
+
+##### Integration tests
+<!--
+Integration tests are contained in https://git.k8s.io/kubernetes/test/integration.
+Integration tests allow control of the configuration parameters used to start the binaries under test.
+This is different from e2e tests which do not allow configuration of parameters.
+Doing this allows testing non-default options and multiple different and potentially conflicting command line options.
+For more details, see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing-strategy.md
+
+If integration tests are not necessary or useful, explain why.
+-->
+
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, document that tests have been written,
+have been executed regularly, and have been stable.
+This can be done with:
+- permalinks to the GitHub source code
+- links to the periodic job (typically https://testgrid.k8s.io/sig-release-master-blocking#integration-master), filtered by the test name
+- a search in the Kubernetes bug triage tool (https://storage.googleapis.com/k8s-triage/index.html)
+-->
+
+Integration tests will verify:
+- Successful generation of namespaced `ResourceClaims` from
+  `ClusterResourceClaimTemplate` resources when a Pod is created.
+- Correct `ownerReferences` on the generated `ResourceClaims` and matching
+  garbage collection when Pods are deleted.
+- API validation ensuring that only one of `resourceClaimName`,
+  `resourceClaimTemplateName`, and `clusterResourceClaimTemplateName` is set on
+  Pod creation.
+- Proper behavior in edge cases (e.g. non-existent templates, updates to
+  templates, and multi-namespace references).
+
+##### e2e tests
+<!--
+This question should be filled when targeting a release.
+For Alpha, describe what tests will be added to ensure proper quality of the enhancement.
+
+For Beta and GA, document that tests have been written,
+have been executed regularly, and have been stable.
+This can be done with:
+- permalinks to the GitHub source code
+- links to the periodic job (typically a job owned by the SIG responsible for the feature), filtered by the test name
+- a search in the Kubernetes bug triage tool (https://storage.googleapis.com/k8s-triage/index.html)
+
+We expect no non-infra related flakes in the last month as a GA graduation criteria.
+If e2e tests are not necessary or useful, explain why.
+-->
+
+E2E tests will verify:
+- Complete scheduling lifecycle of a Pod referencing a
+  `ClusterResourceClaimTemplate` using a test DRA resource driver (successful
+  allocation, execution, and deallocation/clean-up).
+- Correct resource isolation and independent allocation across multiple
+  namespaces referencing the same cluster-scoped template.
+
+### Graduation Criteria
+
+<!--
+**Note:** *Not required until targeted at a release.*
+
+Define graduation milestones.
+
+These may be defined in terms of API maturity, [feature gate] graduations, or as
+something else. The KEP should keep this high-level with a focus on what
+signals will be looked at to determine graduation.
+
+Consider the following in developing the graduation criteria for this enhancement:
+- [Maturity levels (`alpha`, `beta`, `stable`)][maturity-levels]
+- [Feature gate][feature gate] lifecycle
+- [Deprecation policy][deprecation-policy]
+
+Clearly define what graduation means by either linking to the [API doc
+definition](https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning)
+or by redefining what graduation means.
+
+In general we try to use the same stages (alpha, beta, GA), regardless of how the
+functionality is accessed.
+
+[feature gate]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[maturity-levels]: https://git.k8s.io/community/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[deprecation-policy]: https://kubernetes.io/docs/reference/using-api/deprecation-policy/
+
+Below are some examples to consider, in addition to the aforementioned [maturity levels][maturity-levels].
+-->
+#### Alpha
+
+- API fields added and gate `ClusterResourceClaimTemplates` introduced.
+- Controller logic implemented for resolving cluster templates.
+- Tests added and enabled.
+
+#### Beta
+
+- API types graduated to beta.
+- Feature gate enabled by default.
+- Gather feedback.
+
+#### GA
+
+- API types graduated to GA.
+- Feature gate locked to true.
+
+<!--
+#### Deprecation
+- Announce deprecation and support policy of the existing flag
+- Two versions passed since introducing the functionality that deprecates the flag (to address version skew)
+- Address feedback on usage/changed behavior, provided on GitHub issues
+- Deprecate the flag
+-->
+
+### Upgrade / Downgrade Strategy
+
+<!--
+If applicable, how will the component be upgraded and downgraded? Make sure
+this is in the test plan.
+
+Consider the following in developing an upgrade/downgrade strategy for this
+enhancement:
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to maintain previous behavior?
+- What changes (in invocations, configurations, API use, etc.) is an existing
+  cluster required to make on upgrade, in order to make use of the enhancement?
+-->
+
+- **Upgrade**: Enabling the `ClusterResourceClaimTemplates` feature gate
+  registers the `ClusterResourceClaimTemplate` API. The feature is opt-in and
+  does not affect existing workloads.
+- **Downgrade**: Disabling the feature gate will prevent the creation of new
+  `ClusterResourceClaimTemplate` objects, and Pod creation requests referencing
+  them will be rejected. Already-generated, namespaced `ResourceClaims` remain
+  unaffected and continue to function as standard claims.
+
+### Version Skew Strategy
+
+<!--
+If applicable, how will the component handle version skew with other
+components? What are the guarantees? Make sure this is in the test plan.
+
+Consider the following in developing a version skew strategy for this
+enhancement:
+- Does this enhancement involve coordinating behavior in the control plane and nodes?
+- How does an n-3 kubelet or kube-proxy without this feature available behave when this feature is used?
+- How does an n-1 kube-controller-manager or kube-scheduler without this feature available behave when this feature is used?
+- Will any other components on the node change? For example, changes to CSI,
+  CRI or CNI may require updating that component before the kubelet.
+-->
+
+- **Kube-apiserver / Kube-controller-manager skew**: If `kube-apiserver` is
+  upgraded but `kube-controller-manager` is not, Pods referencing a cluster
+  template will be admitted but remain in `Pending` state indefinitely because
+  the claim controller won't generate the namespaced `ResourceClaims`.
+- **Kubelet skew**: The kubelet only interacts with standard, namespaced
+  `ResourceClaim` objects. Since the cluster-scoped template resolution is
+  performed entirely by the control plane, there is no dependency or version
+  skew concerns with older Kubelets.
+
+## Production Readiness Review Questionnaire
+
+<!--
+
+Production readiness reviews are intended to ensure that features merging into
+Kubernetes are observable, scalable and supportable; can be safely operated in
+production environments, and can be disabled or rolled back in the event they
+cause increased failures in production. See more in the PRR KEP at
+https://git.k8s.io/enhancements/keps/sig-architecture/1194-prod-readiness.
+
+The production readiness review questionnaire must be completed and approved
+for the KEP to move to `implementable` status and be included in the release.
+
+In some cases, the questions below should also have answers in `kep.yaml`. This
+is to enable automation to verify the presence of the review, and to reduce review
+burden and latency.
+
+The KEP must have a approver from the
+[`prod-readiness-approvers`](http://git.k8s.io/enhancements/OWNERS_ALIASES)
+team. Please reach out on the
+[#prod-readiness](https://kubernetes.slack.com/archives/CPNHUMN74) channel if
+you need any help or guidance.
+-->
+
+### Feature Enablement and Rollback
+
+<!--
+This section must be completed when targeting alpha to a release.
+-->
+
+###### How can this feature be enabled / disabled in a live cluster?
+
+<!--
+Pick one of these and delete the rest.
+
+Documentation is available on [feature gate lifecycle] and expectations, as
+well as the [existing list] of feature gates.
+
+[feature gate lifecycle]: https://git.k8s.io/community/contributors/devel/sig-architecture/feature-gates.md
+[existing list]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+-->
+
+- [x] Feature gate (also fill in values in `kep.yaml`)
+  - Feature gate name: `ClusterResourceClaimTemplates`
+  - Components depending on the feature gate: `kube-apiserver`, `kube-controller-manager`
+- [ ] Other
+  - Describe the mechanism:
+  - Will enabling / disabling the feature require downtime of the control
+    plane?
+  - Will enabling / disabling the feature require downtime or reprovisioning
+    of a node?
+
+###### Does enabling the feature change any default behavior?
+
+<!--
+Any change of default behavior may be surprising to users or break existing
+automations, so be extremely careful here.
+-->
+
+No.
+
+###### Can the feature be disabled once it has been enabled (i.e. can we roll back the enablement)?
+
+<!--
+Describe the consequences on existing workloads (e.g., if this is a runtime
+feature, can it break the existing applications?).
+
+Feature gates are typically disabled by setting the flag to `false` and
+restarting the component. No other changes should be necessary to disable the
+feature.
+
+NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
+-->
+
+Yes. If disabled, new Pod specifications with `clusterResourceClaimTemplateName`
+set will be rejected during API validation. Existing Pods with the field
+populated will fail validation on any subsequent updates. Generated
+`ResourceClaim` resources already created will continue to exist and be bound,
+but further template resolution will be disabled.
+
+###### What happens if we reenable the feature if it was previously rolled back?
+
+The `kube-apiserver` and `kube-controller-manager` will resume resolving
+`ClusterResourceClaimTemplate` references and generating corresponding local
+`ResourceClaim` resources for any new or updated Pods.
+
+###### Are there any tests for feature enablement/disablement?
+
+<!--
+The e2e framework does not currently support enabling or disabling feature
+gates. However, unit tests in each component dealing with managing data, created
+with and without the feature, are necessary. At the very least, think about
+conversion tests if API types are being modified.
+
+Additionally, for features that are introducing a new API field, unit tests that
+are exercising the `switch` of feature gate itself (what happens if I disable a
+feature gate after having objects written with the new field) are also critical.
+You can take a look at one potential example of such test in:
+https://github.com/kubernetes/kubernetes/pull/97058/files#diff-7826f7adbc1996a05ab52e3f5f02429e94b68ce6bce0dc534d1be636154fded3R246-R282
+-->
+
+We will cover feature enablement/disablement in both unit tests and integration tests.
+
+### Rollout, Upgrade and Rollback Planning
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### How can a rollout or rollback fail? Can it impact already running workloads?
+
+<!--
+Try to be as paranoid as possible - e.g., what if some components will restart
+mid-rollout?
+
+Be sure to consider highly-available clusters, where, for example,
+feature flags will be enabled on some API servers and not others during the
+rollout. Similarly, consider large clusters and how enablement/disablement
+will rollout across nodes.
+-->
+
+During upgrade, if a new `kube-apiserver` is upgraded and admits a Pod with
+`clusterResourceClaimTemplateName` but `kube-controller-manager` has not yet
+been upgraded or does not have the feature gate enabled, the Pod will remain
+pending indefinitely because the claim controller won't create the namespaced
+`ResourceClaim`. Already running workloads are unaffected.
+
+###### What specific metrics should inform a rollback?
+
+<!--
+What signals should users be paying attention to when the feature is young
+that might indicate a serious problem?
+-->
+
+- An increase in the number of Pods stuck in `Pending` state with unscheduled
+  `ResourceClaims`.
+- High error rates in `kube-controller-manager` logs related to `ResourceClaim`
+  creation.
+
+###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
+
+<!--
+Describe manual testing that was done and the outcomes.
+Longer term, we may want to require automated upgrade/rollback tests, but we
+are missing a bunch of machinery and tooling and can't do that now.
+-->
+
+To be completed at Beta stage.
+
+###### Is the rollout accompanied by any deprecations and/or removals of features, APIs, fields of API types, flags, etc.?
+
+<!--
+Even if applying deprecation policies, they may still surprise some users.
+-->
+
+No.
+
+### Monitoring Requirements
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### How can an operator determine if the feature is in use by workloads?
+
+<!--
+Ideally, this should be a metric. Operations against the Kubernetes API (e.g.,
+checking if there are objects with field X set) may be a last resort. Avoid
+logs or events for this purpose.
+-->
+
+An operator can list `ClusterResourceClaimTemplate` objects or query
+`kube-apiserver` request metrics for `clusterresourceclaimtemplates`.
+
+###### How can someone using this feature know that it is working for their instance?
+
+<!--
+For instance, if this is a pod-related feature, it should be possible to determine if the feature is functioning properly
+for each individual pod.
+Pick one more of these and delete the rest.
+Please describe all items visible to end users below with sufficient detail so that they can verify correct enablement
+and operation of this feature.
+Recall that end users cannot usually observe component logs or access metrics.
+-->
+
+- [ ] Events
+  - Event Reason: 
+- [x] API .status
+  - Condition name: `ResourceClaim` transitions to `status.allocation` set.
+  - Other field: Pod's `status.resourceClaims` list.
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
+
+<!--
+This is your opportunity to define what "normal" quality of service looks like
+for a feature.
+
+It's impossible to provide comprehensive guidance, but at the very
+high level (needs more precise definitions) those may be things like:
+  - per-day percentage of API calls finishing with 5XX errors <= 1%
+  - 99% percentile over day of absolute value from (job creation time minus expected
+    job creation time) for cron job <= 10%
+  - 99.9% of /health requests per day finish with 200 code
+
+These goals will help you determine what you need to measure (SLIs) in the next
+question.
+-->
+
+99% of local `ResourceClaim` creations corresponding to a
+`ClusterResourceClaimTemplate` should succeed within 1 second of the Pod being
+admitted.
+
+###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
+
+<!--
+Pick one more of these and delete the rest.
+-->
+
+- [x] Metrics
+  - Metric name: `controller_runtime_reconcile_errors_total` (filtered by `resourceclaim` controller)
+  - [Optional] Aggregation method: `sum`
+  - Components exposing the metric: `kube-controller-manager`
+- [ ] Other (treat as last resort)
+  - Details:
+
+###### Are there any missing metrics that would be useful to have to improve observability of this feature?
+
+<!--
+Describe the metrics themselves and the reasons why they weren't added (e.g., cost,
+implementation difficulties, etc.).
+-->
+
+No. Standard API server request latency/error metrics and controller-runtime
+metrics are sufficient.
+
+
+### Dependencies
+
+<!--
+This section must be completed when targeting beta to a release.
+-->
+
+###### Does this feature depend on any specific services running in the cluster?
+
+<!--
+Think about both cluster-level services (e.g. metrics-server) as well
+as node-level agents (e.g. specific version of CRI). Focus on external or
+optional services that are needed. For example, if this feature depends on
+a cloud provider API, or upon an external software-defined storage or network
+control plane.
+
+For each of these, fill in the following—thinking about running existing user workloads
+and creating new ones, as well as about cluster-level services (e.g. DNS):
+  - [Dependency name]
+    - Usage description:
+      - Impact of its outage on the feature:
+      - Impact of its degraded performance or high-error rates on the feature:
+-->
+
+No.
+
+### Scalability
+
+<!--
+For alpha, this section is encouraged: reviewers should consider these questions
+and attempt to answer them.
+
+For beta, this section is required: reviewers must answer these questions.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+-->
+
+###### Will enabling / using this feature result in any new API calls?
+
+<!--
+Describe them, providing:
+  - API call type (e.g. PATCH pods)
+  - estimated throughput
+  - originating component(s) (e.g. Kubelet, Feature-X-controller)
+Focusing mostly on:
+  - components listing and/or watching resources they didn't before
+  - API calls that may be triggered by changes of some Kubernetes resources
+    (e.g. update of object X triggers new updates of object Y)
+  - periodic API calls to reconcile state (e.g. periodic fetching state,
+    heartbeats, leader election, etc.)
+-->
+
+Yes:
+- `kube-controller-manager` will list and watch `ClusterResourceClaimTemplates`
+  (cluster-wide informer index).
+- Throughput is bounded by Pod creation/admission rates that use these
+  templates.
+
+###### Will enabling / using this feature result in introducing new API types?
+
+<!--
+Describe them, providing:
+  - API type
+  - Supported number of objects per cluster
+  - Supported number of objects per namespace (for namespace-scoped objects)
+-->
+
+Yes, `ClusterResourceClaimTemplate`.
+
+###### Will enabling / using this feature result in any new calls to the cloud provider?
+
+<!--
+Describe them, providing:
+  - Which API(s):
+  - Estimated increase:
+-->
+
+No.
+
+###### Will enabling / using this feature result in increasing size or count of the existing API objects?
+
+<!--
+Describe them, providing:
+  - API type(s):
+  - Estimated increase in size: (e.g., new annotation of size 32B)
+  - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
+-->
+
+Yes, Pod specifications referencing a cluster template will have one extra field
+(`clusterResourceClaimTemplateName`) set.
+
+###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
+
+<!--
+Look at the [existing SLIs/SLOs].
+
+Think about adding additional work or introducing new steps in between
+(e.g. need to do X to start a container), etc. Please describe the details.
+
+[existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
+-->
+
+No additional checks or operations are performed during Pod admission that
+would impact existing SLIs/SLOs.
+
+###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
+
+<!--
+Things to keep in mind include: additional in-memory state, additional
+non-trivial computations, excessive access to disks (including increased log
+volume), significant amount of data sent and/or received over network, etc.
+This through this both in small and large cases, again with respect to the
+[supported limits].
+
+[supported limits]: https://git.k8s.io/community//sig-scalability/configs-and-limits/thresholds.md
+-->
+
+No. The new informer in `kube-controller-manager` caches only
+`ClusterResourceClaimTemplates` which are highly static and low in count.
+
+###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
+
+<!--
+Focus not just on happy cases, but primarily on more pathological cases
+(e.g. probes taking a minute instead of milliseconds, failed pods consuming resources, etc.).
+If any of the resources can be exhausted, how this is mitigated with the existing limits
+(e.g. pods per node) or new limits added by this KEP?
+
+Are there any tests that were run/should be run to understand performance characteristics better
+and validate the declared limits?
+-->
+
+No.
+
+### Troubleshooting
+
+<!--
+This section must be completed when targeting beta to a release.
+
+For GA, this section is required: approvers should be able to confirm the
+previous answers based on experience in the field.
+
+The Troubleshooting section currently serves the `Playbook` role. We may consider
+splitting it into a dedicated `Playbook` document (potentially with some monitoring
+details). For now, we leave it here.
+-->
+
+###### How does this feature react if the API server and/or etcd is unavailable?
+
+Admission/creation of Pods using the templates, as well as the creation, update,
+or deletion of the `ClusterResourceClaimTemplate` resources themselves, is blocked,
+similar to other Kubernetes resources.
+
+###### What are other known failure modes?
+
+<!--
+For each of them, fill in the following information by copying the below template:
+  - [Failure mode brief description]
+    - Detection: How can it be detected via metrics? Stated another way:
+      how can an operator troubleshoot without logging into a master or worker node?
+    - Mitigations: What can be done to stop the bleeding, especially for already
+      running user workloads?
+    - Diagnostics: What are the useful log messages and their required logging
+      levels that could help debug the issue?
+      Not required until feature graduated to beta.
+    - Testing: Are there any tests for failure mode? If not, describe why.
+-->
+
+- **Template Reference Resolution Failure**: A Pod specifies a non-existent
+  `clusterResourceClaimTemplateName`.
+  - Detection: Pod remains `Pending` with a status event indicating that
+    template resolution failed.
+  - Mitigations: Correct the Pod specification to use a valid template or create
+    the referenced `ClusterResourceClaimTemplate`.
+  - Diagnostics: Look at events on the Pod and logs of
+    `kube-controller-manager`.
+
+###### What steps should be taken if SLOs are not being met to determine the problem?
+
+Verify that `kube-controller-manager` has connection to `kube-apiserver`. Check
+`kube-controller-manager` logs and the rate of reconcile errors for the
+`resourceclaim` controller.
+
+
+## Implementation History
+
+<!--
+Major milestones in the lifecycle of a KEP should be tracked in this section.
+Major milestones might include:
+- the `Summary` and `Motivation` sections being merged, signaling SIG acceptance
+- the `Proposal` section being merged, signaling agreement on a proposed design
+- the date implementation started
+- the first Kubernetes release where an initial version of the KEP was available
+- the version of Kubernetes where the KEP graduated to general availability
+- when the KEP was retired or superseded
+-->
+
+- **2026-06-02**: Initial KEP drafted and proposed targeting v1.37 Alpha.
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+Introducing `ClusterResourceClaimTemplate` adds another API resource to
+`resource.k8s.io` and expands the `PodResourceClaim` API structure. However,
+this is justified by the significant simplification it brings to cluster-scoped
+DRA configuration and resource control.
+
+## Alternatives
+
+<!--
+What other approaches did you consider, and why did you rule them out? These do
+not need to be as detailed as the proposal, but should include enough
+information to express the idea and why it was not acceptable.
+-->
+
+- **Shadowing / Fallback Resolution**: Allow `resourceClaimTemplateName` to
+  resolve to a cluster-scoped resource if the namespaced template is not found.
+  - *Why Rejected*: Shadowing leads to unpredictable resolution behavior and
+    silent failures. An administrator creating a namespaced template would
+    silently override/shadow the cluster-scoped template, changing Pod
+    provisioning paths without explicit audit trails. Dedicated fields make
+    references completely explicit and easily auditable.
+
+## Infrastructure Needed (Optional)
+
+<!--
+Use this section if you need things from the project/SIG. Examples include a
+new subproject, repos requested, or GitHub details. Listing these here allows a
+SIG to get the process for these resources started right away.
+-->
+
+None.
+

--- a/keps/sig-node/5978-cluster-resource-claim-template/README.md
+++ b/keps/sig-node/5978-cluster-resource-claim-template/README.md
@@ -96,7 +96,7 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [API Changes](#api-changes)
-  - [<code>ResourceClaim</code> Controller Changes](#resourceclaim-controller-changes)
+  - [ResourceClaim Controller Changes](#resourceclaim-controller-changes)
   - [Admission &amp; Validation](#admission--validation)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -179,11 +179,11 @@ A good summary is probably at least a paragraph in length.
 -->
 
 We propose introducing a new cluster-scoped API resource,
-`ClusterResourceClaimTemplate`, to allow cluster administrators to define
+ClusterResourceClaimTemplate, to allow cluster administrators to define
 standard Dynamic Resource Allocation (DRA) templates once at the cluster level.
 Any workload (via Pod or PodGroup) in any namespace can reference these templates. During Pod or PodGroup
 scheduling/admission, the control plane's resource claim controller resolves the
-cluster template and automatically generates a namespace-local `ResourceClaim`
+cluster template and automatically generates a namespace-local ResourceClaim
 under the Pod's or PodGroup's namespace.
 
 ## Motivation
@@ -197,9 +197,9 @@ demonstrate the interest in a KEP within the wider Kubernetes community.
 [experience reports]: https://github.com/golang/go/wiki/ExperienceReports
 -->
 
-Currently, `ResourceClaimTemplate` is namespace-scoped. Administrators managing
+Currently, ResourceClaimTemplate is namespace-scoped. Administrators managing
 clusters with specialized hardware (GPUs, FPGAs, high-performance network
-devices) must deploy and synchronize identical `ResourceClaimTemplate` resources
+devices) must deploy and synchronize identical ResourceClaimTemplate resources
 across all active namespaces. This namespace pollution makes cluster management
 complex, especially in dynamic, multi-tenant clusters. Cluster-scoped templates
 solve this by allowing a single central template definition.
@@ -225,10 +225,10 @@ What is out of scope for this KEP? Listing non-goals helps to focus discussion
 and make progress.
 -->
 
-- Changing how namespace-local `ResourceClaimTemplate` behaves.
+- Changing how namespace-local ResourceClaimTemplate behaves.
 - Dynamically shadowing namespaced templates with cluster templates (resolution
   must be explicit).
-- Direct cluster-wide sharing of a single namespaced `ResourceClaim` instance
+- Direct cluster-wide sharing of a single namespaced ResourceClaim instance
   (claims remain isolated per namespace).
 
 ## Proposal
@@ -243,14 +243,14 @@ nitty-gritty.
 -->
 
 We propose introducing a new cluster-scoped API resource,
-`ClusterResourceClaimTemplate`, which serves as a cluster-wide template for
-generating `ResourceClaims`. Along with this, we propose adding a new
+ClusterResourceClaimTemplate, which serves as a cluster-wide template for
+generating ResourceClaims. Along with this, we propose adding a new
 `clusterResourceClaimTemplateName` field to `PodResourceClaim` and `PodGroupResourceClaim` alongside the
 existing `resourceClaimName` and `resourceClaimTemplateName` fields. 
 
 When `clusterResourceClaimTemplateName` is populated in a Pod or PodGroup specification, the
-`ResourceClaim` controller fetches the referenced `ClusterResourceClaimTemplate`
-and generates a corresponding `ResourceClaim` in the Pod's or PodGroup's namespace,
+ResourceClaim controller fetches the referenced ClusterResourceClaimTemplate
+and generates a corresponding ResourceClaim in the Pod's or PodGroup's namespace,
 maintaining standard resource ownership and garbage collection semantics.
 
 ### User Stories (Optional)
@@ -267,12 +267,12 @@ As a cluster administrator of an AI training platform, I want to expose
 high-performance GPUs (e.g., NVIDIA H100) to all research groups across the
 cluster without managing templates in every individual namespace.
 
-1. The administrator defines a single `ClusterResourceClaimTemplate` named
+1. The administrator defines a single ClusterResourceClaimTemplate named
    `nvidia-h100-80gb` at the cluster scope.
 2. A developer/researcher in a newly provisioned namespace (e.g.,
    `project-alpha`) creates a Pod that references this template. The ephemeral
    resource claim controller automatically generates the namespaced
-   `ResourceClaim` in `project-alpha` with the spec defined in
+   ResourceClaim in `project-alpha` with the spec defined in
    `nvidia-h100-80gb`:
 
 ```yaml
@@ -327,7 +327,7 @@ proposal will be implemented, this is the place to discuss them.
 
 ### API Changes
 
-We will introduce a new cluster-scoped resource `ClusterResourceClaimTemplate`
+We will introduce a new cluster-scoped resource ClusterResourceClaimTemplate
 in `resource.k8s.io`:
 
 ```go
@@ -415,31 +415,31 @@ type PodGroupResourceClaim struct {
 }
 ```
 
-### `ResourceClaim` Controller Changes
+### ResourceClaim Controller Changes
 
 `ResourceClaimController` will be updated to:
-- Fetch `ClusterResourceClaimTemplate` resources using a cluster-level template
+- Fetch ClusterResourceClaimTemplate resources using a cluster-level template
   informer.
 - When a `PodResourceClaim` references a `ClusterResourceClaimTemplateName`,
-  create a namespaced `ResourceClaim` in the Pod's namespace using
-  `template.Spec.Spec`, and attach standard OwnerReferences mapping it to the
+  create a namespaced ResourceClaim in the Pod's namespace using the ClusterResourceClaimTemplate's
+  `Spec.Spec`, and attach standard OwnerReferences mapping it to the
   Pod.
 - When a `PodGroupResourceClaim` references a `ClusterResourceClaimTemplateName`,
-  create a namespaced `ResourceClaim` in the PodGroup's namespace using
-  `template.Spec.Spec`, and attach standard OwnerReferences mapping it to the
+  create a namespaced ResourceClaim in the PodGroup's namespace using the ClusterResourceClaimTemplate's
+  `Spec.Spec`, and attach standard OwnerReferences mapping it to the
   PodGroup.
 
 ### Admission & Validation
 
 A Pod or PodGroup reference to a cluster-scoped template does not require explicit reference
-authorization checks (such as `SubjectAccessReview`) during Pod or PodGroup admission. This
+authorization checks (such as SubjectAccessReview) during Pod or PodGroup admission. This
 is consistent with other cluster-scoped templates and class resources like
-`StorageClass` or `RuntimeClass`.
+StorageClass or RuntimeClass.
 
-Because a `ClusterResourceClaimTemplate` is a template containing a declarative
+Because a ClusterResourceClaimTemplate is a template containing a declarative
 `ResourceClaimSpec` and does not grant any special capabilities on its own, a
 user could always copy the template's content and create an equivalent
-namespaced `ResourceClaimTemplate` or inline `ResourceClaim`. Enforcing access
+namespaced ResourceClaimTemplate or inline ResourceClaim. Enforcing access
 control on the actual underlying hardware or scheduling resources must be done
 at the resource driver level or via namespace resource quotas/limits.
 
@@ -496,6 +496,7 @@ extending the production code to implement this enhancement.
 - `k8s.io/kubernetes/pkg/apis/scheduling/validation`: `90.6%`
 - `k8s.io/kubernetes/pkg/apis/resource/validation`: `96.6%`
 - `k8s.io/kubernetes/pkg/controller/resourceclaim`: `75.0%`
+- `k8s.io/dynamic-resource-allocation/resourceclaim`: `90.6%`
 
 ##### Integration tests
 <!--
@@ -521,9 +522,9 @@ This can be done with:
 -->
 
 Integration tests will verify:
-- Successful generation of namespaced `ResourceClaims` from
-  `ClusterResourceClaimTemplate` resources when a Pod or PodGroup is created.
-- Correct `ownerReferences` on the generated `ResourceClaims` and matching
+- Successful generation of namespaced ResourceClaims from
+  ClusterResourceClaimTemplate resources when a Pod or PodGroup is created.
+- Correct `ownerReferences` on the generated ResourceClaims and matching
   garbage collection when Pods or PodGroups are deleted.
 - API validation ensuring that only one of `resourceClaimName`,
   `resourceClaimTemplateName`, and `clusterResourceClaimTemplateName` is set on
@@ -549,7 +550,7 @@ If e2e tests are not necessary or useful, explain why.
 
 E2E tests will verify:
 - Complete scheduling lifecycle of a Pod or PodGroup referencing a
-  `ClusterResourceClaimTemplate` using a test DRA resource driver (successful
+  ClusterResourceClaimTemplate using a test DRA resource driver (successful
   allocation, execution, and deallocation/clean-up).
 - Correct resource isolation and independent allocation across multiple
   namespaces referencing the same cluster-scoped template.
@@ -623,11 +624,11 @@ enhancement:
 -->
 
 - **Upgrade**: Enabling the `ClusterResourceClaimTemplates` feature gate
-  registers the `ClusterResourceClaimTemplate` API. The feature is opt-in and
+  registers the ClusterResourceClaimTemplate API. The feature is opt-in and
   does not affect existing workloads.
 - **Downgrade**: Disabling the feature gate will prevent the creation of new
-  `ClusterResourceClaimTemplate` objects, and Pod or PodGroup creation requests referencing
-  them will be rejected. Already-generated, namespaced `ResourceClaims` remain
+  ClusterResourceClaimTemplate objects, and Pod or PodGroup creation requests referencing
+  them will be rejected. Already-generated, namespaced ResourceClaims remain
   unaffected and continue to function as standard claims.
 
 ### Version Skew Strategy
@@ -648,9 +649,9 @@ enhancement:
 - **Kube-apiserver / Kube-controller-manager skew**: If `kube-apiserver` is
   upgraded but `kube-controller-manager` is not, Pods or PodGroups referencing a cluster
   template will be admitted but remain in `Pending` state indefinitely because
-  the claim controller won't generate the namespaced `ResourceClaims`.
+  the claim controller won't generate the namespaced ResourceClaims.
 - **Kubelet skew**: The kubelet only interacts with standard, namespaced
-  `ResourceClaim` objects. Since the cluster-scoped template resolution is
+  ResourceClaim objects. Since the cluster-scoped template resolution is
   performed entirely by the control plane, there is no dependency or version
   skew concerns with older Kubelets.
 
@@ -731,14 +732,14 @@ NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
 Yes. If disabled, new Pod or PodGroup specifications with `clusterResourceClaimTemplateName`
 set will be rejected during API validation. Existing Pods or PodGroups with the field
 populated will fail validation on any subsequent updates. Generated
-`ResourceClaim` resources already created will continue to exist and be bound,
+ResourceClaim resources already created will continue to exist and be bound,
 but further template resolution will be disabled.
 
 ###### What happens if we reenable the feature if it was previously rolled back?
 
 The `kube-apiserver` and `kube-controller-manager` will resume resolving
-`ClusterResourceClaimTemplate` references and generating corresponding local
-`ResourceClaim` resources for any new or updated Pods or PodGroups.
+ClusterResourceClaimTemplate references and generating corresponding local
+ResourceClaim resources for any new or updated Pods or PodGroups.
 
 ###### Are there any tests for feature enablement/disablement?
 
@@ -779,7 +780,7 @@ During upgrade, if a new `kube-apiserver` is upgraded and admits a Pod or PodGro
 `clusterResourceClaimTemplateName` but `kube-controller-manager` has not yet
 been upgraded or does not have the feature gate enabled, the Pod or PodGroup will remain
 pending indefinitely because the claim controller won't create the namespaced
-`ResourceClaim`. Already running workloads are unaffected.
+ResourceClaim. Already running workloads are unaffected.
 
 ###### What specific metrics should inform a rollback?
 
@@ -789,8 +790,8 @@ that might indicate a serious problem?
 -->
 
 - An increase in the number of Pods or PodGroups stuck in `Pending` state with unscheduled
-  `ResourceClaims`.
-- High error rates in `kube-controller-manager` logs related to `ResourceClaim`
+  ResourceClaims.
+- High error rates in `kube-controller-manager` logs related to ResourceClaim
   creation.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
@@ -828,7 +829,7 @@ checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
 
-An operator can list `ClusterResourceClaimTemplate` objects or query
+An operator can list ClusterResourceClaimTemplate objects or query
 `kube-apiserver` request metrics for `clusterresourceclaimtemplates`.
 
 ###### How can someone using this feature know that it is working for their instance?
@@ -845,8 +846,8 @@ Recall that end users cannot usually observe component logs or access metrics.
 - [ ] Events
   - Event Reason: 
 - [x] API .status
-  - Condition name: `ResourceClaim` transitions to `status.allocation` set.
-  - Other field: Pod's `status.resourceClaims` list, and the existence of the generated namespaced `ResourceClaim` owned by the Pod or PodGroup.
+  - Condition name: ResourceClaim transitions to `status.allocation` set.
+  - Other field: Pod's `status.resourceClaims` list, and the existence of the generated namespaced ResourceClaim owned by the Pod or PodGroup.
 - [ ] Other (treat as last resort)
   - Details:
 
@@ -867,8 +868,8 @@ These goals will help you determine what you need to measure (SLIs) in the next
 question.
 -->
 
-99% of local `ResourceClaim` creations corresponding to a
-`ClusterResourceClaimTemplate` should succeed within 1 second of the Pod or PodGroup being
+99% of local ResourceClaim creations corresponding to a
+ClusterResourceClaimTemplate should succeed within 1 second of the Pod or PodGroup being
 admitted.
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
@@ -948,7 +949,7 @@ Focusing mostly on:
 -->
 
 Yes:
-- `kube-controller-manager` will list and watch `ClusterResourceClaimTemplates`
+- `kube-controller-manager` will list and watch ClusterResourceClaimTemplates
   (cluster-wide informer index).
 - Throughput is bounded by Pod or PodGroup creation/admission rates that use these
   templates.
@@ -962,7 +963,7 @@ Describe them, providing:
   - Supported number of objects per namespace (for namespace-scoped objects)
 -->
 
-Yes, `ClusterResourceClaimTemplate`.
+Yes, ClusterResourceClaimTemplate.
 
 ###### Will enabling / using this feature result in any new calls to the cloud provider?
 
@@ -1013,7 +1014,7 @@ This through this both in small and large cases, again with respect to the
 -->
 
 No. The new informer in `kube-controller-manager` caches only
-`ClusterResourceClaimTemplates` which are highly static and low in count.
+ClusterResourceClaimTemplates which are highly static and low in count.
 
 ###### Can enabling / using this feature result in resource exhaustion of some node resources (PIDs, sockets, inodes, etc.)?
 
@@ -1045,7 +1046,7 @@ details). For now, we leave it here.
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
 Admission/creation of Pods or PodGroups using the templates, as well as the creation, update,
-or deletion of the `ClusterResourceClaimTemplate` resources themselves, is blocked,
+or deletion of the ClusterResourceClaimTemplate resources themselves, is blocked,
 similar to other Kubernetes resources.
 
 ###### What are other known failure modes?
@@ -1068,7 +1069,7 @@ For each of them, fill in the following information by copying the below templat
   - Detection: Pod or PodGroup remains `Pending` (or unscheduled) with a status event indicating that
     template resolution failed.
   - Mitigations: Correct the Pod or PodGroup specification to use a valid template or create
-    the referenced `ClusterResourceClaimTemplate`.
+    the referenced ClusterResourceClaimTemplate.
   - Diagnostics: Look at events on the Pod/PodGroup and logs of
     `kube-controller-manager`.
 
@@ -1100,7 +1101,7 @@ Major milestones might include:
 Why should this KEP _not_ be implemented?
 -->
 
-Introducing `ClusterResourceClaimTemplate` adds another API resource to
+Introducing ClusterResourceClaimTemplate adds another API resource to
 `resource.k8s.io` and expands the `PodResourceClaim` API structure. However,
 this is justified by the significant simplification it brings to cluster-scoped
 DRA configuration and resource control.

--- a/keps/sig-node/5978-cluster-resource-claim-template/README.md
+++ b/keps/sig-node/5978-cluster-resource-claim-template/README.md
@@ -181,10 +181,10 @@ A good summary is probably at least a paragraph in length.
 We propose introducing a new cluster-scoped API resource,
 `ClusterResourceClaimTemplate`, to allow cluster administrators to define
 standard Dynamic Resource Allocation (DRA) templates once at the cluster level.
-Any workload in any namespace can reference these templates. During Pod
+Any workload (via Pod or PodGroup) in any namespace can reference these templates. During Pod or PodGroup
 scheduling/admission, the control plane's resource claim controller resolves the
 cluster template and automatically generates a namespace-local `ResourceClaim`
-under the Pod's namespace.
+under the Pod's or PodGroup's namespace.
 
 ## Motivation
 
@@ -211,12 +211,12 @@ List the specific goals of the KEP. What is it trying to achieve? How will we
 know that this has succeeded?
 -->
 
-- Introduce a new cluster-scoped API resource: `ClusterResourceClaimTemplate`.
-- Support referencing `ClusterResourceClaimTemplate` inside `PodResourceClaim`.
-- Automatically generate namespaced `ResourceClaim` resources on behalf of Pods
-  referencing the cluster-scoped template.
-- Ensure referencing a cluster-scoped template behaves consistently with
-  namespaced templates and does not introduce new privilege escalation vectors.
+- **Reduce administrative overhead**: Eliminate the need to replicate and
+  synchronize identical DRA templates across multiple namespaces.
+- **Simplify workload configuration**: Allow Pods and PodGroups in any namespace
+  to easily consume centrally managed hardware templates.
+- **Preserve namespace isolation**: Ensure cluster-scoped templates do not
+  introduce privilege escalation or cross-namespace risks.
 
 ### Non-Goals
 
@@ -245,12 +245,12 @@ nitty-gritty.
 We propose introducing a new cluster-scoped API resource,
 `ClusterResourceClaimTemplate`, which serves as a cluster-wide template for
 generating `ResourceClaims`. Along with this, we propose adding a new
-`clusterResourceClaimTemplateName` field to `PodResourceClaim` alongside the
+`clusterResourceClaimTemplateName` field to `PodResourceClaim` and `PodGroupResourceClaim` alongside the
 existing `resourceClaimName` and `resourceClaimTemplateName` fields. 
 
-When `clusterResourceClaimTemplateName` is populated in a Pod specification, the
+When `clusterResourceClaimTemplateName` is populated in a Pod or PodGroup specification, the
 `ResourceClaim` controller fetches the referenced `ClusterResourceClaimTemplate`
-and generates a corresponding `ResourceClaim` in the Pod's namespace,
+and generates a corresponding `ResourceClaim` in the Pod's or PodGroup's namespace,
 maintaining standard resource ownership and garbage collection semantics.
 
 ### User Stories (Optional)
@@ -274,7 +274,6 @@ cluster without managing templates in every individual namespace.
    resource claim controller automatically generates the namespaced
    `ResourceClaim` in `project-alpha` with the spec defined in
    `nvidia-h100-80gb`:
-
 
 ```yaml
 apiVersion: v1
@@ -389,6 +388,33 @@ type PodResourceClaim struct {
 }
 ```
 
+We will also add `ClusterResourceClaimTemplateName` to `PodGroupResourceClaim`
+in `k8s.io/api/scheduling/v1alpha3` (or the appropriate API group for
+PodGroups):
+
+```go
+type PodGroupResourceClaim struct {
+  Name string `json:"name"`
+  ResourceClaimName *string `json:"resourceClaimName,omitempty"`
+  ResourceClaimTemplateName *string `json:"resourceClaimTemplateName,omitempty"`
+
+  // ClusterResourceClaimTemplateName is the name of a ClusterResourceClaimTemplate
+  // object in the cluster.
+  //
+  // The template will be used to create a new ResourceClaim in the same
+  // namespace as this PodGroup, which will be bound to this PodGroup. Except for the
+  // cluster scope, it behaves identically to ResourceClaimTemplateName.
+  //
+  // This field is immutable and no changes will be made to the
+  // corresponding ResourceClaim by the control plane after creating the
+  // ResourceClaim.
+  //
+  // Exactly one of ResourceClaimName, ResourceClaimTemplateName, and
+  // ClusterResourceClaimTemplateName must be set.
+  ClusterResourceClaimTemplateName *string `json:"clusterResourceClaimTemplateName,omitempty"`
+}
+```
+
 ### `ResourceClaim` Controller Changes
 
 `ResourceClaimController` will be updated to:
@@ -398,11 +424,15 @@ type PodResourceClaim struct {
   create a namespaced `ResourceClaim` in the Pod's namespace using
   `template.Spec.Spec`, and attach standard OwnerReferences mapping it to the
   Pod.
+- When a `PodGroupResourceClaim` references a `ClusterResourceClaimTemplateName`,
+  create a namespaced `ResourceClaim` in the PodGroup's namespace using
+  `template.Spec.Spec`, and attach standard OwnerReferences mapping it to the
+  PodGroup.
 
 ### Admission & Validation
 
-A Pod reference to a cluster-scoped template does not require explicit reference
-authorization checks (such as `SubjectAccessReview`) during Pod admission. This
+A Pod or PodGroup reference to a cluster-scoped template does not require explicit reference
+authorization checks (such as `SubjectAccessReview`) during Pod or PodGroup admission. This
 is consistent with other cluster-scoped templates and class resources like
 `StorageClass` or `RuntimeClass`.
 
@@ -414,7 +444,7 @@ control on the actual underlying hardware or scheduling resources must be done
 at the resource driver level or via namespace resource quotas/limits.
 
 During admission, the API server will perform standard structural validation on
-the `clusterResourceClaimTemplateName` field (e.g. checking that only one of the
+the `clusterResourceClaimTemplateName` field in both `PodResourceClaim` and `PodGroupResourceClaim` (e.g. checking that only one of the
 template/claim name fields is populated).
 
 ### Test Plan
@@ -463,6 +493,7 @@ extending the production code to implement this enhancement.
 -->
 
 - `k8s.io/kubernetes/pkg/apis/core/validation`: `85.5%`
+- `k8s.io/kubernetes/pkg/apis/scheduling/validation`: `90.6%`
 - `k8s.io/kubernetes/pkg/apis/resource/validation`: `96.6%`
 - `k8s.io/kubernetes/pkg/controller/resourceclaim`: `75.0%`
 
@@ -491,12 +522,12 @@ This can be done with:
 
 Integration tests will verify:
 - Successful generation of namespaced `ResourceClaims` from
-  `ClusterResourceClaimTemplate` resources when a Pod is created.
+  `ClusterResourceClaimTemplate` resources when a Pod or PodGroup is created.
 - Correct `ownerReferences` on the generated `ResourceClaims` and matching
-  garbage collection when Pods are deleted.
+  garbage collection when Pods or PodGroups are deleted.
 - API validation ensuring that only one of `resourceClaimName`,
   `resourceClaimTemplateName`, and `clusterResourceClaimTemplateName` is set on
-  Pod creation.
+  Pod or PodGroup creation.
 - Proper behavior in edge cases (e.g. non-existent templates, updates to
   templates, and multi-namespace references).
 
@@ -517,7 +548,7 @@ If e2e tests are not necessary or useful, explain why.
 -->
 
 E2E tests will verify:
-- Complete scheduling lifecycle of a Pod referencing a
+- Complete scheduling lifecycle of a Pod or PodGroup referencing a
   `ClusterResourceClaimTemplate` using a test DRA resource driver (successful
   allocation, execution, and deallocation/clean-up).
 - Correct resource isolation and independent allocation across multiple
@@ -595,7 +626,7 @@ enhancement:
   registers the `ClusterResourceClaimTemplate` API. The feature is opt-in and
   does not affect existing workloads.
 - **Downgrade**: Disabling the feature gate will prevent the creation of new
-  `ClusterResourceClaimTemplate` objects, and Pod creation requests referencing
+  `ClusterResourceClaimTemplate` objects, and Pod or PodGroup creation requests referencing
   them will be rejected. Already-generated, namespaced `ResourceClaims` remain
   unaffected and continue to function as standard claims.
 
@@ -615,7 +646,7 @@ enhancement:
 -->
 
 - **Kube-apiserver / Kube-controller-manager skew**: If `kube-apiserver` is
-  upgraded but `kube-controller-manager` is not, Pods referencing a cluster
+  upgraded but `kube-controller-manager` is not, Pods or PodGroups referencing a cluster
   template will be admitted but remain in `Pending` state indefinitely because
   the claim controller won't generate the namespaced `ResourceClaims`.
 - **Kubelet skew**: The kubelet only interacts with standard, namespaced
@@ -697,8 +728,8 @@ feature.
 NOTE: Also set `disable-supported` to `true` or `false` in `kep.yaml`.
 -->
 
-Yes. If disabled, new Pod specifications with `clusterResourceClaimTemplateName`
-set will be rejected during API validation. Existing Pods with the field
+Yes. If disabled, new Pod or PodGroup specifications with `clusterResourceClaimTemplateName`
+set will be rejected during API validation. Existing Pods or PodGroups with the field
 populated will fail validation on any subsequent updates. Generated
 `ResourceClaim` resources already created will continue to exist and be bound,
 but further template resolution will be disabled.
@@ -707,7 +738,7 @@ but further template resolution will be disabled.
 
 The `kube-apiserver` and `kube-controller-manager` will resume resolving
 `ClusterResourceClaimTemplate` references and generating corresponding local
-`ResourceClaim` resources for any new or updated Pods.
+`ResourceClaim` resources for any new or updated Pods or PodGroups.
 
 ###### Are there any tests for feature enablement/disablement?
 
@@ -744,9 +775,9 @@ rollout. Similarly, consider large clusters and how enablement/disablement
 will rollout across nodes.
 -->
 
-During upgrade, if a new `kube-apiserver` is upgraded and admits a Pod with
+During upgrade, if a new `kube-apiserver` is upgraded and admits a Pod or PodGroup with
 `clusterResourceClaimTemplateName` but `kube-controller-manager` has not yet
-been upgraded or does not have the feature gate enabled, the Pod will remain
+been upgraded or does not have the feature gate enabled, the Pod or PodGroup will remain
 pending indefinitely because the claim controller won't create the namespaced
 `ResourceClaim`. Already running workloads are unaffected.
 
@@ -757,7 +788,7 @@ What signals should users be paying attention to when the feature is young
 that might indicate a serious problem?
 -->
 
-- An increase in the number of Pods stuck in `Pending` state with unscheduled
+- An increase in the number of Pods or PodGroups stuck in `Pending` state with unscheduled
   `ResourceClaims`.
 - High error rates in `kube-controller-manager` logs related to `ResourceClaim`
   creation.
@@ -815,7 +846,7 @@ Recall that end users cannot usually observe component logs or access metrics.
   - Event Reason: 
 - [x] API .status
   - Condition name: `ResourceClaim` transitions to `status.allocation` set.
-  - Other field: Pod's `status.resourceClaims` list.
+  - Other field: Pod's `status.resourceClaims` list, and the existence of the generated namespaced `ResourceClaim` owned by the Pod or PodGroup.
 - [ ] Other (treat as last resort)
   - Details:
 
@@ -837,7 +868,7 @@ question.
 -->
 
 99% of local `ResourceClaim` creations corresponding to a
-`ClusterResourceClaimTemplate` should succeed within 1 second of the Pod being
+`ClusterResourceClaimTemplate` should succeed within 1 second of the Pod or PodGroup being
 admitted.
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
@@ -919,7 +950,7 @@ Focusing mostly on:
 Yes:
 - `kube-controller-manager` will list and watch `ClusterResourceClaimTemplates`
   (cluster-wide informer index).
-- Throughput is bounded by Pod creation/admission rates that use these
+- Throughput is bounded by Pod or PodGroup creation/admission rates that use these
   templates.
 
 ###### Will enabling / using this feature result in introducing new API types?
@@ -952,7 +983,7 @@ Describe them, providing:
   - Estimated amount of new objects: (e.g., new Object X for every existing Pod)
 -->
 
-Yes, Pod specifications referencing a cluster template will have one extra field
+Yes, Pod or PodGroup specifications referencing a cluster template will have one extra field
 (`clusterResourceClaimTemplateName`) set.
 
 ###### Will enabling / using this feature result in increasing time taken by any operations covered by existing SLIs/SLOs?
@@ -966,7 +997,7 @@ Think about adding additional work or introducing new steps in between
 [existing SLIs/SLOs]: https://git.k8s.io/community/sig-scalability/slos/slos.md#kubernetes-slisslos
 -->
 
-No additional checks or operations are performed during Pod admission that
+No additional checks or operations are performed during Pod or PodGroup admission that
 would impact existing SLIs/SLOs.
 
 ###### Will enabling / using this feature result in non-negligible increase of resource usage (CPU, RAM, disk, IO, ...) in any components?
@@ -1013,7 +1044,7 @@ details). For now, we leave it here.
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
-Admission/creation of Pods using the templates, as well as the creation, update,
+Admission/creation of Pods or PodGroups using the templates, as well as the creation, update,
 or deletion of the `ClusterResourceClaimTemplate` resources themselves, is blocked,
 similar to other Kubernetes resources.
 
@@ -1032,13 +1063,13 @@ For each of them, fill in the following information by copying the below templat
     - Testing: Are there any tests for failure mode? If not, describe why.
 -->
 
-- **Template Reference Resolution Failure**: A Pod specifies a non-existent
+- **Template Reference Resolution Failure**: A Pod or PodGroup specifies a non-existent
   `clusterResourceClaimTemplateName`.
-  - Detection: Pod remains `Pending` with a status event indicating that
+  - Detection: Pod or PodGroup remains `Pending` (or unscheduled) with a status event indicating that
     template resolution failed.
-  - Mitigations: Correct the Pod specification to use a valid template or create
+  - Mitigations: Correct the Pod or PodGroup specification to use a valid template or create
     the referenced `ClusterResourceClaimTemplate`.
-  - Diagnostics: Look at events on the Pod and logs of
+  - Diagnostics: Look at events on the Pod/PodGroup and logs of
     `kube-controller-manager`.
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?

--- a/keps/sig-node/5978-cluster-resource-claim-template/kep.yaml
+++ b/keps/sig-node/5978-cluster-resource-claim-template/kep.yaml
@@ -7,6 +7,7 @@ owning-sig: sig-node
 status: implementable
 creation-date: "2026-06-02"
 reviewers:
+  - "@everpeace"
   - "@mortent"
 approvers:
   - "@pohly"

--- a/keps/sig-node/5978-cluster-resource-claim-template/kep.yaml
+++ b/keps/sig-node/5978-cluster-resource-claim-template/kep.yaml
@@ -1,0 +1,41 @@
+title: "DRA: ClusterResourceClaimTemplate"
+kep-number: 5978
+authors:
+  - "@troychiu"
+owning-sig: sig-node
+# participating-sigs:
+status: implementable
+creation-date: "2026-06-02"
+reviewers:
+  - "@mortent"
+approvers:
+  - "@pohly"
+  - "@johnbelamaric"
+
+# The target maturity stage in the current dev cycle for this KEP.
+# If the purpose of this KEP is to deprecate a user-visible feature
+# and a Deprecated feature gates are added, they should be deprecated|disabled|removed.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v1.37"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v1.37"
+  beta: "v1.38"
+  stable: "v1.40"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: ClusterResourceClaimTemplates
+    components:
+      - kube-apiserver
+      - kube-controller-manager
+disable-supported: true
+
+# The following PRR answers are required at beta release
+metrics: []

--- a/keps/sig-node/5978-cluster-resource-claim-template/kep.yaml
+++ b/keps/sig-node/5978-cluster-resource-claim-template/kep.yaml
@@ -4,7 +4,7 @@ authors:
   - "@troychiu"
 owning-sig: sig-node
 # participating-sigs:
-status: implementable
+status: withdrawn
 creation-date: "2026-06-02"
 reviewers:
   - "@everpeace"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: ClusterResourceClaimTemplates can be defined by the administrator once in the cluster scope, and used by workloads to create namespaced ResourceClaims.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5978

<!-- other comments or additional information -->
- Other comments: Gemini helped create this PR