### PR TITLE
OWNERS should not overshare

### DIFF
--- a/keps/sig-node/1769-memory-manager/kep.yaml
+++ b/keps/sig-node/1769-memory-manager/kep.yaml
@@ -14,6 +14,7 @@ reviewers:
   - "@klueska"
   - "@derekwaynecarr"
 approvers:
+  - "@klueska" # sig-node-assigned-approver
   - "@derekwaynecarr"
 see-also:
 replaces:

--- a/keps/sig-node/2000-graceful-node-shutdown/kep.yaml
+++ b/keps/sig-node/2000-graceful-node-shutdown/kep.yaml
@@ -10,6 +10,7 @@ reviewers:
   - "@SergeyKanzhelev"
   - "@karan"
 approvers:
+  - "@yujuhong" # sig-node-assigned-approver
   - "@dchen1107"
   - "@derekwaynecarr"
 

--- a/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
+++ b/keps/sig-node/2625-cpumanager-policies-thread-placement/kep.yaml
@@ -12,6 +12,7 @@ reviewers:
   - "@klueska"
   - "@swatisehgal"
 approvers:
+  - "@klueska" # sig-node-assigned-approver
   - "@sig-node-tech-leads"
 see-also:
 - "keps/sig-node/2902-cpumanager-distribute-cpus-policy-option/"

--- a/keps/sig-node/3545-improved-multi-numa-alignment/kep.yaml
+++ b/keps/sig-node/3545-improved-multi-numa-alignment/kep.yaml
@@ -9,6 +9,7 @@ status: implemented
 creation-date: "2022-09-26"
 reviewers: []
 approvers:
+  - "@klueska" # sig-node-assigned-approver
   - "@sig-node-tech-leads"
 last-updated: "2024-11-06"
 see-also: []

--- a/keps/sig-node/3721-support-for-env-files/kep.yaml
+++ b/keps/sig-node/3721-support-for-env-files/kep.yaml
@@ -13,7 +13,7 @@ reviewers:
   - "@sftim"
   - "@SergeyKanzhelev"
 approvers:
-  - "@SergeyKanzhelev"
+  - "@SergeyKanzhelev" # sig-node-assigned-approver
 see-also:
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-node/3960-pod-lifecycle-sleep-action/kep.yaml
+++ b/keps/sig-node/3960-pod-lifecycle-sleep-action/kep.yaml
@@ -10,6 +10,7 @@ reviewers:
   - "@thockin"
   - "@bobbypage"
 approvers:
+  - "@SergeyKanzhelev" # sig-node-assigned-approver
   - "@mrunalp"
 see-also: []
 replaces: []

--- a/keps/sig-node/3983-drop-in-configuration/kep.yaml
+++ b/keps/sig-node/3983-drop-in-configuration/kep.yaml
@@ -11,6 +11,7 @@ last-updated: 2024-09-30
 reviewers:
   - "@harche"
 approvers:
+  - "@SergeyKanzhelev" # sig-node-assigned-approver
   - "@mrunalp"
 
 # The target maturity stage in the current dev cycle for this KEP.

--- a/keps/sig-node/4176-cpumanager-spread-cpus-preferred-policy/kep.yaml
+++ b/keps/sig-node/4176-cpumanager-spread-cpus-preferred-policy/kep.yaml
@@ -12,6 +12,7 @@ creation-date: "2023-09-04"
 reviewers:
   - "@ffromani"
 approvers:
+  - "@klueska" # sig-node-assigned-approver
   - "@sig-node-tech-leads"
 see-also: []
 replaces: []

--- a/keps/sig-node/4369-allow-special-characters-environment-variable/kep.yaml
+++ b/keps/sig-node/4369-allow-special-characters-environment-variable/kep.yaml
@@ -12,7 +12,7 @@ reviewers:
   - "@thockin"
 approvers:
   - "@thockin"
