### PR TITLE
KEP-4322: Require ClusterProperty resources in ClusterProfile status properties

### DIFF
--- a/keps/sig-multicluster/4322-cluster-inventory/README.md
+++ b/keps/sig-multicluster/4322-cluster-inventory/README.md
@@ -604,11 +604,13 @@ minimum kubelet version, maximum kubelet version, and enabled featureset version
 
 #### Properties
 
-Name/value pairs to represent properties of the clusters. It could be a
-collection of ClusterProperty resources, but could also be info based on
-other implementations. The name of the cluster property can be predefined
-name from ClusterProperty resources and is allowed to be customized by
-different cluster managers.
+Name/value pairs to represent properties of the clusters. Cluster managers
+SHOULD include ClusterProperty resources defined on the member cluster in the
+ClusterProfile's `.status.properties`. They MAY also include properties from
+other implementations. Properties derived from ClusterProperty resources MUST
+preserve the name and value of the ClusterProperty as-is. Cluster managers MAY
+additionally include their own custom-named properties, as long as they do not
+conflict with names derived from ClusterProperty resources.
 
 #### Conditions
 


### PR DESCRIPTION
- One-line PR description: Require ClusterProperty resources to be reflected in ClusterProfile
`.status.properties` with their names and values preserved

- Issue link: https://github.com/kubernetes/enhancements/issues/4322

- Other comments:
There are already multiple cluster managers implementing the ClusterInventory API, each with its own
rules for populating properties. This creates a risk that ClusterProfile API consumers cannot be reused
across cluster managers even though they should be. To keep consumers portable regardless of which
cluster manager is used, this PR changes the wording so that ClusterProperty resources MUST be reflected
in the ClusterProfile's `.status.properties`, preserving their names and values as-is. Cluster managers
can still add their own custom-named properties as long as they do no
