### PR TITLE
verify-node-approvers

### DIFF
--- a/docs/kepval.md
+++ b/docs/kepval.md
@@ -12,3 +12,14 @@ Enhancement Proposal) is valid.
 ## Development
 
 1. Run the tests with `go test -cover ./...`
+
+## SIG Node assigned reviewers/approvers
+
+A `kep.yaml` may annotate individual entries with the inline comments
+`# sig-node-assigned-reviewer` and `# sig-node-assigned-approver` to
+[scale SIG Node KEP approvers](https://github.com/kubernetes/community/blob/main/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers). Any handle so
+annotated must also be listed in the `OWNERS` file next to that `kep.yaml`:
+assigned reviewers under `reviewers:`, assigned approvers under `approvers:`.
+Conversely, every entry in an `OWNERS` file must have a corresponding annotation
+in `kep.yaml` — extra entries in `OWNERS` that are not annotated in `kep.yaml`
+are also flagged as violations.

--- a/hack/verify-node-approvers.sh
+++ b/hack/verify-node-approvers.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# cd to the root path
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${ROOT}"
+
+# run the node approvers verification
+GO111MODULE=on go test -v ./test/node_approvers_test.go

--- a/keps/sig-node/4188-kubelet-pod-readiness-api/OWNERS
+++ b/keps/sig-node/4188-kubelet-pod-readiness-api/OWNERS
@@ -6,6 +6,3 @@ reviewers:
   - swatisehgal # sig-node-assigned-reviewer
   - tallclair # sig-node-assigned-reviewer
   - SergeyKanzhelev # sig-node-assigned-reviewer
-
-approvers:
-  - dchen1107 # sig-node-tl

--- a/keps/sig-node/4563-eviction-request-api/OWNERS
+++ b/keps/sig-node/4563-eviction-request-api/OWNERS
@@ -4,6 +4,3 @@
 
 reviewers:
   - haircommander # sig-node-assigned-reviewer
-
-approvers:
-  - dchen1107 # sig-node-tl

--- a/keps/sig-node/4680-add-resource-health-to-pod-status/OWNERS
+++ b/keps/sig-node/4680-add-resource-health-to-pod-status/OWNERS
@@ -6,5 +6,4 @@ reviewers:
   - ffromani # sig-node-assigned-reviewer
 
 approvers:
-  - mrunalp # sig-node-tl
   - SergeyKanzhelev # sig-node-assigned-approver

--- a/keps/sig-node/4680-add-resource-health-to-pod-status/kep.yaml
+++ b/keps/sig-node/4680-add-resource-health-to-pod-status/kep.yaml
@@ -16,7 +16,7 @@ reviewers:
   - "@johnbelamaric"
 approvers:
   - "@mrunalp" # sig-node-tl
-  - "@SergeyKanzhelev" # sig-node-assigned-approver"
+  - "@SergeyKanzhelev" # sig-node-assigned-approver
 
 see-also:
   - "/keps/sig-node/1287-in-place-update-pod-resources" # for AllocatedResources status field

--- a/keps/sig-node/5328-node-declared-features/kep.yaml
+++ b/keps/sig-node/5328-node-declared-features/kep.yaml
@@ -16,6 +16,7 @@ reviewers:
   - '@dom4ha'
   - '@macsko'
   - '@haircommander' # sig-node-assigned-reviewer
+  - '@swatisehgal' # sig-node-assigned-reviewer
 approvers:
 - "@tallclair" # sig-node-assigned-approver
 - '@dchen1107' # sig-node-tl

--- a/keps/sig-node/5394-psi-node-conditions/OWNERS
+++ b/keps/sig-node/5394-psi-node-conditions/OWNERS
@@ -5,7 +5,3 @@
 reviewers:
   - haircommander # sig-node-assigned-reviewer
   - ndixita # sig-node-assigned-reviewer
-
-approvers:
-  - mrunalp # sig-node-tl
-  - dchen1107 # sig-node-tl

--- a/keps/sig-node/5526-pod-level-resource-managers/OWNERS
+++ b/keps/sig-node/5526-pod-level-resource-managers/OWNERS
@@ -10,4 +10,3 @@ reviewers:
 
 approvers:
   - ffromani # sig-node-assigned-approver
-  - dchen1107 # sig-node-tl

--- a/keps/sig-node/5526-pod-level-resource-managers/kep.yaml
+++ b/keps/sig-node/5526-pod-level-resource-managers/kep.yaml
@@ -10,7 +10,7 @@ status: implementable
 creation-date: 2025-09-10
 reviewers:
   - "@ndixita" # sig-node-assigned-reviewer
-  - "@ffromani"
+  - "@ffromani" # sig-node-assigned-reviewer
   - "@tallclair" # sig-node-assigned-reviewer
   - "@kad" # sig-node-assigned-reviewer
 approvers:

--- a/keps/sig-node/5554-in-place-update-pod-resources-alongside-static-cpu-manager-policy/OWNERS
+++ b/keps/sig-node/5554-in-place-update-pod-resources-alongside-static-cpu-manager-policy/OWNERS
@@ -4,6 +4,3 @@
 
 reviewers:
   - ffromani # sig-node-assigned-reviewer
-
-approvers:
-  - dchen1107 # sig-node-tl

--- a/keps/sig-node/5607-hostnetwork-userns/OWNERS
+++ b/keps/sig-node/5607-hostnetwork-userns/OWNERS
@@ -5,6 +5,3 @@
 reviewers:
   - mikebrow # sig-node-assigned-reviewer
   - haircommander # sig-node-assigned-reviewer
-
-approvers:
-  - mrunalp # sig-node-tl

--- a/pkg/nodeapprovers/OWNERS
+++ b/pkg/nodeapprovers/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+
+  - sig-node-leads

--- a/pkg/nodeapprovers/testdata/extra-in-owners/OWNERS
+++ b/pkg/nodeapprovers/testdata/extra-in-owners/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - tallclair # sig-node-assigned-reviewer
+  - mrunalp
+
+approvers:
+  - dchen1107 # sig-node-assigned-approver
+  - derekwaynecarr

--- a/pkg/nodeapprovers/testdata/extra-in-owners/kep.yaml
+++ b/pkg/nodeapprovers/testdata/extra-in-owners/kep.yaml
@@ -1,0 +1,8 @@
+title: Extra In OWNERS Fixture
+kep-number: 7
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@tallclair" # sig-node-assigned-reviewer
+approvers:
+  - "@dchen1107" # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/missing-approver/OWNERS
+++ b/pkg/nodeapprovers/testdata/missing-approver/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - SergeyKanzhelev # sig-node-assigned-reviewer
+  - tallclair
+
+approvers:
+  - tallclair

--- a/pkg/nodeapprovers/testdata/missing-approver/kep.yaml
+++ b/pkg/nodeapprovers/testdata/missing-approver/kep.yaml
@@ -1,0 +1,8 @@
+title: Missing Approver Fixture
+kep-number: 3
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@tallclair" # sig-node-assigned-reviewer
+approvers:
+  - "@someoneelse" # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/missing-reviewer/OWNERS
+++ b/pkg/nodeapprovers/testdata/missing-reviewer/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - SergeyKanzhelev # sig-node-assigned-reviewer
+  - tallclair
+
+approvers:
+  - tallclair

--- a/pkg/nodeapprovers/testdata/missing-reviewer/kep.yaml
+++ b/pkg/nodeapprovers/testdata/missing-reviewer/kep.yaml
@@ -1,0 +1,8 @@
+title: Missing Reviewer Fixture
+kep-number: 2
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@someoneelse" # sig-node-assigned-reviewer
+approvers:
+  - "@tallclair" # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/mixed-case/OWNERS
+++ b/pkg/nodeapprovers/testdata/mixed-case/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - tallclair # sig-node-assigned-reviewer
+
+approvers:
+  - tallclair # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/mixed-case/kep.yaml
+++ b/pkg/nodeapprovers/testdata/mixed-case/kep.yaml
@@ -1,0 +1,8 @@
+title: Mixed Case Fixture
+kep-number: 6
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@TallClair" # sig-node-assigned-reviewer
+approvers:
+  - "@TALLCLAIR" # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/no-markers/kep.yaml
+++ b/pkg/nodeapprovers/testdata/no-markers/kep.yaml
@@ -1,0 +1,9 @@
+title: No Markers Fixture
+kep-number: 5
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@mrunalp"
+  - "@tallclair" # sig-node-tl
+approvers:
+  - "@dchen1107"

--- a/pkg/nodeapprovers/testdata/no-owners/kep.yaml
+++ b/pkg/nodeapprovers/testdata/no-owners/kep.yaml
@@ -1,0 +1,8 @@
+title: No Owners Fixture
+kep-number: 4
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@tallclair" # sig-node-assigned-reviewer
+approvers:
+  - "@dchen1107" # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/valid/OWNERS
+++ b/pkg/nodeapprovers/testdata/valid/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - tallclair # sig-node-assigned-reviewer
+
+approvers:
+  - tallclair # sig-node-assigned-approver

--- a/pkg/nodeapprovers/testdata/valid/kep.yaml
+++ b/pkg/nodeapprovers/testdata/valid/kep.yaml
@@ -1,0 +1,10 @@
+title: Valid Fixture
+kep-number: 1
+owning-sig: sig-node
+status: implementable
+reviewers:
+  - "@mrunalp"
+  - "@tallclair" # sig-node-assigned-reviewer
+approvers:
+  - "@dchen1107" # sig-node-tl
+  - "@tallclair" # sig-node-assigned-approver

--- a/pkg/nodeapprovers/verify.go
+++ b/pkg/nodeapprovers/verify.go
@@ -1,0 +1,258 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package nodeapprovers verifies that reviewers/approvers annotated in a
+// kep.yaml with the inline comments "# sig-node-assigned-reviewer" and
+// "# sig-node-assigned-approver" are listed in the neighboring OWNERS file
+// (assigned reviewers under reviewers:, assigned approvers under approvers:).
+package nodeapprovers
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Hardcoded inline-comment markers identifying SIG Node assigned reviewers and
+// approvers in a kep.yaml file.
+const (
+	reviewerMarker = "sig-node-assigned-reviewer"
+	approverMarker = "sig-node-assigned-approver"
+
+	reviewerRole = "reviewer"
+	approverRole = "approver"
+)
+
+// Violation describes a single assigned reviewer/approver that is not correctly
+// listed in the neighboring OWNERS file.
+type Violation struct {
+	// KEPPath is the path to the kep.yaml that carries the assignment.
+	KEPPath string
+	// Role is either "reviewer" or "approver".
+	Role string
+	// User is the normalized (lowercased, no leading "@") username.
+	User string
+	// Reason is a human-readable explanation of the violation.
+	Reason string
+}
+
+// String returns a readable, single-line representation of the violation.
+func (v Violation) String() string {
+	return fmt.Sprintf("%s: assigned %s %q %s", v.KEPPath, v.Role, v.User, v.Reason)
+}
+
+// ownersFile is the minimal shape of an OWNERS file needed for verification.
+type ownersFile struct {
+	Reviewers []string `yaml:"reviewers"`
+	Approvers []string `yaml:"approvers"`
+}
+
+// normalizeUser trims a leading "@" and lowercases the handle. GitHub handles
+// are case-insensitive, and OWNERS files use bare names while kep.yaml uses
+// "@name".
+func normalizeUser(name string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(name), "@"))
+}
+
+// markerOf returns the trimmed marker text from a yaml LineComment (stripping a
+// leading "#" and surrounding spaces), e.g. "# sig-node-assigned-reviewer" ->
+// "sig-node-assigned-reviewer".
+func markerOf(lineComment string) string {
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lineComment), "#"))
+}
+
+// assignedUsers walks the given sequence node (the value of reviewers: or
+// approvers:) and returns the normalized usernames whose inline comment matches
+// the supplied marker.
+func assignedUsers(seq *yaml.Node, marker string) []string {
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return nil
+	}
+
+	var users []string
+	for _, item := range seq.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		if markerOf(item.LineComment) == marker {
+			users = append(users, normalizeUser(item.Value))
+		}
+	}
+
+	return users
+}
+
+// mappingValue returns the value node for the given key in a mapping node, or
+// nil if the key is absent or the node is not a mapping.
+func mappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+// containsNormalized reports whether the normalized list includes the normalized user.
+func containsNormalized(list []string, user string) bool {
+	for _, item := range list {
+		if normalizeUser(item) == user {
+			return true
+		}
+	}
+
+	return false
+}
+
+// VerifyKEP verifies a single kep.yaml file and returns any violations found.
+func VerifyKEP(kepYAMLPath string) ([]Violation, error) {
+	data, err := os.ReadFile(kepYAMLPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", kepYAMLPath, err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", kepYAMLPath, err)
+	}
+
+	// Unwrap the document node to get the top-level mapping.
+	var root *yaml.Node
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		root = doc.Content[0]
+	} else {
+		root = &doc
+	}
+
+	assignedReviewers := assignedUsers(mappingValue(root, "reviewers"), reviewerMarker)
+	assignedApprovers := assignedUsers(mappingValue(root, "approvers"), approverMarker)
+
+	if len(assignedReviewers) == 0 && len(assignedApprovers) == 0 {
+		return nil, nil
+	}
+
+	ownersPath := filepath.Join(filepath.Dir(kepYAMLPath), "OWNERS")
+	ownersData, err := os.ReadFile(ownersPath)
+	if err != nil {
+		var violations []Violation
+		for _, u := range assignedReviewers {
+			violations = append(violations, Violation{
+				KEPPath: kepYAMLPath,
+				Role:    reviewerRole,
+				User:    u,
+				Reason:  "OWNERS file not found",
+			})
+		}
+		for _, u := range assignedApprovers {
+			violations = append(violations, Violation{
+				KEPPath: kepYAMLPath,
+				Role:    approverRole,
+				User:    u,
+				Reason:  "OWNERS file not found",
+			})
+		}
+		return violations, nil
+	}
+
+	var owners ownersFile
+	if err := yaml.Unmarshal(ownersData, &owners); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", ownersPath, err)
+	}
+
+	var violations []Violation
+	for _, u := range assignedReviewers {
+		if !containsNormalized(owners.Reviewers, u) {
+			violations = append(violations, Violation{
+				KEPPath: kepYAMLPath,
+				Role:    reviewerRole,
+				User:    u,
+				Reason:  "not listed under reviewers in OWNERS",
+			})
+		}
+	}
+	for _, u := range assignedApprovers {
+		if !containsNormalized(owners.Approvers, u) {
+			violations = append(violations, Violation{
+				KEPPath: kepYAMLPath,
+				Role:    approverRole,
+				User:    u,
+				Reason:  "not listed under approvers in OWNERS",
+			})
+		}
+	}
+
+	// Reverse check: every entry in OWNERS must have a corresponding
+	// annotation in kep.yaml.
+	for _, u := range owners.Reviewers {
+		if !containsNormalized(assignedReviewers, normalizeUser(u)) {
+			violations = append(violations, Violation{
+				KEPPath: kepYAMLPath,
+				Role:    reviewerRole,
+				User:    normalizeUser(u),
+				Reason:  "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+			})
+		}
+	}
+	for _, u := range owners.Approvers {
+		if !containsNormalized(assignedApprovers, normalizeUser(u)) {
+			violations = append(violations, Violation{
+				KEPPath: kepYAMLPath,
+				Role:    approverRole,
+				User:    normalizeUser(u),
+				Reason:  "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+			})
+		}
+	}
+
+	return violations, nil
+}
+
+// VerifyAll walks rootDir (typically the repo's keps/ directory) for files named
+// kep.yaml and aggregates the violations from each.
+func VerifyAll(rootDir string) ([]Violation, error) {
+	var violations []Violation
+
+	err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "kep.yaml" {
+			return nil
+		}
+
+		v, err := VerifyKEP(path)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, v...)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return violations, nil
+}

--- a/pkg/nodeapprovers/verify_test.go
+++ b/pkg/nodeapprovers/verify_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeapprovers
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// violationsFor returns the expected violations for a fixture directory, with
+// KEPPath filled in to point at that fixture's kep.yaml.
+func violationsFor(dir string, partials ...Violation) []Violation {
+	kepPath := filepath.Join("testdata", dir, "kep.yaml")
+	out := make([]Violation, 0, len(partials))
+	for _, p := range partials {
+		p.KEPPath = kepPath
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestVerifyKEP(t *testing.T) {
+	testcases := []struct {
+		name string
+		dir  string
+		want []Violation
+	}{
+		{
+			name: "valid",
+			dir:  "valid",
+		},
+		{
+			// Mixed-case handles in kep.yaml must match lowercase OWNERS
+			// entries after normalization, so no violations are expected.
+			name: "mixed case normalizes",
+			dir:  "mixed-case",
+		},
+		{
+			name: "missing reviewer",
+			dir:  "missing-reviewer",
+			want: violationsFor("missing-reviewer",
+				Violation{
+					Role:   reviewerRole,
+					User:   "someoneelse",
+					Reason: "not listed under reviewers in OWNERS",
+				},
+				Violation{
+					Role:   reviewerRole,
+					User:   "tallclair",
+					Reason: "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+				},
+			),
+		},
+		{
+			name: "missing approver",
+			dir:  "missing-approver",
+			want: violationsFor("missing-approver",
+				Violation{
+					Role:   approverRole,
+					User:   "someoneelse",
+					Reason: "not listed under approvers in OWNERS",
+				},
+				Violation{
+					Role:   approverRole,
+					User:   "tallclair",
+					Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+				},
+			),
+		},
+		{
+			name: "no owners",
+			dir:  "no-owners",
+			want: violationsFor("no-owners",
+				Violation{
+					Role:   reviewerRole,
+					User:   "tallclair",
+					Reason: "OWNERS file not found",
+				},
+				Violation{
+					Role:   approverRole,
+					User:   "dchen1107",
+					Reason: "OWNERS file not found",
+				},
+			),
+		},
+		{
+			name: "no markers",
+			dir:  "no-markers",
+		},
+		{
+			name: "extra in owners",
+			dir:  "extra-in-owners",
+			want: violationsFor("extra-in-owners",
+				Violation{
+					Role:   reviewerRole,
+					User:   "mrunalp",
+					Reason: "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+				},
+				Violation{
+					Role:   approverRole,
+					User:   "derekwaynecarr",
+					Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+				},
+			),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			kepPath := filepath.Join("testdata", tc.dir, "kep.yaml")
+			violations, err := VerifyKEP(kepPath)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.want, violations, "violations: %v", violations)
+		})
+	}
+}
+
+func TestVerifyAll(t *testing.T) {
+	violations, err := VerifyAll("testdata")
+	require.NoError(t, err)
+
+	// Aggregated violations across all fixtures: missing-reviewer and
+	// missing-approver each contribute one, no-owners contributes two,
+	// extra-in-owners contributes two, and valid, mixed-case, and no-markers
+	// contribute none.
+	want := make([]Violation, 0, 8)
+	want = append(want, violationsFor("missing-reviewer",
+		Violation{
+			Role:   reviewerRole,
+			User:   "someoneelse",
+			Reason: "not listed under reviewers in OWNERS",
+		},
+		Violation{
+			Role:   reviewerRole,
+			User:   "tallclair",
+			Reason: "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+		},
+	)...)
+	want = append(want, violationsFor("missing-approver",
+		Violation{
+			Role:   approverRole,
+			User:   "someoneelse",
+			Reason: "not listed under approvers in OWNERS",
+		},
+		Violation{
+			Role:   approverRole,
+			User:   "tallclair",
+			Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+		},
+	)...)
+	want = append(want, violationsFor("no-owners",
+		Violation{
+			Role:   reviewerRole,
+			User:   "tallclair",
+			Reason: "OWNERS file not found",
+		},
+		Violation{
+			Role:   approverRole,
+			User:   "dchen1107",
+			Reason: "OWNERS file not found",
+		},
+	)...)
+	want = append(want, violationsFor("extra-in-owners",
+		Violation{
+			Role:   reviewerRole,
+			User:   "mrunalp",
+			Reason: "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+		},
+		Violation{
+			Role:   approverRole,
+			User:   "derekwaynecarr",
+			Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+		},
+	)...)
+
+	require.ElementsMatch(t, want, violations, "violations: %v", violations)
+}

--- a/test/node_approvers_test.go
+++ b/test/node_approvers_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/enhancements/pkg/nodeapprovers"
+)
+
+// TestNodeApprovers verifies that every kep.yaml reviewer/approver annotated
+// with the sig-node-assigned-reviewer / sig-node-assigned-approver inline
+// comment is listed in the neighboring OWNERS file. It runs over the real
+// keps/ tree and is exercised automatically in CI via hack/test-go.sh.
+func TestNodeApprovers(t *testing.T) {
+	wd, err := os.Getwd()
+	require.Nil(t, err)
+
+	rootDir := filepath.Dir(wd)
+
+	violations, err := nodeapprovers.VerifyAll(filepath.Join(rootDir, "keps"))
+	require.Nil(t, err)
+
+	if len(violations) > 0 {
+		msgs := make([]string, 0, len(violations))
+		for _, v := range violations {
+			msgs = append(msgs, v.String())
+		}
+		t.Fatalf(
+			"%d SIG Node assigned reviewer/approver violation(s) found:\n%s",
+			len(violations),
+			strings.Join(msgs, "\n"),
+		)
+	}
+}


### PR DESCRIPTION
- One-line PR description:

Keep OWNERS and kep.yaml in sync for SIG Node approvers scaling

@haircommander and @wojtek-t for the feedback on approach


Note: some AI was used