-  - "@SergeyKanzhelev"
+  - "@SergeyKanzhelev" # sig-node-assigned-approver
 
 see-also: []
 replaces: []

--- a/keps/sig-node/4540-strict-cpu-reservation/kep.yaml
+++ b/keps/sig-node/4540-strict-cpu-reservation/kep.yaml
@@ -11,7 +11,7 @@ reviewers:
   - "@ffromani"
   - "@swatisehgal"                                                                      
 approvers:
-  - "@ffromani"
+  - "@ffromani" # sig-node-assigned-approver
 see-also: []
 replaces: []
 

--- a/keps/sig-node/4622-topologymanager-max-allowable-numa-nodes/kep.yaml
+++ b/keps/sig-node/4622-topologymanager-max-allowable-numa-nodes/kep.yaml
@@ -11,7 +11,7 @@ reviewers:
   - "@klueska"
   - "@ffromani"
 approvers:
-  - "@klueska"
+  - "@klueska" # sig-node-assigned-approver
 see-also: 
   - "keps/sig-node/2625-cpumanager-policies-thread-placement/"
   - "keps/sig-node/2902-cpumanager-distribute-cpus-policy-option/"

--- a/keps/sig-node/4800-cpumanager-split-uncorecache/kep.yaml
+++ b/keps/sig-node/4800-cpumanager-split-uncorecache/kep.yaml
@@ -13,8 +13,8 @@ reviewers:
   - "@kannon92"
   - "@kad"
 approvers:
-  - "@ffromani"
-  - "@klueska" 
+  - "@ffromani" # sig-node-assigned-approver
+  - "@klueska"
 
 see-also: 
   - keps/sig-node/2625-cpumanager-policies-thread-placement"

--- a/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/kep.yaml
+++ b/keps/sig-node/4818-allow-zero-value-for-sleep-action-of-prestop-hook/kep.yaml
@@ -11,7 +11,7 @@ reviewers:
   - "@kannon92"
   - "@ffromani"
 approvers:
-  - "@SergeyKanzhelev"
+  - "@SergeyKanzhelev" # sig-node-assigned-approver
 
 see-also:
   - "/keps/sig-node/3960-pod-lifecycle-sleep-action"

--- a/keps/sig-node/4960-container-stop-signals/kep.yaml
+++ b/keps/sig-node/4960-container-stop-signals/kep.yaml
@@ -7,15 +7,14 @@ participating-sigs:
   - sig-node
   - sig-windows
 creation-date: "2025-02-01"
-reviewers: 
-  - '@mikebrow'
+reviewers:
+  - '@mikebrow' # sig-node-assigned-reviewer
   - '@thockin'
   - '@mrunalp'
   - '@kannon92'
-  - "@mikebrow" # sig-node-assigned-reviewer
-approvers: 
+approvers:
+  - '@sergeykanzhelev' # sig-node-assigned-approver
   - '@mrunalp'
-  - "@sergeykanzhelev" # sig-node-assigned-approver
 
 status: implementable
 stage: beta

--- a/keps/sig-node/5304-dra-attributes-downward-api/kep.yaml
+++ b/keps/sig-node/5304-dra-attributes-downward-api/kep.yaml
@@ -11,7 +11,7 @@ reviewers:
   - "@mortent"
   - "@SergeyKanzhelev"
 approvers:
-  - "@mrunalp" # sig-node-tl
+  - "@mrunalp" # sig-node-assigned-approver
 
 see-also:
 - "/keps/sig-node/4381-dra-structured-parameters"

--- a/keps/sig-node/5677-dra-resource-availability-visibility/kep.yaml
+++ b/keps/sig-node/5677-dra-resource-availability-visibility/kep.yaml
@@ -15,7 +15,7 @@ reviewers:
   - "@liggitt"
   - "@pohly"
 approvers:
-  - "@mrunalp" # sig-node-tl
+  - "@mrunalp" # sig-node-assigned-approver
 
 see-also:
   - "/keps/sig-node/4381-dra-structured-parameters"

