### PR TITLE
KEP-2149, KEP-4322: Allow a cluster to belong to multiple ClusterSets

### DIFF
--- a/keps/sig-multicluster/2149-clusterid/README.md
+++ b/keps/sig-multicluster/2149-clusterid/README.md
@@ -245,6 +245,8 @@ and managed as Kubernetes resources
     the same hostnames
   * Facilitate enrichment of log / event / metrics data with cluster id / set
     coordinates
+* Support expressing that a cluster belongs to multiple ClusterSets
+  simultaneously
 
 ### Non-Goals
 
@@ -257,7 +259,6 @@ and make progress.
 * Solve any problems without specific, tangible use cases (though we will leave
   room for extension).
 * In particular, this KEP explicitly does not consider 
-   * a cluster joining multiple ClusterSets
    * how or whether users should be able to specify aliases for cluster ids and
      what they could be used for
 
@@ -287,10 +288,12 @@ may be referenced by workloads within the cluster. The identifier must be a vali
 [RFC-1123](https://tools.ietf.org/html/rfc1123) DNS subdomain, and should be less
 than 128 characters in total.
 
-While it is a member of a ClusterSet, a cluster must also have an additional
-`clusterset.k8s.io ClusterProperty` which describes its current membership. This
-property must be present as long as the cluster's membership in a
-ClusterSet lasts, and removed when the cluster is no longer a member.
+While it is a member of one or more ClusterSets, a cluster must also have an
+additional `clusterset.k8s.io ClusterProperty` which describes its current
+memberships as a comma-separated list of the names of every ClusterSet the
+cluster belongs to. This property must be present as long as the cluster is a
+member of at least one ClusterSet, and removed when the cluster is no longer a
+member of any ClusterSet.
 
 More detail and examples of the uniqueness, lifespan, immutability, and content
 requirements for both the `cluster.clusterset.k8s.io ClusterProperty` and
@@ -321,8 +324,9 @@ any interesting metadata about it, such as what cloud provider it is hosted on._
 
 #### Joining or moving between ClusterSets
 
-I want the ability to add a previously-isolated cluster to a ClusterSet, or to
-move a cluster from one ClusterSet to another and be aware of this change.
+I want the ability to add a previously-isolated cluster to a ClusterSet, to
+move a cluster from one ClusterSet to another, or to have a cluster belong to
+multiple ClusterSets at the same time, and be aware of these changes.
 
 #### Multi-Cluster Services
 
@@ -398,8 +402,8 @@ Contains a unique identifier for the containing cluster.
 
 ##### Uniqueness
 
-*   The identifier **must** be unique within the ClusterSet to which its cluster
-    belongs for the duration of the cluster’s membership.
+*   The identifier **must** be unique within every ClusterSet to which its
+    cluster belongs for the duration of the cluster’s membership.
 *   The identifier **may** be globally unique beyond the scope of its
     ClusterSet.
 *   The identifier **may** be unique beyond the span of its cluster’s membership
@@ -409,8 +413,8 @@ Contains a unique identifier for the containing cluster.
 ##### Lifespan
 
 *   The identifier **must** exist and not be changed for the duration of a
-    cluster’s membership in a ClusterSet, and as long as a `clusterset.k8s.io`
-    property referring to that cluster in that ClusterSet exists.
+    cluster’s membership in any ClusterSet, and as long as a `clusterset.k8s.io`
+    property referring to that cluster in any of those ClusterSets exists.
 
 
 ##### Contents
@@ -427,7 +431,7 @@ Contains a unique identifier for the containing cluster.
 ##### Consumers
 
 *   **May** rely on the identifier existing, unmodified for the
-    entire duration of its membership in a ClusterSet.
+    entire duration of its membership in each ClusterSet it belongs to.
 *   **Should** watch the `cluster.clusterset.k8s.io` property to handle
     potential changes if they live beyond the ClusterSet membership.
 *   **May** rely on the existence of an identifier for clusters that do not
@@ -450,29 +454,31 @@ the same ClusterSet.
 
 #### Property: `clusterset.k8s.io`
 
-Contains an identifier that relates the containing cluster to the ClusterSet in
-which it belongs.
+Contains one or more identifiers that relate the containing cluster to the
+ClusterSet(s) in which it belongs.
 
 
 ##### Lifespan
 
-*   The identifier **must** exist and be immutable for the duration of a
-    cluster’s membership in a ClusterSet.
-*   The identifier **must not** exist when the cluster is not a member of a
+*   The identifier of each ClusterSet **must** be present in the value for the
+    duration of the cluster’s membership in that ClusterSet, and **must** be
+    removed from the value when that membership ends.
+*   The property **must not** exist when the cluster is not a member of any
     ClusterSet.
 
 
 ##### Contents
 
-*   The identifier **must** associate the cluster with a ClusterSet.
+*   The value **must** be a comma-separated list of the names of every
+    ClusterSet the cluster belongs to.
 
 
 ##### Consumers
 
-*   **May** rely on the identifier existing, unmodified for the
-    entire duration of its membership in a ClusterSet.
+*   **May** rely on a ClusterSet’s entry existing in the value, unmodified, for
+    the entire duration of the cluster’s membership in that ClusterSet.
 *   **Should** watch the clusterset property to detect the span of a cluster’s
-    membership in a ClusterSet.
+    membership in each ClusterSet.
 
 
 ### Additional Properties
@@ -613,10 +619,10 @@ ClusterSet, any dependent tooling explicitly *cannot* assume the
 `cluster.clusterset.k8s.io ClusterProperty` for a given cluster will stay
 constant on its own merit. For example, log aggregation of a given cluster id
 based on this property should only be trusted to be referring to the same
-cluster for as long as it has one ClusterSet membership; similarly, controllers
-whose logic depends on distinguishing clusters by cluster id can only trust this
-property to disambiguate the same cluster for as long as the cluster has one
-ClusterSet membership.
+cluster for as long as it remains a member of at least one ClusterSet;
+similarly, controllers whose logic depends on distinguishing clusters by
+cluster id can only trust this property to disambiguate the same cluster for as
+long as the cluster remains a member of at least one ClusterSet.
 
 Despite this flexibility in the KEP, cluster ids may still be useful before
 ClusterSet membership needs to be established; again, particularly if the
@@ -680,9 +686,9 @@ property.
 
 Because there are obligations of the `cluster.clusterset.k8s.io ClusterProperty`
 that are not meanigfully verifiable until a cluster tries to join a ClusterSet
-and set its `clusterset.k8s.io ClusterProperty`, the admission controller
-responsible for setting a `clusterset.k8s.io ClusterProperty` will need the
-ability to reject such an attempt when it is invalid, and alert `[UNRESOLVED]`
+and add it to its `clusterset.k8s.io ClusterProperty`, the admission controller
+responsible for setting or updating a `clusterset.k8s.io ClusterProperty` will
+need the ability to reject such an attempt when it is invalid, and alert `[UNRESOLVED]`
 or possibly affect changes to that cluster's `cluster.clusterset.k8s.io
 ClusterProperty` to make it valid `[/UNRESOLVED]`. Two symptomatic cases of this
 would be:
@@ -694,9 +700,9 @@ would be:
    ClusterProperty` tries to join a ClusterSet.
 
 In situations like these, the admission controller will need to fail to add the
-invalid cluster to the ClusterSet by refusing to set its `clusterset.k8s.io
-ClusterProperty`, and surface an error that is actionable to make the property
-valid.
+invalid cluster to the ClusterSet by refusing to set or update its
+`clusterset.k8s.io ClusterProperty`, and surface an error that is actionable to
+make the property valid.
 
 ```
 # An example object of `clusterset.k8s.io ClusterProperty`:
@@ -706,7 +712,7 @@ kind: ClusterProperty
 metadata:
   name: clusterset.k8s.io
 spec:
-  value: environ-1
+  value: environ-1,environ-2
 ```
 
 ### CRD upgrade path

--- a/keps/sig-multicluster/4322-cluster-inventory/README.md
+++ b/keps/sig-multicluster/4322-cluster-inventory/README.md
@@ -463,7 +463,8 @@ The ClusterProfile API represents a single member cluster in a cluster inventory
 #### What's the relationship between a cluster inventory and clusterSet?
 A cluster inventory may or may not represent a ClusterSet. A cluster inventory is considered a [clusterSet](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#terminology)
 if all its member clusters adhere to the [namespace sameness](https://github.com/kubernetes/community/blob/master/sig-multicluster/namespace-sameness-position-statement.md) principle.
-Note that a cluster can only be in one ClusterSet while there is not such restriction for a cluster inventory.
+Note that a cluster may belong to multiple ClusterSets at the same time, and likewise there is no restriction on
+the number of cluster inventories a cluster can be part of.
 
 #### How should the API be consumed?
 We recommend that all ClusterProfile objects within the same cluster inventory reside on
@@ -476,16 +477,14 @@ While there are no strict requirements, we recommend making the ClusterProfile A
 This approach allows users to leverage Kubernetes' native namespace-based RBAC if they wish to restrict access to 
 certain clusters within the inventory.
 
-However, if a cluster inventory represents a ClusterSet, all its ClusterProfile objects MUST be part of the same clusterSet
-and namespace must be used as the grouping mechanism. In addition, the namespace must have a label with the key "clusterset.multicluster.x-k8s.io"
-and the value as the name of the clusterSet.
+However, if a cluster inventory represents a ClusterSet, all its ClusterProfile objects MUST be part of that clusterSet.
 
 #### Uniqueness of the ClusterProfile object
 While there are no strict requirements, we recommend that there is only one ClusterProfile object representing any member cluster
 on a hub cluster. 
 
-However, a ClusterProfile object can only be in one ClusterSet since the namespace sameness property is transitive, therefore 
-it can only be in the namespace of that clusterSet if it is in a ClusterSet.
+A ClusterProfile object may be associated with multiple ClusterSets; its memberships are expressed with the
+`clusterset.k8s.io` property.
 
 
 ### Risks and Mitigations
@@ -611,6 +610,19 @@ other implementations. Properties derived from ClusterProperty resources MUST
 preserve the name and value of the ClusterProperty as-is. Cluster managers MAY
 additionally include their own custom-named properties, as long as they do not
 conflict with names derived from ClusterProperty resources.
+
+The `clusterset.k8s.io` property defined by
+[KEP-2149](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/2149-clusterid)
+is the source of truth for ClusterSet membership. When the member cluster
+belongs to multiple ClusterSets, the property value is a comma-separated list
+of all ClusterSet names.
+
+To make ClusterProfiles selectable by ClusterSet with standard label
+selectors, a cluster manager SHOULD also mirror each membership as a label on
+the ClusterProfile, with the key
+`clusterset.multicluster.x-k8s.io/<clusterset-name>` and the value `"true"`.
+Note that the name segment of a label key is limited to 63 characters, which
+constrains the ClusterSet names representable as labels.
 
 #### Conditions
 
@@ -1016,6 +1028,8 @@ metadata:
  name: generated-cluster-name
  labels:
    x-k8s.io/cluster-manager: some-cluster-manager
+   clusterset.multicluster.x-k8s.io/some-clusterset: "true"
+   clusterset.multicluster.x-k8s.io/another-clusterset: "true"
 spec:
   displayName: cluster-us-east
   clusterManager:
@@ -1025,7 +1039,7 @@ status:
     kubernetes: 1.28.0
   properties:
    - name: clusterset.k8s.io
-     value: some-clusterset
+     value: some-clusterset,another-clusterset
    - name: location
      value: apac
   conditions:
@@ -1058,7 +1072,7 @@ status:
     kubernetes: 1.28.0
   properties:
    - name: clusterset.k8s.io
-     value: some-clusterset
+     value: some-clusterset,another-clusterset
    - name: location
      value: us-central1
   accessProviders:
@@ -1646,7 +1660,7 @@ more straightforward with namespaced resources.
 
 ![illustration of global hub for multiple clustersets topology](./global-hub.svg)
 
-In this model, a single global hub cluster is used to manage multiple clustersets (a "Prod" clusterset and "Dev" clusterset in this illustration). For this use case, some means of segmenting the ClusterProfile resources into distinct groups for each clusterset is needed, and ideally should facilitate selecting all ClusterProfiles of a given clusterset. Because of this selection-targeting goal, setting clusterset membership within the `spec` of a ClusterProfile would not be sufficient. While setting a label such as the proposed `clusterset.multicluster.x-k8s.io` on the ClusterProfile resource (instead of a namespace) could be acceptable, managing multiple cluster-scoped ClusterProfile resources for multiple unrelated clustersets on a single global hub could quickly get cluttered. In addition to grouping clarity, namespace scoping could allow RBAC delegation for separate teams to manage resources for their own clustersets in isolation while still using a shared hub. The group of all clusters registered on the hub (potentially including clusters belonging to different clustersets or clusters not belonging to any clusterset) may represent a single "inventory" or multiple inventories, but such a definition is beyond the scope of this document and is permissible to be an undefined implementation detail.
+In this model, a single global hub cluster is used to manage multiple clustersets (a "Prod" clusterset and "Dev" clusterset in this illustration). For this use case, some means of segmenting the ClusterProfile resources into distinct groups for each clusterset is needed, and ideally should facilitate selecting all ClusterProfiles of a given clusterset. Because of this selection-targeting goal, setting clusterset membership within the `spec` of a ClusterProfile would not be sufficient. While setting a clusterset label on the ClusterProfile resource (instead of a namespace) could be acceptable, managing multiple cluster-scoped ClusterProfile resources for multiple unrelated clustersets on a single global hub could quickly get cluttered. In addition to grouping clarity, namespace scoping could allow RBAC delegation for separate teams to manage resources for their own clustersets in isolation while still using a shared hub. The group of all clusters registered on the hub (potentially including clusters belonging to different clustersets or clusters not belonging to any clusterset) may represent a single "inventory" or multiple inventories, but such a definition is beyond the scope of this document and is permissible to be an undefined implementation detail.
 
 #### Global hub cluster per clusterset
 


### PR DESCRIPTION
- One-line PR description: Remove the single-ClusterSet-membership assumption from KEP-2149 and KEP-4322, encoding multiple memberships as a comma-separated `clusterset.k8s.io` value

- Issue link: https://github.com/kubernetes/enhancements/issues/6238

- Other comments:
One commit per KEP:

- KEP-2149: the `clusterset.k8s.io` property value becomes a comma-separated list of every ClusterSet the cluster belongs to; multi-membership moves from Non-Goals to Goals.
- KEP-4322: ClusterSet membership is expressed by the `clusterset.k8s.io` property; the requirement to label the inventory namespace with `clusterset.multicluster.x-k8s.io` is dropped; cluster managers SHOULD mirror each membership as a `clusterset.multicluster.x-k8s.io/<name>: "true"` label so ClusterProfiles stay selectable with standard label selectors.
