### PR TITLE
Update sig-node KEP approvers/reviewers from project board

### DIFF
--- a/keps/sig-node/4960-container-stop-signals/kep.yaml
+++ b/keps/sig-node/4960-container-stop-signals/kep.yaml
@@ -12,8 +12,10 @@ reviewers:
   - '@thockin'
   - '@mrunalp'
   - '@kannon92'
+  - "@mikebrow" # sig-node-assigned-reviewer
 approvers: 
   - '@mrunalp'
+  - "@sergeykanzhelev" # sig-node-assigned-approver
 
 status: implementable
 stage: beta

--- a/keps/sig-node/5328-node-declared-features/kep.yaml
+++ b/keps/sig-node/5328-node-declared-features/kep.yaml
@@ -18,7 +18,6 @@ reviewers:
   - '@haircommander' # sig-node-assigned-reviewer
   - '@swatisehgal' # sig-node-assigned-reviewer
 approvers:
-- "@tallclair" # sig-node-assigned-approver
 - '@dchen1107' # sig-node-tl
 - '@tallclair' # sig-node-assigned-approver
 - '@dom4ha' # SIG-Scheduling

--- a/keps/sig-node/5607-hostnetwork-userns/OWNERS
+++ b/keps/sig-node/5607-hostnetwork-userns/OWNERS
@@ -5,3 +5,5 @@
 reviewers:
   - mikebrow # sig-node-assigned-reviewer
   - haircommander # sig-node-assigned-reviewer
+approvers:
+  - haircommander # sig-node-assigned-approver

--- a/keps/sig-node/5607-hostnetwork-userns/kep.yaml
+++ b/keps/sig-node/5607-hostnetwork-userns/kep.yaml
@@ -13,6 +13,7 @@ reviewers:
   - "@mikebrow" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp" # sig-node-tl
+  - "@haircommander" # sig-node-assigned-approver
 
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature


### PR DESCRIPTION
- One-line PR description:

Add missing sig-node-assigned-approver and sig-node-assigned-reviewer annotations to kep.yaml files based on the SIG Node project board. Remove duplicate entries.

See triaged: https://github.com/orgs/kubernetes/projects/265/

/sig node
/assign @mrunalp @dchen1107 