--- a/pkg/nodeapprovers/testdata/no-markers/OWNERS
+++ b/pkg/nodeapprovers/testdata/no-markers/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - tallclair # sig-node-assigned-reviewer
+
+approvers:
+  - dchen1107 # sig-node-assigned-approver

--- a/pkg/nodeapprovers/verify.go
+++ b/pkg/nodeapprovers/verify.go
@@ -149,13 +149,13 @@ func VerifyKEP(kepYAMLPath string) ([]Violation, error) {
 	assignedReviewers := assignedUsers(mappingValue(root, "reviewers"), reviewerMarker)
 	assignedApprovers := assignedUsers(mappingValue(root, "approvers"), approverMarker)
 
-	if len(assignedReviewers) == 0 && len(assignedApprovers) == 0 {
-		return nil, nil
-	}
-
 	ownersPath := filepath.Join(filepath.Dir(kepYAMLPath), "OWNERS")
 	ownersData, err := os.ReadFile(ownersPath)
-	if err != nil {
+	if os.IsNotExist(err) {
+		if len(assignedReviewers) == 0 && len(assignedApprovers) == 0 {
+			// No annotations and no OWNERS file — nothing to check.
+			return nil, nil
+		}
 		var violations []Violation
 		for _, u := range assignedReviewers {
 			violations = append(violations, Violation{
@@ -174,6 +174,8 @@ func VerifyKEP(kepYAMLPath string) ([]Violation, error) {
 			})
 		}
 		return violations, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", ownersPath, err)
 	}
 
 	var owners ownersFile

--- a/pkg/nodeapprovers/verify_test.go
+++ b/pkg/nodeapprovers/verify_test.go
@@ -100,8 +100,20 @@ func TestVerifyKEP(t *testing.T) {
 			),
 		},
 		{
-			name: "no markers",
+			name: "no markers but OWNERS exists",
 			dir:  "no-markers",
+			want: violationsFor("no-markers",
+				Violation{
+					Role:   reviewerRole,
+					User:   "tallclair",
+					Reason: "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+				},
+				Violation{
+					Role:   approverRole,
+					User:   "dchen1107",
+					Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+				},
+			),
 		},
 		{
 			name: "extra in owners",
@@ -135,11 +147,10 @@ func TestVerifyAll(t *testing.T) {
 	violations, err := VerifyAll("testdata")
 	require.NoError(t, err)
 
-	// Aggregated violations across all fixtures: missing-reviewer and
-	// missing-approver each contribute one, no-owners contributes two,
-	// extra-in-owners contributes two, and valid, mixed-case, and no-markers
-	// contribute none.
-	want := make([]Violation, 0, 8)
+	// Aggregated violations across all fixtures: missing-reviewer,
+	// missing-approver, no-owners, extra-in-owners, and no-markers each
+	// contribute two, and valid and mixed-case contribute none.
+	want := make([]Violation, 0, 10)
 	want = append(want, violationsFor("missing-reviewer",
 		Violation{
 			Role:   reviewerRole,
@@ -185,6 +196,18 @@ func TestVerifyAll(t *testing.T) {
 		Violation{
 			Role:   approverRole,
 			User:   "derekwaynecarr",
+			Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
+		},
+	)...)
+	want = append(want, violationsFor("no-markers",
+		Violation{
+			Role:   reviewerRole,
+			User:   "tallclair",
+			Reason: "listed in OWNERS but not annotated as sig-node-assigned-reviewer in kep.yaml",
+		},
+		Violation{
+			Role:   approverRole,
+			User:   "dchen1107",
 			Reason: "listed in OWNERS but not annotated as sig-node-assigned-approver in kep.yaml",
 		},
 	)...)


### PR DESCRIPTION
/assign @haircommander 

- One-line PR description:

Previos change had early exit when no tags are found in kep.yaml. We should treat kep.yaml to be a definitive source of truth


/sig node