### PR TITLE
[KEP-4817] Graduate to stable for 1.37

### DIFF
--- a/keps/sig-node/4817-resource-claim-device-status/README.md
+++ b/keps/sig-node/4817-resource-claim-device-status/README.md
@@ -603,7 +603,7 @@ N/A
 - Implementation merged ([kubernetes/kubernetes#128240](https://github.com/kubernetes/kubernetes/pull/128240)): 2024-11-08
 - Released as an alpha feature behind a feature-gate: 2024-12-11 (Kubernetes v1.32)
 - Released as a beta feature with the feature-gate enabled by default: 2025-05-15 (Kubernetes v1.33)
-- Released as a stable feature: 2025-12-17 (Kubernetes v1.35)
+- Released as a stable feature: 2026-08-26 (Kubernetes v1.37)
 
 ## Drawbacks
 

--- a/keps/sig-node/4817-resource-claim-device-status/kep.yaml
+++ b/keps/sig-node/4817-resource-claim-device-status/kep.yaml
@@ -29,13 +29,13 @@ see-also:
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable
 
-latest-milestone: "v1.36"
+latest-milestone: "v1.37"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v1.32"
   beta: "v1.33"
-  stable: "v1.36"
+  stable: "v1.37"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Graduate the ResourceClaim Device Status (KEP-4817) to stable/ga.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4817

<!-- other comments or additional information -->
- Other comments: