### PR TITLE
KEP-4222: Clarify transcoding opt-out path for apiservers.

### DIFF
--- a/keps/sig-api-machinery/4222-cbor-serializer/README.md
+++ b/keps/sig-api-machinery/4222-cbor-serializer/README.md
@@ -785,7 +785,11 @@ stream serializer will not. In practice, the watch decoder assumes that the non-
 can directly decode the Raw bytes of a `metav1.WatchEvent` decoded by the stream serializer.
 
 There will be a migration period during which it will remain possible to disable automatic
-transcoding of RawExtension via feature gate.
+transcoding of RawExtension by clients via client-go feature gate. API servers based on the generic
+API server module (`k8s.io/apiserver`) must remove hardcoded assumptions about the format of
+RawExtension bytes decoded from request bodies. It will remain possible to disable the
+CBORServingAndStorage feature gate for at least 3 releases at beta in order to provide sufficient
+time to update API servers without blocking `k8s.io/apiserver` dependency updates.
 
 ##### Migration
 


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Explains how ecosystem apiservers built on `k8s.io/apiserver` can phase out assumptions about the format of the raw bytes of a decoded RawExtension.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/4222

<!-- other comments or additional information -->
- Other comments: