### PR TITLE
KEP-5732: renamed metric scheduler_generated_placements_total

### DIFF
--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/README.md
@@ -758,8 +758,8 @@ are actively using the feature.
   - `spec.schedulingConstrains` field is not empty.
   - Condition Name: `PodGroupInitiallyScheduled`
 - [X] Metrics
-  - Metric: `scheduler_placement_total`
-  - Value is greater then 0.
+  - Metric: `scheduler_generated_placements_total`
+  - Value is greater than 0.
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
@@ -782,7 +782,7 @@ of the standard scheduling loop.
 
 The beta version of this feature introduces three new metrics to track pod group scheduling behavior:
 
-- `scheduler_placement_total` — counter tracking the total number of candidate placements generated
+- `scheduler_generated_placements_total` — counter tracking the total number of candidate placements generated
   during pod group scheduling.
 - `scheduler_placement_evaluations_total` — counter tracking the total number of evaluated candidate
   placements, partitioned by the result label (`feasible`/`infeasible`).

--- a/keps/sig-scheduling/5732-topology-aware-workload-scheduling/kep.yaml
+++ b/keps/sig-scheduling/5732-topology-aware-workload-scheduling/kep.yaml
@@ -46,6 +46,6 @@ disable-supported: true
 
 # The following PRR answers are required at beta release
 metrics:
-  - scheduler_placement_total
+  - scheduler_generated_placements_total
   - scheduler_placement_evaluations_total
   - scheduler_placement_evaluation_duration_seconds


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description:
Renamed the scheduler_placement_total metric to scheduler_generated_placements_total.
<!-- link to the k/enhancements issue -->
- Issue link:
https://github.com/kubernetes/enhancements/issues/5732
<!-- other comments or additional information -->
- Other comments: