### PR TITLE
Graduate KEP 4960 (Container Stop Signals) to beta in 1.37

### DIFF
--- a/keps/prod-readiness/sig-node/4960.yaml
+++ b/keps/prod-readiness/sig-node/4960.yaml
@@ -1,3 +1,5 @@
 kep-number: 4960
 alpha:
   approver: "@deads2k"
+beta:
+  approver: "@deads2k"

--- a/keps/sig-node/4960-container-stop-signals/README.md
+++ b/keps/sig-node/4960-container-stop-signals/README.md
@@ -190,11 +190,11 @@ message ContainerConfig {
 }
 
 + enum Signal {
-+   RUNTIME_DEFAULT   = 0;
-+   SIGABRT           = 1;
-+   SIGALRM           = 2;
++   SIGNAL_RUNTIME_DEFAULT   = 0;
++   SIGNAL_SIGABRT           = 1;
++   SIGNAL_SIGALRM           = 2;
 +   ...
-+   SIGRTMAX          = 65;
++   SIGNAL_SIGRTMAX          = 65;
 + }
 ```
 

--- a/keps/sig-node/4960-container-stop-signals/kep.yaml
+++ b/keps/sig-node/4960-container-stop-signals/kep.yaml
@@ -16,11 +16,11 @@ approvers:
   - '@mrunalp'
 
 status: implementable
-stage: alpha
-latest-milestone: "v1.36"
+stage: beta
+latest-milestone: "v1.37"
 milestone:
     alpha: "v1.33"
-    beta: ""
+    beta: "v1.37"
     stable: ""
 
 feature-gates:


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP updates for graduating KEP 4960 to beta in 1.37

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4960

<!-- other comments or additional information -->
- Other comments: