### PR TITLE
Add Path field to Proposal for accurate KEP README.md URLs

### DIFF
--- a/api/proposal.go
+++ b/api/proposal.go
@@ -101,6 +101,7 @@ type Proposal struct {
 	ID       string `json:"id"`
 	PRNumber string `json:"prNumber,omitempty"`
 	Name     string `json:"name,omitempty"`
+	Path     string `json:"path,omitempty"`
 
 	Title             string   `json:"title" yaml:"title" validate:"required"`
 	Number            string   `json:"kepNumber" yaml:"kep-number" validate:"required"`

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -470,6 +470,10 @@ func (r *Repo) loadKEPFromYaml(repoPath, kepPath string) (*api.Proposal, error) 
 	}
 
 	p.Name = filepath.Base(filepath.Dir(kepPath))
+	p.Path = strings.TrimPrefix(
+		filepath.Dir(kepPath),
+		ProposalPathStub+string(filepath.Separator),
+	)
 	prrApprovalPath := filepath.Join(repoPath, ProposalPathStub, PRRApprovalPathStub)
 
 	// Read the PRR approval file and add any listed PRR approvers in there


### PR DESCRIPTION
KEPs under SIG subdirectories (e.g. `sig-cloud-provider/azure/`, `sig-cluster-lifecycle/kubeadm/`) produce incorrect links in `keps.json` because `owningSig` does not include the subdirectory.

This adds a `Path` field to `api.Proposal` containing the actual filesystem path relative to `keps/`, enabling downstream consumers to construct correct README URLs.

Closes: #6214
Refs: kubernetes/contributor-site#803