### PR TITLE
KEP-6089: Update KEP with the changes during implementation

### DIFF
--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -122,8 +122,9 @@ gaps of the initial alpha.
 ### Goals
 
 - Add a user-facing `spec.scheduling` (`JobSchedulingConfiguration`) field to the `batch/v1` Job,
-  embedding the `scheduling.k8s.io/v1alpha3` building blocks (`policy`, `constraints`,
-  `disruptionMode`, `resourceClaims`) so users can express explicit scheduling intent.
+  embedding the `scheduling.k8s.io/v1alpha3` building blocks (`schedulingPolicy`,
+  `schedulingConstraints`, `disruptionMode`, `resourceClaims`) so users can express explicit
+  scheduling intent.
 - Default to `Basic` scheduling when `spec.scheduling` is omitted, so the observable scheduling 
   outcome of existing Jobs is preserved (no all-or-nothing gate, and any number of schedulable 
   pods proceed to binding). Following the [KEP-6089], the controller still materializes a `Basic`
@@ -132,8 +133,8 @@ gaps of the initial alpha.
 - Let users opt in to `Gang` scheduling, with `minCount` defaulting to `parallelism` when omitted.
 - Compile `spec.scheduling` into `Workload`/`PodGroup` objects via the shared `workloadbuilder`
   library instead of bespoke controller logic.
-- Support mutable `spec.scheduling.policy.gang.minCount` for elastic scaling, while keeping all
-  other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
+- Support mutable `spec.scheduling.schedulingPolicy.gang.minCount` for elastic scaling, while
+  keeping all other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
   `minCount` in `PodGroup`/`PodGroupTemplate` mutable in v1.37 to support workload scaling.
 - When the Job is not the root of the workload tree (the `OwnerReference` refers to a parent
   controller that compiles and owns the `Workload`), defer `Workload` management to that parent,
@@ -211,9 +212,9 @@ spec:
   completions: 4
   completionMode: Indexed
   scheduling:               # New API field - scheduling intent
-    policy:
+    schedulingPolicy:
       gang: {}              # minCount omitted -> defaults to parallelism (4)
-    constraints:
+    schedulingConstraints:
       topology:
         - level: "topology.kubernetes.io/zone"
     disruptionMode:
@@ -252,7 +253,7 @@ spec:
     schedulingPolicy:
       gang:
         minCount: 4         # defaulted from Job.spec.parallelism
-    constraints:
+    schedulingConstraints:
       topology:
         - level: "topology.kubernetes.io/zone"
     disruptionMode:
@@ -274,10 +275,9 @@ metadata:
     name: <workload-name>
     uid: <workload-uid>
 spec:
-  podGroupTemplateRef:
-    workload:
-      workloadName: <workload-name>
-      podGroupTemplateName: <podGroup-template-name>
+  workloadRef:
+    workloadName: <workload-name>
+    templateName: <podGroup-template-name>
   schedulingPolicy:
     gang:
       minCount: 4
@@ -347,10 +347,9 @@ metadata:
     name: <workload-name>
     uid: <workload-uid>
 spec:
-  podGroupTemplateRef:
-    workload:
-      workloadName: <workload-name>
-      podGroupTemplateName: <podGroup-template-name>
+  workloadRef:
+    workloadName: <workload-name>
+    templateName: <podGroup-template-name>
   schedulingPolicy:
     basic: {}
 ```
@@ -376,7 +375,7 @@ spec:
       completions: 4
       completionMode: Indexed
       scheduling:
-        policy:
+        schedulingPolicy:
           gang: {}            # minCount defaults to parallelism (4) per Job
       template:
         spec:
@@ -423,7 +422,7 @@ spec:
 #### ML Training Job with Gang Scheduling
 
 As a machine learning engineer, I want to run a distributed training job with 8 workers that must
-all be scheduled together. I set `spec.scheduling.policy.gang` on the Job (optionally with a
+all be scheduled together. I set `spec.scheduling.schedulingPolicy.gang` on the Job (optionally with a
 topology constraint to co-locate the workers), so that if only 7 workers can be scheduled, no pods
 start and no resources are wasted. I do not have to set `parallelism` and `completions`
 in a specific way to "qualify" for gang scheduling; I declare my intent explicitly.
@@ -431,8 +430,9 @@ in a specific way to "qualify" for gang scheduling; I declare my intent explicit
 #### Backward-Compatible Standard Batch Job
 
 As a data engineer, I want to run a batch processing job that processes files independently without
-gang scheduling requirements. I omit `spec.scheduling` entirely (or set `spec.scheduling.policy.basic`
-explicitly for the same effect), so the Job defaults to `Basic` scheduling. The observable scheduling
+gang scheduling requirements. I omit `spec.scheduling` entirely (or set
+`spec.scheduling.schedulingPolicy.basic` explicitly for the same effect), so the Job defaults to
+`Basic` scheduling. The observable scheduling
 outcome matches a standard Job, while a `Basic` `Workload`/`PodGroup` is still materialized, giving me consistent objects to observe its scheduling state.
 
 ### Notes/Constraints/Caveats
@@ -441,7 +441,7 @@ outcome matches a standard Job, while a `Basic` `Workload`/`PodGroup` is still m
 
 - The alpha targets single-level `Job` workloads: one `Job` maps to one `PodGroup`, and all pods in
   the `Job` share a single scheduling policy. Elastic scaling is supported through the mutable `gang.minCount`.
-- `spec.scheduling.policy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
+- `spec.scheduling.schedulingPolicy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
   other `spec.scheduling` fields are immutable after creation.
 - The Job controller creates `Workload`/`PodGroup` objects for every eligible Job, including  
 `Basic` scheduling, the only way to avoid the objects entirely is to disable the feature gate. 
@@ -469,7 +469,7 @@ the original scheduling outcome even though a `Basic` `Workload`/`PodGroup` is s
   quantifies the impact, and the feature stays behind the `WorkloadWithJob` feature gate for alpha.
 
 - **Behavior change between alphas.** Jobs that were automatically gang-scheduled in v1.36 default
-  to `Basic` in v1.37 unless the user sets `spec.scheduling.policy.gang`. 
+  to `Basic` in v1.37 unless the user sets `spec.scheduling.schedulingPolicy.gang`. 
   * *Mitigation:* gang is now an explicit opt-in; this is documented in the 
   [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy) and release notes.
 
@@ -525,19 +525,24 @@ type JobSpec struct {
 
 // JobSchedulingConfiguration composes the reusable WAS building blocks.
 type JobSchedulingConfiguration struct {
-    // Policy defines the gang or basic scheduling rules for this Job.
+    // SchedulingPolicy defines the gang or basic scheduling rules for this Job.
+    // Exactly one of Basic or Gang must be set. Immutable after creation except
+    // that schedulingPolicy.gang.minCount may be changed.
     // +optional
-    Policy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"policy,omitempty"`
+    SchedulingPolicy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"schedulingPolicy,omitempty"`
 
-    // Constraints defines topology co-location constraints for the Job's pods.
+    // SchedulingConstraints defines topology co-location constraints for the Job's pods.
+    // Immutable after creation.
     // +optional
-    Constraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"constraints,omitempty"`
+    SchedulingConstraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"schedulingConstraints,omitempty"`
 
     // DisruptionMode specifies how the pods in this Job should be disrupted (Single vs All).
+    // Immutable after creation.
     // +optional
     DisruptionMode *schedulingv1alpha3.WorkloadPodGroupDisruptionMode `json:"disruptionMode,omitempty"`
 
     // ResourceClaims specifies dynamic resource claims shared across the Job's pods.
+    // At most 4 claims may be set. Immutable after creation.
     // +optional
     ResourceClaims []schedulingv1alpha3.WorkloadPodGroupResourceClaim `json:"resourceClaims,omitempty"`
 }
@@ -570,20 +575,30 @@ The Job controller compiles `spec.scheduling` into a `Workload` using the `workl
 
 The `scheduling.k8s.io/v1alpha3` building-block types live in the API staging repo
 (`k8s.io/api/scheduling/v1alpha3`). The `workloadbuilder` library lives separately in
-`k8s.io/component-helpers`, so it can be vendored by both in-tree controllers and out-of-tree 
-controllers. The Job controller consumes its `NewBuilder`/`Build`, `WorkloadItem`, and 
-`MapPodGroupConfig`. If the library API shifts before it stabilizes, the Job integration 
-tracks those changes through the shared dependency rather than maintaining its own copy.
+`k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder`, so it can be vendored by both
+in-tree controllers and out-of-tree controllers. The Job controller consumes its `WorkloadItem`
+(populating `Input` with a `WorkloadInput` of the versioned building blocks and their field paths),
+`NewBuilder`, and the `Builder`'s `Validate`, `BuildWorkload`, and `NewPodGroup` methods. For the
+delegated (non-root) `PodGroup` path it uses `NewBuilderFromExistingWorkload` to materialize a
+`PodGroup` from the parent-owned `Workload` without recompiling it. If the library API shifts before
+it stabilizes, the Job integration tracks those changes through the shared dependency rather than
+maintaining its own copy.
 
 #### Building the Logical Tree and Compiling the `Workload`
 
-The controller's `generateWorkload` helper performs four steps: 
-  1. Set the Job's default configuration to `Basic`.
-  2. Map the user-facing `spec.scheduling` block into the library IR via `MapPodGroupConfig`.
-  3. Assemble a single-node WorkloadItem, if needed supplying minCount for gang from spec.parallelism.
-    as the fallback gang size.
-  4. Invoke `Build`, passing the Job's identity and a controller `OwnerReference` so the emitted
-    `Workload` is owned by the Job and garbage-collected with it.
+The controller's `generateWorkload` helper assembles a single-node `WorkloadItem` and drives the
+`Builder`:
+  1. Set the item's `DefaultConfig` to `Basic` (and copy the pod template's `priorityClassName`
+     onto it so the compiled `PodGroupTemplate` inherits the group's priority).
+  2. Record the user-facing `spec.scheduling` block in the item's `Input` as a `WorkloadInput`,
+     pairing each building block (`schedulingPolicy`, `schedulingConstraints`, `disruptionMode`,
+     `resourceClaims`) with its `spec.scheduling` sub-path. A nil block falls back to the default
+     field-by-field.
+  3. Attach a callback that defaults an unset gang `minCount` to `spec.parallelism` (clamped to a
+     minimum of 1). Callbacks mutate only the resolved config, never the Job spec.
+  4. Construct the `Builder` with `NewBuilder(item, BuildOptions{...})`, passing the Job's identity
+     and a controller `OwnerReference` (which becomes `spec.controllerRef`) so the emitted
+     `Workload` is owned by the Job and garbage-collected with it, then call `BuildWorkload`.
 
 
 #### API Validation via the `workloadbuilder` Library
@@ -601,24 +616,30 @@ The controller's `generateWorkload` helper performs four steps:
    `gang.minCount` in the same request is validated against the final state.
    * topology constraints, disruption mode, and resourceClaims are individually well-formed;
    * on update, every `spec.scheduling` field is immutable **except** `gang.minCount`.
-2. **`workloadbuilder` semantic validation** owns the *consistency* rules. The API server calls the
-   library's `Validate` entrypoint, which performs the same configuration resolution and policy
-   validation that `Build` runs and returns aggregated field errors. This
-   guarantees that any configuration the API server accepts is one the controller can compile into a
-   valid `Workload`, rejecting combinations that are structurally legal but semantically invalid
-   (e.g. an unsupported disruption mode, or a policy/constraint pairing the builder cannot translate)
+   The bulk of these structural rules are expressed as declarative validation (DV) markers on the 
+   building-block types, so the api-server runs the generated `Validate_*` validators automatically.
+2. **`workloadbuilder` complex validation** owns the *consistency* rules that DV cannot express. The
+   API server calls the `Builder`'s `Validate(ctx, rootPath, ValidationInput{})` entrypoint, which
+   resolves the config (default merged with the mapped `Input`, callbacks applied) and then checks
+   the controller's opt-in allow-lists (`AllowedPolicies`, `AllowedDisruptionModes`) plus cross-field
+   rules such as rejecting the `all` disruption mode with the `Basic` policy. Errors are reported at
+   the `spec.scheduling` sub-path recorded in each block's `PathElements`. Because in-tree Job
+   validation already runs DV at the api-server, it sets `BuildOptions.DisableDeclarativeValidation`
+   so `Validate` performs only the complex checks (and needs no owner). This guarantees any
+   configuration the API server accepts is one the controller can compile into a valid `Workload`,
    uniformly across all integrating controllers. Because resolution reads only the incoming object
    and never cluster state, it is safe to call from the registry layer; it complements, and does not
-   replace, the structural and immutability checks in the api-server validation.
+   replace, the structural and immutability checks above.
 
 #### Instantiating the runtime `PodGroup`
 
-`Build` returns only the `Workload` (the scheduling template); it does not create the runtime
-`PodGroup`. After the `Workload` exists on the API server, the Job controller instantiates the
-`PodGroup` from the `Workload`'s single `PodGroupTemplate`. For a Job there is exactly one template,
-so the controller creates one `PodGroup` that references the template and carries two
-ownerReferences — a controller ref to the `Job` (so it is GC'd with the Job) and a non-controller
-ref to the `Workload`:
+`BuildWorkload` returns only the `Workload` (the scheduling template); it does not create the
+runtime `PodGroup`. After the `Workload` exists on the API server, the Job controller calls the
+`Builder`'s `NewPodGroup(name, templateName)` to instantiate the `PodGroup` from the `Workload`'s
+single `PodGroupTemplate`. For a Job there is exactly one template, so the controller creates one
+`PodGroup` whose `spec.workloadRef` references the `Workload` and template by name
+(`workloadName`/`templateName`) and that carries two ownerReferences — a controller ref to the `Job`
+(so it is GC'd with the Job) and a non-controller ref to the `Workload`:
 
 
 Pods are then created by the existing Job pod-management logic with
@@ -632,12 +653,12 @@ keys on for gang/topology behavior.
   designed to be idempotent and crash-safe:
 
 - **Discovery first:** the controller looks up an existing `Workload`/`PodGroup` (via
-  `spec.controllerRef` / `spec.podGroupTemplateRef`) before compiling, so a restart between
+  `spec.controllerRef` / `spec.workloadRef`) before compiling, so a restart between
   creating the `Workload` and the `PodGroup` does not produce duplicates.
 - **Ordering:** `Workload` is created (or found) before the `PodGroup`, and both before pods, so
   references always resolve.
-- **Errors are retryable:** a validation error returned by `Build` is terminal for that spec and is
-  surfaced as a Job condition/event (the user must fix `spec.scheduling`); an API error creating the
+- **Errors are retryable:** a compile error returned by `BuildWorkload` is terminal for that spec and
+  is surfaced as a Job condition/event (the user must fix `spec.scheduling`); an API error creating the
   `Workload`/`PodGroup` requeues the Job with backoff and blocks pod creation until it succeeds.
 - **Updates:** on a `gang.minCount` (or `parallelism`-driven) change the controller re-runs
   `generateWorkload` to produce a fresh `Workload` spec and applies it to the existing object, then
@@ -655,7 +676,7 @@ garbage-collects them when the `Job` is deleted.
 
 #### Workload and PodGroup Discovery
 
-Discovery of those objects is based on references (`workload.spec.controllerRef` and `podGroup.spec.podGroupTemplateRef`), not on ownership. 
+Discovery of those objects is based on references (`workload.spec.controllerRef` and `podGroup.spec.workloadRef`), not on ownership. 
 `ownerReference` is used only for controller-created objects so that they are garbage-collected when the Job is 
 deleted. Workloads which are created by user or higher-level controller may not be given ownerReferences to the Job, so they are not deleted when the Job is deleted.
 
@@ -665,7 +686,7 @@ A `Workload` is considered the Workload for this Job object if:
 
 Similarly, a `PodGroup` is considered the `PodGroup` for this Job if:
 - The `PodGroup` is in the Job’s namespace
-- Its `spec.podGroupTemplateRef.workload.workloadName` equals the name of the `Workload` for this Job. 
+- Its `spec.workloadRef.workloadName` equals the name of the `Workload` for this Job. 
 
 #### Controller Workflow
 
@@ -681,7 +702,7 @@ The controller discovers or creates `Workload` and `PodGroup` as follows:
 1. If the Job carries an `OwnerReference` to a parent controller that owns the `Workload` 
 (i.e., `JobSet`), the Job controller does not create a `Workload` (skip step 3 and step 4). 
 It then branches on whether the parent delegates `PodGroup` management, detected via the 
-`scheduling.k8s.io/podgroup-template` annotation on the Job:
+`scheduling.k8s.io/group-template-name` annotation on the Job:
    - **Annotation present (PodGroup delegated):** the parent owns the `Workload` but expects the Job
      to manage its own runtime `PodGroup`. Proceed to step 5, creating the `PodGroup` linked to the
      parent-owned `Workload` via the parent's named `PodGroupTemplate` (the annotation value) and when
@@ -703,7 +724,7 @@ It then branches on whether the parent delegates `PodGroup` management, detected
    `spec.scheduling` rather than from the Job's type. It maps `spec.scheduling` into the
    `workloadbuilder` library, which applies the defaulting rules (defaulting to `Basic`, defaulting
    `Gang.minCount` to `parallelism`) and compiles the `Workload`. This happens for every eligible Job, including those that default to `Basic`.
-5. Look up `PodGroup`(s) in the Job's namespace whose `podGroup.spec.podGroupTemplateRef` is
+5. Look up `PodGroup`(s) in the Job's namespace whose `podGroup.spec.workloadRef` is
    associated with the target `PodGroupTemplate` for this Job. For a root Job that template lives in
    the Job-owned `Workload` while a delegated non-root Job (step 1, annotation present) it is the
    parent's `PodGroupTemplate`.
@@ -747,14 +768,14 @@ flowchart BT
     PodGroup -->|ownerRef <br/> (root Job only)| Workload
     Workload -->|ownerRef| Job
 
-    PodGroup -.->|via <br/> podGroupTemplateRef| Workload
+    PodGroup -.->|via <br/> workloadRef| Workload
 
     linkStyle 5 stroke:#888,color:#888
 ```
 
 - The `Workload` object has an ownerReference to the `Job` object with `controller: true` in case 
   it was created by the Job controller.
-- The `PodGroup` object links to a `Workload` via `spec.podGroupTemplateRef`. When created 
+- The `PodGroup` object links to a `Workload` via `spec.workloadRef`. When created 
 by the Job controller it carries a controller ownerReference to the `Job`. A parent-owned 
 `Workload` is never given an ownerReference from the `PodGroup`.
 - The `Pod` object has an ownerReference to the `Job` object with `controller: true` and another 
@@ -770,15 +791,15 @@ This is a controller-side resolution that is required to resolve the unset case 
 
 - **`Scheduling` unset → `Basic`.** Existing and non-WAS Jobs carry no `spec.scheduling`, the
   controller resolves the absent policy to `Basic`, preserving their behavior.
-- **`Scheduling` set but `Policy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
+- **`Scheduling` set but `SchedulingPolicy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
   discriminated union for which the compiled `PodGroup` must carry exactly one concrete policy, so a
-  nil `Policy` is resolved to `Basic`.
+  nil `SchedulingPolicy` is resolved to `Basic`.
 - **`Gang` with `MinCount` unset → `MinCount = parallelism`.** Done controller-side only 
 without persisting the derived value back onto the Job spec because writing it back would make a 
 user-set `minCount` indistinguishable from the default on later updates, where `minCount` is mutable.
 
-Optional modifiers (`DisruptionMode`, `Constraints`, `ResourceClaims`) are deliberately not
-defaulted. Unlike `Policy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `Constraints`
+Optional modifiers (`DisruptionMode`, `SchedulingConstraints`, `ResourceClaims`) are deliberately not
+defaulted. Unlike `SchedulingPolicy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `SchedulingConstraints`
 means no topology co-location, and a nil `ResourceClaims` means no shared claims.
 
 #### Object Creation Order
@@ -793,7 +814,7 @@ The kube-scheduler waits for `PodGroup` when Pods have `schedulingGroup`, so sch
 #### Handling Updates and Mutability
 
 To support dynamic scaling of gang-scheduled workloads (Elastic Jobs), the Job API allows in-flight
-updates to `spec.scheduling.policy.gang.minCount`; all other `spec.scheduling` fields are immutable
+updates to `spec.scheduling.schedulingPolicy.gang.minCount`; all other `spec.scheduling` fields are immutable
 after Job creation, and updates that change them are rejected by API validation. This replaces the
 v1.36 validation that rejected `spec.parallelism` updates for gang Jobs: because the gang size is
 now driven by the mutable `minCount` ([KEP-4671]), `spec.parallelism` is no longer frozen for gang
@@ -804,7 +825,7 @@ consistent with what the controller actually compiles. The update-validation rul
 
   * `spec.parallelism` becomes *mutable* again: the v1.36 rule that rejected `spec.parallelism`
   updates for gang Jobs is removed, restoring Elastic Indexed Jobs.
-  * `spec.scheduling.policy.gang.minCount` is *mutable* in-flight: on change the controller
+  * `spec.scheduling.schedulingPolicy.gang.minCount` is *mutable* in-flight: on change the controller
   recompiles the `Workload` and re-syncs the `PodGroup` size.
   * All other `spec.scheduling` fields remain *immutable* after creation, enforced by api-server
   validation, since changing the policy, topology, disruption mode, or resourceClaims would require
@@ -817,7 +838,7 @@ scale the gang without ever touching `spec.scheduling`.
 
 A user can change the target gang size in one of two ways:
 
-- by setting `spec.scheduling.policy.gang.minCount` directly, when it is set explicitly
+- by setting `spec.scheduling.schedulingPolicy.gang.minCount` directly, when it is set explicitly
 - by setting `spec.parallelism`, when `minCount` is unset.
 
 In either case, the Job controller reconciles the change as follows:
@@ -845,7 +866,11 @@ higher-level controller:
 
 - **BYO `Workload`:** the user pre-creates a `Workload` whose `spec.controllerRef` points to 
 the `Job` and still expects the `Job` controller to create the runtime `PodGroup`(s) from 
-that `Workload` template.
+that `Workload` template. When the pre-created `Workload` carries a single `PodGroupTemplate`,
+the controller binds it automatically. When it carries multiple templates, the `Job` must
+name the one to bind via the `scheduling.k8s.io/group-template-name` annotation (the same signal
+used to delegate a `PodGroup` to a parent-owned `Workload`); without it the controller cannot
+disambiguate and falls back to default scheduling.
 - **BYO `PodGroup`:** the user manages the `PodGroup` themselves and wires pods to it by setting
   `pod.spec.schedulingGroup.podGroupName` directly via the `PodTemplate`. Here the controller does
   not create or own the `PodGroup` at all.
@@ -859,8 +884,9 @@ How the new `spec.scheduling` fields interact with BYO objects:
 - When an authoritative BYO `Workload`/`PodGroup` is present for the `Job`, the controller uses it 
 as-is and does not translate `spec.scheduling` into it or reconcile the two. This avoids a split-brain where the controller would fight the object's owner or over reconcile the two.
 - `minCount` is not synced into a BYO `PodGroup` [KEP-4671].
-- If a discovered `Workload` has an unsupported shape for alpha, the controller ignores it and 
-surfaces a condition or event.
+- If a discovered `Workload` has an unsupported shape for alpha (e.g. multiple templates without
+a `scheduling.k8s.io/group-template-name` annotation naming one, or a named template that does not
+exist), the controller ignores it and surfaces a condition or event.
 
 ### Naming Conventions
 
@@ -913,10 +939,11 @@ to implement this enhancement.
   without the api-server writing these values back into the Job's `spec.scheduling`.
   - `workloadbuilder` compilation: `Basic` vs `Gang` policy, and that topology constraints,
     disruption mode (single/all), and resourceClaims are mapped into the generated `Workload`/
-    `PodGroup`; that a `Job` builds a flat single-node tree via `MapPodGroupConfig`.
+    `PodGroup`; that a `Job` builds a flat single-node `WorkloadItem` tree whose `Input` carries the
+    mapped `spec.scheduling` building blocks.
   - A `Basic` `Workload`/`PodGroup` is created for a Job with `spec.scheduling` omitted.
   - pod creation includes the correct `schedulingGroup`.
-  - Mutability/validation: updates to `spec.scheduling.policy.gang.minCount` are allowed; updates to
+  - Mutability/validation: updates to `spec.scheduling.schedulingPolicy.gang.minCount` are allowed; updates to
     any other `spec.scheduling` field are rejected.
   - `gang.minCount > spec.parallelism` is rejected on both create and update. A single 
   request that raises `spec.parallelism` and `gang.minCount` together is accepted.
@@ -941,7 +968,7 @@ We will add the following integration tests to the Job controller (`test/integra
 - Lifecycle test for both `Basic` and `Gang` Jobs (create, update, delete Job; verify `Workload`
   and `PodGroup` are materialized, pods have `schedulingGroup`, and Job deletion cascades to
   `Workload`/`PodGroup` deletion).
-- Elastic scaling: updating `spec.scheduling.policy.gang.minCount` (or `spec.parallelism` when
+- Elastic scaling: updating `spec.scheduling.schedulingPolicy.gang.minCount` (or `spec.parallelism` when
   `minCount` is unset) updates the `Workload` and the runtime `PodGroup`.
 - Passthrough: topology constraints, disruption mode, and resourceClaims declared in
   `spec.scheduling` appear in the compiled `Workload`/`PodGroup`.
@@ -953,7 +980,7 @@ We will add the following integration tests to the Job controller (`test/integra
   mapped to the parent's `PodGroupTemplate` when the annotation is present.
 - The controller discovers and uses a pre-created `Workload`/`PodGroup`,
   does not take ownership, and does not mutate it on Job spec changes — in particular, updating
-  `spec.scheduling.policy.gang.minCount` leaves a BYO `PodGroup`'s `minCount` untouched, and 
+  `spec.scheduling.schedulingPolicy.gang.minCount` leaves a BYO `PodGroup`'s `minCount` untouched, and 
   the BYO object is not GC'd when the Job is deleted.
 - Jobs created by CronJob get one `Workload` and one `PodGroup` per Job, and these are GC'd when the
   Job completes or is deleted.
@@ -1048,7 +1075,7 @@ N/A for alpha release
 
 - **Behavior change between alphas:** in v1.36, indexed fully-parallel Jobs were automatically
   gang-scheduled; in v1.37 those same Jobs default to `Basic` unless the user sets
-  `spec.scheduling.policy.gang`. Gang scheduling is now an explicit opt-in. Operators upgrading
+  `spec.scheduling.schedulingPolicy.gang`. Gang scheduling is now an explicit opt-in. Operators upgrading
   between alphas should be aware that previously auto-gang'd Jobs will schedule pod-by-pod unless
   updated.
 
@@ -1292,6 +1319,9 @@ No. This feature is purely control-plane and does not affect node resources.
   selection with the explicit user-facing `spec.scheduling` API from [KEP-6089], adopting the
   shared `workloadbuilder` library, Universal Representation, and mutable `gang.minCount` for
   elastic scaling.
+- 2026-07-14: Synced the KEP with the implementation of the Job scheduling fields, the
+  `workloadbuilder` integration and `workloadbuilder` API (`Validate` with a
+  `ValidationInput` and the `NewBuilderFromExistingWorkload` constructor).
 
 ## Drawbacks
 

--- a/keps/sig-apps/5547-integrate-workload-with-job/README.md
+++ b/keps/sig-apps/5547-integrate-workload-with-job/README.md
@@ -122,9 +122,8 @@ gaps of the initial alpha.
 ### Goals
 
 - Add a user-facing `spec.scheduling` (`JobSchedulingConfiguration`) field to the `batch/v1` Job,
-  embedding the `scheduling.k8s.io/v1alpha3` building blocks (`schedulingPolicy`,
-  `schedulingConstraints`, `disruptionMode`, `resourceClaims`) so users can express explicit
-  scheduling intent.
+  embedding the `scheduling.k8s.io/v1alpha3` building blocks (`policy`, `constraints`,
+  `disruptionMode`, `resourceClaims`) so users can express explicit scheduling intent.
 - Default to `Basic` scheduling when `spec.scheduling` is omitted, so the observable scheduling 
   outcome of existing Jobs is preserved (no all-or-nothing gate, and any number of schedulable 
   pods proceed to binding). Following the [KEP-6089], the controller still materializes a `Basic`
@@ -133,8 +132,8 @@ gaps of the initial alpha.
 - Let users opt in to `Gang` scheduling, with `minCount` defaulting to `parallelism` when omitted.
 - Compile `spec.scheduling` into `Workload`/`PodGroup` objects via the shared `workloadbuilder`
   library instead of bespoke controller logic.
-- Support mutable `spec.scheduling.schedulingPolicy.gang.minCount` for elastic scaling, while
-  keeping all other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
+- Support mutable `spec.scheduling.policy.gang.minCount` for elastic scaling, while keeping all
+  other `spec.scheduling` fields immutable after creation. This relies on [KEP-4671] that makes 
   `minCount` in `PodGroup`/`PodGroupTemplate` mutable in v1.37 to support workload scaling.
 - When the Job is not the root of the workload tree (the `OwnerReference` refers to a parent
   controller that compiles and owns the `Workload`), defer `Workload` management to that parent,
@@ -212,9 +211,9 @@ spec:
   completions: 4
   completionMode: Indexed
   scheduling:               # New API field - scheduling intent
-    schedulingPolicy:
+    policy:
       gang: {}              # minCount omitted -> defaults to parallelism (4)
-    schedulingConstraints:
+    constraints:
       topology:
         - level: "topology.kubernetes.io/zone"
     disruptionMode:
@@ -253,7 +252,7 @@ spec:
     schedulingPolicy:
       gang:
         minCount: 4         # defaulted from Job.spec.parallelism
-    schedulingConstraints:
+    constraints:
       topology:
         - level: "topology.kubernetes.io/zone"
     disruptionMode:
@@ -275,9 +274,10 @@ metadata:
     name: <workload-name>
     uid: <workload-uid>
 spec:
-  workloadRef:
-    workloadName: <workload-name>
-    templateName: <podGroup-template-name>
+  podGroupTemplateRef:
+    workload:
+      workloadName: <workload-name>
+      podGroupTemplateName: <podGroup-template-name>
   schedulingPolicy:
     gang:
       minCount: 4
@@ -347,9 +347,10 @@ metadata:
     name: <workload-name>
     uid: <workload-uid>
 spec:
-  workloadRef:
-    workloadName: <workload-name>
-    templateName: <podGroup-template-name>
+  podGroupTemplateRef:
+    workload:
+      workloadName: <workload-name>
+      podGroupTemplateName: <podGroup-template-name>
   schedulingPolicy:
     basic: {}
 ```
@@ -375,7 +376,7 @@ spec:
       completions: 4
       completionMode: Indexed
       scheduling:
-        schedulingPolicy:
+        policy:
           gang: {}            # minCount defaults to parallelism (4) per Job
       template:
         spec:
@@ -422,7 +423,7 @@ spec:
 #### ML Training Job with Gang Scheduling
 
 As a machine learning engineer, I want to run a distributed training job with 8 workers that must
-all be scheduled together. I set `spec.scheduling.schedulingPolicy.gang` on the Job (optionally with a
+all be scheduled together. I set `spec.scheduling.policy.gang` on the Job (optionally with a
 topology constraint to co-locate the workers), so that if only 7 workers can be scheduled, no pods
 start and no resources are wasted. I do not have to set `parallelism` and `completions`
 in a specific way to "qualify" for gang scheduling; I declare my intent explicitly.
@@ -430,9 +431,8 @@ in a specific way to "qualify" for gang scheduling; I declare my intent explicit
 #### Backward-Compatible Standard Batch Job
 
 As a data engineer, I want to run a batch processing job that processes files independently without
-gang scheduling requirements. I omit `spec.scheduling` entirely (or set
-`spec.scheduling.schedulingPolicy.basic` explicitly for the same effect), so the Job defaults to
-`Basic` scheduling. The observable scheduling
+gang scheduling requirements. I omit `spec.scheduling` entirely (or set `spec.scheduling.policy.basic`
+explicitly for the same effect), so the Job defaults to `Basic` scheduling. The observable scheduling
 outcome matches a standard Job, while a `Basic` `Workload`/`PodGroup` is still materialized, giving me consistent objects to observe its scheduling state.
 
 ### Notes/Constraints/Caveats
@@ -441,7 +441,7 @@ outcome matches a standard Job, while a `Basic` `Workload`/`PodGroup` is still m
 
 - The alpha targets single-level `Job` workloads: one `Job` maps to one `PodGroup`, and all pods in
   the `Job` share a single scheduling policy. Elastic scaling is supported through the mutable `gang.minCount`.
-- `spec.scheduling.schedulingPolicy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
+- `spec.scheduling.policy.gang.minCount` is mutable to support elastic scaling ([KEP-4671]); all 
   other `spec.scheduling` fields are immutable after creation.
 - The Job controller creates `Workload`/`PodGroup` objects for every eligible Job, including  
 `Basic` scheduling, the only way to avoid the objects entirely is to disable the feature gate. 
@@ -469,7 +469,7 @@ the original scheduling outcome even though a `Basic` `Workload`/`PodGroup` is s
   quantifies the impact, and the feature stays behind the `WorkloadWithJob` feature gate for alpha.
 
 - **Behavior change between alphas.** Jobs that were automatically gang-scheduled in v1.36 default
-  to `Basic` in v1.37 unless the user sets `spec.scheduling.schedulingPolicy.gang`. 
+  to `Basic` in v1.37 unless the user sets `spec.scheduling.policy.gang`. 
   * *Mitigation:* gang is now an explicit opt-in; this is documented in the 
   [Upgrade / Downgrade Strategy](#upgrade--downgrade-strategy) and release notes.
 
@@ -525,24 +525,19 @@ type JobSpec struct {
 
 // JobSchedulingConfiguration composes the reusable WAS building blocks.
 type JobSchedulingConfiguration struct {
-    // SchedulingPolicy defines the gang or basic scheduling rules for this Job.
-    // Exactly one of Basic or Gang must be set. Immutable after creation except
-    // that schedulingPolicy.gang.minCount may be changed.
+    // Policy defines the gang or basic scheduling rules for this Job.
     // +optional
-    SchedulingPolicy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"schedulingPolicy,omitempty"`
+    Policy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"policy,omitempty"`
 
-    // SchedulingConstraints defines topology co-location constraints for the Job's pods.
-    // Immutable after creation.
+    // Constraints defines topology co-location constraints for the Job's pods.
     // +optional
-    SchedulingConstraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"schedulingConstraints,omitempty"`
+    Constraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"constraints,omitempty"`
 
     // DisruptionMode specifies how the pods in this Job should be disrupted (Single vs All).
-    // Immutable after creation.
     // +optional
     DisruptionMode *schedulingv1alpha3.WorkloadPodGroupDisruptionMode `json:"disruptionMode,omitempty"`
 
     // ResourceClaims specifies dynamic resource claims shared across the Job's pods.
-    // At most 4 claims may be set. Immutable after creation.
     // +optional
     ResourceClaims []schedulingv1alpha3.WorkloadPodGroupResourceClaim `json:"resourceClaims,omitempty"`
 }
@@ -575,30 +570,20 @@ The Job controller compiles `spec.scheduling` into a `Workload` using the `workl
 
 The `scheduling.k8s.io/v1alpha3` building-block types live in the API staging repo
 (`k8s.io/api/scheduling/v1alpha3`). The `workloadbuilder` library lives separately in
-`k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder`, so it can be vendored by both
-in-tree controllers and out-of-tree controllers. The Job controller consumes its `WorkloadItem`
-(populating `Input` with a `WorkloadInput` of the versioned building blocks and their field paths),
-`NewBuilder`, and the `Builder`'s `Validate`, `BuildWorkload`, and `NewPodGroup` methods. For the
-delegated (non-root) `PodGroup` path it uses `NewBuilderFromExistingWorkload` to materialize a
-`PodGroup` from the parent-owned `Workload` without recompiling it. If the library API shifts before
-it stabilizes, the Job integration tracks those changes through the shared dependency rather than
-maintaining its own copy.
+`k8s.io/component-helpers`, so it can be vendored by both in-tree controllers and out-of-tree 
+controllers. The Job controller consumes its `NewBuilder`/`Build`, `WorkloadItem`, and 
+`MapPodGroupConfig`. If the library API shifts before it stabilizes, the Job integration 
+tracks those changes through the shared dependency rather than maintaining its own copy.
 
 #### Building the Logical Tree and Compiling the `Workload`
 
-The controller's `generateWorkload` helper assembles a single-node `WorkloadItem` and drives the
-`Builder`:
-  1. Set the item's `DefaultConfig` to `Basic` (and copy the pod template's `priorityClassName`
-     onto it so the compiled `PodGroupTemplate` inherits the group's priority).
-  2. Record the user-facing `spec.scheduling` block in the item's `Input` as a `WorkloadInput`,
-     pairing each building block (`schedulingPolicy`, `schedulingConstraints`, `disruptionMode`,
-     `resourceClaims`) with its `spec.scheduling` sub-path. A nil block falls back to the default
-     field-by-field.
-  3. Attach a callback that defaults an unset gang `minCount` to `spec.parallelism` (clamped to a
-     minimum of 1). Callbacks mutate only the resolved config, never the Job spec.
-  4. Construct the `Builder` with `NewBuilder(item, BuildOptions{...})`, passing the Job's identity
-     and a controller `OwnerReference` (which becomes `spec.controllerRef`) so the emitted
-     `Workload` is owned by the Job and garbage-collected with it, then call `BuildWorkload`.
+The controller's `generateWorkload` helper performs four steps: 
+  1. Set the Job's default configuration to `Basic`.
+  2. Map the user-facing `spec.scheduling` block into the library IR via `MapPodGroupConfig`.
+  3. Assemble a single-node WorkloadItem, if needed supplying minCount for gang from spec.parallelism.
+    as the fallback gang size.
+  4. Invoke `Build`, passing the Job's identity and a controller `OwnerReference` so the emitted
+    `Workload` is owned by the Job and garbage-collected with it.
 
 
 #### API Validation via the `workloadbuilder` Library
@@ -616,30 +601,24 @@ The controller's `generateWorkload` helper assembles a single-node `WorkloadItem
    `gang.minCount` in the same request is validated against the final state.
    * topology constraints, disruption mode, and resourceClaims are individually well-formed;
    * on update, every `spec.scheduling` field is immutable **except** `gang.minCount`.
-   The bulk of these structural rules are expressed as declarative validation (DV) markers on the 
-   building-block types, so the api-server runs the generated `Validate_*` validators automatically.
-2. **`workloadbuilder` complex validation** owns the *consistency* rules that DV cannot express. The
-   API server calls the `Builder`'s `Validate(ctx, rootPath, ValidationInput{})` entrypoint, which
-   resolves the config (default merged with the mapped `Input`, callbacks applied) and then checks
-   the controller's opt-in allow-lists (`AllowedPolicies`, `AllowedDisruptionModes`) plus cross-field
-   rules such as rejecting the `all` disruption mode with the `Basic` policy. Errors are reported at
-   the `spec.scheduling` sub-path recorded in each block's `PathElements`. Because in-tree Job
-   validation already runs DV at the api-server, it sets `BuildOptions.DisableDeclarativeValidation`
-   so `Validate` performs only the complex checks (and needs no owner). This guarantees any
-   configuration the API server accepts is one the controller can compile into a valid `Workload`,
+2. **`workloadbuilder` semantic validation** owns the *consistency* rules. The API server calls the
+   library's `Validate` entrypoint, which performs the same configuration resolution and policy
+   validation that `Build` runs and returns aggregated field errors. This
+   guarantees that any configuration the API server accepts is one the controller can compile into a
+   valid `Workload`, rejecting combinations that are structurally legal but semantically invalid
+   (e.g. an unsupported disruption mode, or a policy/constraint pairing the builder cannot translate)
    uniformly across all integrating controllers. Because resolution reads only the incoming object
    and never cluster state, it is safe to call from the registry layer; it complements, and does not
-   replace, the structural and immutability checks above.
+   replace, the structural and immutability checks in the api-server validation.
 
 #### Instantiating the runtime `PodGroup`
 
-`BuildWorkload` returns only the `Workload` (the scheduling template); it does not create the
-runtime `PodGroup`. After the `Workload` exists on the API server, the Job controller calls the
-`Builder`'s `NewPodGroup(name, templateName)` to instantiate the `PodGroup` from the `Workload`'s
-single `PodGroupTemplate`. For a Job there is exactly one template, so the controller creates one
-`PodGroup` whose `spec.workloadRef` references the `Workload` and template by name
-(`workloadName`/`templateName`) and that carries two ownerReferences — a controller ref to the `Job`
-(so it is GC'd with the Job) and a non-controller ref to the `Workload`:
+`Build` returns only the `Workload` (the scheduling template); it does not create the runtime
+`PodGroup`. After the `Workload` exists on the API server, the Job controller instantiates the
+`PodGroup` from the `Workload`'s single `PodGroupTemplate`. For a Job there is exactly one template,
+so the controller creates one `PodGroup` that references the template and carries two
+ownerReferences — a controller ref to the `Job` (so it is GC'd with the Job) and a non-controller
+ref to the `Workload`:
 
 
 Pods are then created by the existing Job pod-management logic with
@@ -653,12 +632,12 @@ keys on for gang/topology behavior.
   designed to be idempotent and crash-safe:
 
 - **Discovery first:** the controller looks up an existing `Workload`/`PodGroup` (via
-  `spec.controllerRef` / `spec.workloadRef`) before compiling, so a restart between
+  `spec.controllerRef` / `spec.podGroupTemplateRef`) before compiling, so a restart between
   creating the `Workload` and the `PodGroup` does not produce duplicates.
 - **Ordering:** `Workload` is created (or found) before the `PodGroup`, and both before pods, so
   references always resolve.
-- **Errors are retryable:** a compile error returned by `BuildWorkload` is terminal for that spec and
-  is surfaced as a Job condition/event (the user must fix `spec.scheduling`); an API error creating the
+- **Errors are retryable:** a validation error returned by `Build` is terminal for that spec and is
+  surfaced as a Job condition/event (the user must fix `spec.scheduling`); an API error creating the
   `Workload`/`PodGroup` requeues the Job with backoff and blocks pod creation until it succeeds.
 - **Updates:** on a `gang.minCount` (or `parallelism`-driven) change the controller re-runs
   `generateWorkload` to produce a fresh `Workload` spec and applies it to the existing object, then
@@ -676,7 +655,7 @@ garbage-collects them when the `Job` is deleted.
 
 #### Workload and PodGroup Discovery
 
-Discovery of those objects is based on references (`workload.spec.controllerRef` and `podGroup.spec.workloadRef`), not on ownership. 
+Discovery of those objects is based on references (`workload.spec.controllerRef` and `podGroup.spec.podGroupTemplateRef`), not on ownership. 
 `ownerReference` is used only for controller-created objects so that they are garbage-collected when the Job is 
 deleted. Workloads which are created by user or higher-level controller may not be given ownerReferences to the Job, so they are not deleted when the Job is deleted.
 
@@ -686,7 +665,7 @@ A `Workload` is considered the Workload for this Job object if:
 
 Similarly, a `PodGroup` is considered the `PodGroup` for this Job if:
 - The `PodGroup` is in the Job’s namespace
-- Its `spec.workloadRef.workloadName` equals the name of the `Workload` for this Job. 
+- Its `spec.podGroupTemplateRef.workload.workloadName` equals the name of the `Workload` for this Job. 
 
 #### Controller Workflow
 
@@ -702,7 +681,7 @@ The controller discovers or creates `Workload` and `PodGroup` as follows:
 1. If the Job carries an `OwnerReference` to a parent controller that owns the `Workload` 
 (i.e., `JobSet`), the Job controller does not create a `Workload` (skip step 3 and step 4). 
 It then branches on whether the parent delegates `PodGroup` management, detected via the 
-`scheduling.k8s.io/group-template-name` annotation on the Job:
+`scheduling.k8s.io/podgroup-template` annotation on the Job:
    - **Annotation present (PodGroup delegated):** the parent owns the `Workload` but expects the Job
      to manage its own runtime `PodGroup`. Proceed to step 5, creating the `PodGroup` linked to the
      parent-owned `Workload` via the parent's named `PodGroupTemplate` (the annotation value) and when
@@ -724,7 +703,7 @@ It then branches on whether the parent delegates `PodGroup` management, detected
    `spec.scheduling` rather than from the Job's type. It maps `spec.scheduling` into the
    `workloadbuilder` library, which applies the defaulting rules (defaulting to `Basic`, defaulting
    `Gang.minCount` to `parallelism`) and compiles the `Workload`. This happens for every eligible Job, including those that default to `Basic`.
-5. Look up `PodGroup`(s) in the Job's namespace whose `podGroup.spec.workloadRef` is
+5. Look up `PodGroup`(s) in the Job's namespace whose `podGroup.spec.podGroupTemplateRef` is
    associated with the target `PodGroupTemplate` for this Job. For a root Job that template lives in
    the Job-owned `Workload` while a delegated non-root Job (step 1, annotation present) it is the
    parent's `PodGroupTemplate`.
@@ -768,14 +747,14 @@ flowchart BT
     PodGroup -->|ownerRef <br/> (root Job only)| Workload
     Workload -->|ownerRef| Job
 
-    PodGroup -.->|via <br/> workloadRef| Workload
+    PodGroup -.->|via <br/> podGroupTemplateRef| Workload
 
     linkStyle 5 stroke:#888,color:#888
 ```
 
 - The `Workload` object has an ownerReference to the `Job` object with `controller: true` in case 
   it was created by the Job controller.
-- The `PodGroup` object links to a `Workload` via `spec.workloadRef`. When created 
+- The `PodGroup` object links to a `Workload` via `spec.podGroupTemplateRef`. When created 
 by the Job controller it carries a controller ownerReference to the `Job`. A parent-owned 
 `Workload` is never given an ownerReference from the `PodGroup`.
 - The `Pod` object has an ownerReference to the `Job` object with `controller: true` and another 
@@ -791,15 +770,15 @@ This is a controller-side resolution that is required to resolve the unset case 
 
 - **`Scheduling` unset → `Basic`.** Existing and non-WAS Jobs carry no `spec.scheduling`, the
   controller resolves the absent policy to `Basic`, preserving their behavior.
-- **`Scheduling` set but `SchedulingPolicy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
+- **`Scheduling` set but `Policy` nil → `Basic`.** `WorkloadPodGroupSchedulingPolicy` is a 
   discriminated union for which the compiled `PodGroup` must carry exactly one concrete policy, so a
-  nil `SchedulingPolicy` is resolved to `Basic`.
+  nil `Policy` is resolved to `Basic`.
 - **`Gang` with `MinCount` unset → `MinCount = parallelism`.** Done controller-side only 
 without persisting the derived value back onto the Job spec because writing it back would make a 
 user-set `minCount` indistinguishable from the default on later updates, where `minCount` is mutable.
 
-Optional modifiers (`DisruptionMode`, `SchedulingConstraints`, `ResourceClaims`) are deliberately not
-defaulted. Unlike `SchedulingPolicy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `SchedulingConstraints`
+Optional modifiers (`DisruptionMode`, `Constraints`, `ResourceClaims`) are deliberately not
+defaulted. Unlike `Policy`, these are optional fields whose absence is a defined state. A nil `DisruptionMode` resolves to standard per-pod (`Single`) disruption, a nil `Constraints`
 means no topology co-location, and a nil `ResourceClaims` means no shared claims.
 
 #### Object Creation Order
@@ -814,7 +793,7 @@ The kube-scheduler waits for `PodGroup` when Pods have `schedulingGroup`, so sch
 #### Handling Updates and Mutability
 
 To support dynamic scaling of gang-scheduled workloads (Elastic Jobs), the Job API allows in-flight
-updates to `spec.scheduling.schedulingPolicy.gang.minCount`; all other `spec.scheduling` fields are immutable
+updates to `spec.scheduling.policy.gang.minCount`; all other `spec.scheduling` fields are immutable
 after Job creation, and updates that change them are rejected by API validation. This replaces the
 v1.36 validation that rejected `spec.parallelism` updates for gang Jobs: because the gang size is
 now driven by the mutable `minCount` ([KEP-4671]), `spec.parallelism` is no longer frozen for gang
@@ -825,7 +804,7 @@ consistent with what the controller actually compiles. The update-validation rul
 
   * `spec.parallelism` becomes *mutable* again: the v1.36 rule that rejected `spec.parallelism`
   updates for gang Jobs is removed, restoring Elastic Indexed Jobs.
-  * `spec.scheduling.schedulingPolicy.gang.minCount` is *mutable* in-flight: on change the controller
+  * `spec.scheduling.policy.gang.minCount` is *mutable* in-flight: on change the controller
   recompiles the `Workload` and re-syncs the `PodGroup` size.
   * All other `spec.scheduling` fields remain *immutable* after creation, enforced by api-server
   validation, since changing the policy, topology, disruption mode, or resourceClaims would require
@@ -838,7 +817,7 @@ scale the gang without ever touching `spec.scheduling`.
 
 A user can change the target gang size in one of two ways:
 
-- by setting `spec.scheduling.schedulingPolicy.gang.minCount` directly, when it is set explicitly
+- by setting `spec.scheduling.policy.gang.minCount` directly, when it is set explicitly
 - by setting `spec.parallelism`, when `minCount` is unset.
 
 In either case, the Job controller reconciles the change as follows:
@@ -866,11 +845,7 @@ higher-level controller:
 
 - **BYO `Workload`:** the user pre-creates a `Workload` whose `spec.controllerRef` points to 
 the `Job` and still expects the `Job` controller to create the runtime `PodGroup`(s) from 
-that `Workload` template. When the pre-created `Workload` carries a single `PodGroupTemplate`,
-the controller binds it automatically. When it carries multiple templates, the `Job` must
-name the one to bind via the `scheduling.k8s.io/group-template-name` annotation (the same signal
-used to delegate a `PodGroup` to a parent-owned `Workload`); without it the controller cannot
-disambiguate and falls back to default scheduling.
+that `Workload` template.
 - **BYO `PodGroup`:** the user manages the `PodGroup` themselves and wires pods to it by setting
   `pod.spec.schedulingGroup.podGroupName` directly via the `PodTemplate`. Here the controller does
   not create or own the `PodGroup` at all.
@@ -884,9 +859,8 @@ How the new `spec.scheduling` fields interact with BYO objects:
 - When an authoritative BYO `Workload`/`PodGroup` is present for the `Job`, the controller uses it 
 as-is and does not translate `spec.scheduling` into it or reconcile the two. This avoids a split-brain where the controller would fight the object's owner or over reconcile the two.
 - `minCount` is not synced into a BYO `PodGroup` [KEP-4671].
-- If a discovered `Workload` has an unsupported shape for alpha (e.g. multiple templates without
-a `scheduling.k8s.io/group-template-name` annotation naming one, or a named template that does not
-exist), the controller ignores it and surfaces a condition or event.
+- If a discovered `Workload` has an unsupported shape for alpha, the controller ignores it and 
+surfaces a condition or event.
 
 ### Naming Conventions
 
@@ -939,11 +913,10 @@ to implement this enhancement.
   without the api-server writing these values back into the Job's `spec.scheduling`.
   - `workloadbuilder` compilation: `Basic` vs `Gang` policy, and that topology constraints,
     disruption mode (single/all), and resourceClaims are mapped into the generated `Workload`/
-    `PodGroup`; that a `Job` builds a flat single-node `WorkloadItem` tree whose `Input` carries the
-    mapped `spec.scheduling` building blocks.
+    `PodGroup`; that a `Job` builds a flat single-node tree via `MapPodGroupConfig`.
   - A `Basic` `Workload`/`PodGroup` is created for a Job with `spec.scheduling` omitted.
   - pod creation includes the correct `schedulingGroup`.
-  - Mutability/validation: updates to `spec.scheduling.schedulingPolicy.gang.minCount` are allowed; updates to
+  - Mutability/validation: updates to `spec.scheduling.policy.gang.minCount` are allowed; updates to
     any other `spec.scheduling` field are rejected.
   - `gang.minCount > spec.parallelism` is rejected on both create and update. A single 
   request that raises `spec.parallelism` and `gang.minCount` together is accepted.
@@ -968,7 +941,7 @@ We will add the following integration tests to the Job controller (`test/integra
 - Lifecycle test for both `Basic` and `Gang` Jobs (create, update, delete Job; verify `Workload`
   and `PodGroup` are materialized, pods have `schedulingGroup`, and Job deletion cascades to
   `Workload`/`PodGroup` deletion).
-- Elastic scaling: updating `spec.scheduling.schedulingPolicy.gang.minCount` (or `spec.parallelism` when
+- Elastic scaling: updating `spec.scheduling.policy.gang.minCount` (or `spec.parallelism` when
   `minCount` is unset) updates the `Workload` and the runtime `PodGroup`.
 - Passthrough: topology constraints, disruption mode, and resourceClaims declared in
   `spec.scheduling` appear in the compiled `Workload`/`PodGroup`.
@@ -980,7 +953,7 @@ We will add the following integration tests to the Job controller (`test/integra
   mapped to the parent's `PodGroupTemplate` when the annotation is present.
 - The controller discovers and uses a pre-created `Workload`/`PodGroup`,
   does not take ownership, and does not mutate it on Job spec changes — in particular, updating
-  `spec.scheduling.schedulingPolicy.gang.minCount` leaves a BYO `PodGroup`'s `minCount` untouched, and 
+  `spec.scheduling.policy.gang.minCount` leaves a BYO `PodGroup`'s `minCount` untouched, and 
   the BYO object is not GC'd when the Job is deleted.
 - Jobs created by CronJob get one `Workload` and one `PodGroup` per Job, and these are GC'd when the
   Job completes or is deleted.
@@ -1075,7 +1048,7 @@ N/A for alpha release
 
 - **Behavior change between alphas:** in v1.36, indexed fully-parallel Jobs were automatically
   gang-scheduled; in v1.37 those same Jobs default to `Basic` unless the user sets
-  `spec.scheduling.schedulingPolicy.gang`. Gang scheduling is now an explicit opt-in. Operators upgrading
+  `spec.scheduling.policy.gang`. Gang scheduling is now an explicit opt-in. Operators upgrading
   between alphas should be aware that previously auto-gang'd Jobs will schedule pod-by-pod unless
   updated.
 
@@ -1319,9 +1292,6 @@ No. This feature is purely control-plane and does not affect node resources.
   selection with the explicit user-facing `spec.scheduling` API from [KEP-6089], adopting the
   shared `workloadbuilder` library, Universal Representation, and mutable `gang.minCount` for
   elastic scaling.
-- 2026-07-14: Synced the KEP with the implementation of the Job scheduling fields, the
-  `workloadbuilder` integration and `workloadbuilder` API (`Validate` with a
-  `ValidationInput` and the `NewBuilderFromExistingWorkload` constructor).
 
 ## Drawbacks
 

--- a/keps/sig-scheduling/6089-was-controller-apis/README.md
+++ b/keps/sig-scheduling/6089-was-controller-apis/README.md
@@ -230,12 +230,12 @@ spec:
   parallelism: 4
   completions: 4
   scheduling: # New API field - scheduling intent
-    policy:
+    schedulingPolicy:
       gang: {} # MinCount is omitted: Job defaults MinCount = parallelism (4)
-    constraints:
+    schedulingConstraints:
       topology:
         - level: "topology.kubernetes.io/zone"
-    disruption:
+    disruptionMode:
       all: {} # DisruptionMode resolves to All (entire group must be disrupted together)
   template:
     spec:
@@ -397,7 +397,7 @@ To keep this specification concise and focused, we only define the detailed Go A
 the leaf-level `PodGroup` specific types. An analogous set of types prefixed with
 `WorkloadCompositePodGroup...` is provided under the same API group.
 
-The Go definitions are structured as follows:
+The Go definitions are structured as follows. The shipped types carry declarative-validation (DV) markers and are declared as `+union` where exactly one member must be set:
 
 ```go
 // API Group: scheduling.k8s.io/v1alpha3
@@ -473,6 +473,22 @@ type WorkloadPodGroupResourceClaim struct {
     ResourceClaimTemplateName *string `json:"resourceClaimTemplateName,omitempty"`
 }
 ```
+
+The composite level provides the analogous `WorkloadCompositePodGroup...` set under the same API
+group, following the same shapes. Its policy building block
+(`WorkloadCompositePodGroupSchedulingPolicy`) uses `minGroupCount` (the minimum number of child
+groups, not pods) in place of the leaf's `minCount`.
+
+**Embedding the building blocks & immutability.**
+These structs are meant to be embedded verbatim into a controller's own API next to its other
+scheduling fields (for example, in a Job's `spec.scheduling`).
+
+The building blocks themselves are not marked `+k8s:immutable` because this would force that decision 
+on every embedder, but different controllers make different choices (one may recreate the 
+`Workload`/`PodGroup` on change; another may freeze it). Instead. The scheduling **policy** is a 
+special case as the variant (`basic`/`gang`) must be frozen while 
+`gang.minCount`/`gang.minGroupCount` stays mutable (to support scaling).
+
 ### Job Integration (batch/v1)
 
 To deliver native, typed Workload-aware Scheduling support in core Kubernetes, we propose
@@ -506,13 +522,13 @@ type JobSpec struct {
 
 // JobSchedulingConfiguration composes the reusable WAS building blocks.
 type JobSchedulingConfiguration struct {
-    // Policy defines the gang or basic scheduling rules for this Job.
+    // SchedulingPolicy defines the gang or basic scheduling rules for this Job.
     // +optional
-    Policy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"policy,omitempty"`
+    SchedulingPolicy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy `json:"schedulingPolicy,omitempty"`
 
-    // Constraints defines topology co-location constraints for the Job's pods.
+    // SchedulingConstraints defines topology co-location constraints for the Job's pods.
     // +optional
-    Constraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"constraints,omitempty"`
+    SchedulingConstraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints `json:"schedulingConstraints,omitempty"`
 
     // DisruptionMode specifies how the pods in this Job should be disrupted (Single vs All).
     // +optional
@@ -529,8 +545,8 @@ type JobSchedulingConfiguration struct {
 To prevent every workload controller (both core and out-of-tree) from writing custom, translation
 and validation logic, we propose providing a shared Go library: `workloadbuilder`.
 
-**Package placement:** The library ships from staging under 
-`k8s.io/component-helpers/scheduling/schedulingv1`. It is scoped as helpers shared by multiple
+**Package placement:** The library ships from staging as the `workloadbuilder` package under
+`k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder`. It is scoped as helpers shared by multiple
 core binaries, keeps a minimal dependency surface (no external deps), and is meant for this 
 kind of scheduling-API translation. `k8s.io/kube-scheduler` was considered but
 carries heavier dependencies and is a less natural import for out-of-tree controllers.
@@ -545,14 +561,16 @@ the library:
 * **Hierarchy-Agnostic Library IR:** The library defines its own internal, polymorphic structures
   (`workloadbuilder.SchedulingConfig`, `workloadbuilder.SchedulingPolicy`, etc.) that represent
   scheduling configurations in a hierarchy-agnostic way.
-* **Standard Mapping Helpers:** To prevent controllers from writing custom translation boilerplate
-  to bridge K8s API types to the library IR, the library provides standard, built-in conversion
-  functions (`MapPodGroupConfig` and `MapCompositeGroupConfig`). These helper adapters cleanly
-  translate public, level-specific schemas into polymorphic IR models at runtime.
+* **Standard Mapping:** To prevent controllers from writing custom translation boilerplate to bridge
+  K8s API types to the library IR, the library maps the public, level-specific building blocks into
+  its polymorphic IR internally. A controller records its user's intent on each node's `Input`: a
+  `WorkloadInput` that pairs each leaf-level building block with the field path (`PathElements`)
+  where it lives in the controller's API, so validation errors are reported at the exact field. The
+  composite level provides the analogous input for `CompositePodGroup` building blocks.
 
 Controller authors construct a logical tree using `WorkloadItem` representing their workload
-structure, populate `DefaultConfig` and the user's `UserConfig` (using the standard mapping
-helpers), and invoke the builder.
+structure, populate each node's `DefaultConfig` (the controller's sane defaults) and `Input` (the
+user's intent), and invoke the builder.
 
 The library encapsulates the following logic:
 1. **Policy Resolution:** Merges default configurations with user-provided overrides (e.g.,
@@ -579,22 +597,24 @@ and the library's validation helpers reject anything not explicitly allowed. Thi
 additions to the building-block API are **denied by default** until a controller explicitly updates
 its allow-list.
 
-The library provides per-field validation helpers that accept the supported options as arguments:
+A controller declares the policies and modes it supports on the builder's `BuildOptions`;
+`Builder.Validate` resolves the config and rejects anything outside the allow-list, reporting at the
+offending block's field path:
 
 ```go
 // In Job's API validation (pkg/apis/batch/validation):
-allErrs = append(allErrs,
-    workloadbuilder.ValidateSchedulingPolicy(
-        spec.Scheduling.Policy, fldPath.Child("policy"),
-        workloadbuilder.BasicPolicy, workloadbuilder.GangPolicy))
-allErrs = append(allErrs,
-    workloadbuilder.ValidateDisruptionMode(
-        spec.Scheduling.DisruptionMode, fldPath.Child("disruptionMode"),
-        workloadbuilder.SingleMode, workloadbuilder.AllMode))
+builder := workloadbuilder.NewBuilder(item, workloadbuilder.BuildOptions{
+    AllowedPolicies:        []workloadbuilder.SchedulingPolicyOption{workloadbuilder.BasicPolicy, workloadbuilder.GangPolicy},
+    AllowedDisruptionModes: []workloadbuilder.DisruptionModeOption{workloadbuilder.SingleMode, workloadbuilder.AllMode},
+    // The apiserver already runs declarative validation on the building blocks,
+    // so in-tree Validate performs only the complex controller-policy checks.
+    DisableDeclarativeValidation: true,
+})
+allErrs = append(allErrs, builder.Validate(ctx, fldPath, workloadbuilder.ValidationInput{})...)
 ```
 
 This gives controllers opt-in semantics: when a new policy is introduced in a future release,
-existing controllers (including `Job`) will reject it until their validation is explicitly updated
+existing controllers (including `Job`) will reject it until their allow-list is explicitly updated
 to include the new option. Out-of-tree controllers get the same guarantee by updating their vendored
 library version and extending their allow-list.
 
@@ -609,7 +629,8 @@ type JobSpec struct {
 }
 ```
 
-Until DV support is available, the library-provided validation helpers serve as a lightweight,
+The structural building-block constraints are already generated as DV validators; until subfield
+allow-list markers land in DV, the builder's allow-list checks in `Validate` serve as a lightweight,
 defensive bridge that keeps the overhead minimal for controller integrators.
 
 #### 3. Library API Definition
@@ -620,6 +641,7 @@ package workloadbuilder
 import (
     "context"
     metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/util/validation/field"
     schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 )
 
@@ -629,6 +651,10 @@ type SchedulingConfig struct {
     DisruptionMode *DisruptionMode
     Policy         *SchedulingPolicy
     ResourceClaims []ResourceClaim
+
+    // PriorityClassName is copied onto the compiled PodGroupTemplate so a PodGroup
+    // materialized from it inherits the group's priority.
+    PriorityClassName string
 }
 
 type SchedulingConstraints struct {
@@ -667,160 +693,264 @@ type ResourceClaim struct {
     ResourceClaimTemplateName *string
 }
 
-// WorkloadItemFunc mutates a single WorkloadItem during Build that is 
-// used for controller-specific defaulting.
-type WorkloadItemFunc func(*WorkloadItem)
+// SchedulingConfigFunc post-processes the merged SchedulingConfig after the
+// default/user merge. Controllers use it for defaulting (e.g. gang MinCount) but
+// it is general-purpose and may perform any controller-specific adjustment.
+type SchedulingConfigFunc func(*SchedulingConfig)
 
 // WorkloadItem represents a logical component of a workload (e.g., the whole JobSet,
 // a specific ReplicatedJob role, or a single standalone Job).
 type WorkloadItem struct {
-    // Name is the logical identifier of this component (e.g., "jobset-root", "driver").
+    // Name is the logical identifier of this component; it becomes the
+    // PodGroupTemplate name and must be non-empty.
     Name string
 
-    // DefaultConfig defines the complete set of "sane defaults" assigned by the controller
-    // based on its specific orchestration domain logic.
+    // DefaultConfig is the controller's "sane defaults" for any field the user
+    // left unset, based on its orchestration domain logic.
     DefaultConfig *SchedulingConfig
 
-    // UserConfig is the exact policy intent configured by the user at this specific level.
-    // Can be nil if the user left the scheduling block unconfigured.
-    UserConfig *SchedulingConfig
+    // Input holds the user's intent for this node as the versioned building blocks
+    // paired with the field paths where the controller embeds them. Nil sub-fields
+    // fall back to DefaultConfig field-by-field.
+    Input WorkloadInput
 
-    // Callbacks is a list of controller-supplied mutator functions that the
-    // controller can attach to this item. Callbacks are primarily intended
-    // as defaulting functions (e.g. MinCount), but they are general-purpose
-    //  and may perform any controller-specific adjustment.
-    Callbacks []WorkloadItemFunc
+    // Callbacks run in order against the resolved config after the default/user merge.
+    Callbacks []SchedulingConfigFunc
 
     // Children contains the logical sub-components of this workload.
-    // - If len(Children) > 0, the node is inferred as a structural group
-    //   (i.e., represents a CompositePodGroupTemplate).
-    // - If len(Children) == 0, the node is inferred as a leaf (i.e. represents a PodGroup)
+    // - If len(Children) > 0, the node is a structural group (CompositePodGroupTemplate).
+    // - If len(Children) == 0, the node is a leaf (PodGroup).
+    //
+    // Multi-level compilation (children -> CompositePodGroupTemplate) is the designed
+    // composite extension; the alpha library compiles a single leaf node into one
+    // PodGroupTemplate and gains composite-tree compilation in a fast-follow (see the
+    // note below).
     Children []*WorkloadItem
 }
 
-// WorkloadBuilder translates the logical WorkloadItem tree into a scheduler Workload object.
-type WorkloadBuilder interface {
-    // Build translates the tree, merges defaults, validates policies,
-    // and generates the Workload resource.
-    Build(
-        ctx context.Context,
-        name, namespace string,
-        owner *metav1.OwnerReference,
-    ) (*schedulingv1alpha3.Workload, error)
+// WorkloadInput bundles the leaf-level building blocks a controller embeds in its
+// own API, each paired with its field path. The zero value means "nothing set", so
+// callers only populate the blocks they care about. The composite level provides an
+// analogous input for the WorkloadCompositePodGroup* building blocks.
+type WorkloadInput struct {
+    Policy         PolicyInput
+    Constraints    ConstraintsInput
+    DisruptionMode DisruptionModeInput
+    ResourceClaims ResourceClaimsInput
 }
 
-// NewBuilder initializes a builder with a specific root node.
-func NewBuilder(root *WorkloadItem) WorkloadBuilder {
-    return &builderImpl{root: root}
+// PolicyInput pairs the scheduling policy building block with its field path.
+// PathElements is the path, relative to the WorkloadItem's rootPath, at which the
+// block is embedded: e.g. a rootPath of `spec.scheduling` with PathElements
+// []string{"schedulingPolicy"} reports errors at `spec.scheduling.schedulingPolicy`.
+type PolicyInput struct {
+    PodGroupData *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy
+    PathElements []string
 }
 
-// MapPodGroupConfig translates standard leaf building blocks into the library's polymorphic IR.
-func MapPodGroupConfig(
-    policy *schedulingv1alpha3.WorkloadPodGroupSchedulingPolicy,
-    constraints *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints,
-    disruption *schedulingv1alpha3.WorkloadPodGroupDisruptionMode,
-    claims []schedulingv1alpha3.WorkloadPodGroupResourceClaim,
-) *SchedulingConfig
+type ConstraintsInput struct {
+    PodGroupData *schedulingv1alpha3.WorkloadPodGroupSchedulingConstraints
+    PathElements []string
+}
 
-// MapCompositeGroupConfig translates standard composite building blocks into the library's polymorphic IR.
-func MapCompositeGroupConfig(
-    policy *schedulingv1alpha3.WorkloadCompositePodGroupSchedulingPolicy,
-    constraints *schedulingv1alpha3.WorkloadCompositePodGroupSchedulingConstraints,
-    disruption *schedulingv1alpha3.WorkloadCompositePodGroupDisruptionMode,
-) *SchedulingConfig
+type DisruptionModeInput struct {
+    PodGroupData *schedulingv1alpha3.WorkloadPodGroupDisruptionMode
+    PathElements []string
+}
+
+type ResourceClaimsInput struct {
+    PodGroupData []schedulingv1alpha3.WorkloadPodGroupResourceClaim
+    PathElements []string
+}
+
+// SchedulingPolicyOption and DisruptionModeOption enumerate the policies and modes
+// a controller opts into. Validate rejects anything outside the allow-list.
+type SchedulingPolicyOption int
+
+const (
+    BasicPolicy SchedulingPolicyOption = iota
+    GangPolicy
+)
+
+type DisruptionModeOption int
+
+const (
+    SingleMode DisruptionModeOption = iota
+    AllMode
+)
+
+// BuildOptions carries the identity of the compiled Workload plus the controller's
+// scheduling allow-lists.
+type BuildOptions struct {
+    Name      string
+    Namespace string
+    // Owner becomes the Workload's controllerRef, used for discovery and GC.
+    Owner *metav1.OwnerReference
+
+    AllowedPolicies        []SchedulingPolicyOption
+    AllowedDisruptionModes []DisruptionModeOption
+
+    // DisableDeclarativeValidation skips declarative validation on the input blocks.
+    // In-tree controllers set this because the apiserver already runs DV.
+    DisableDeclarativeValidation bool
+}
+
+// Builder turns a controller's WorkloadItem tree into scheduler-facing objects.
+// Construct it with NewBuilder (or NewBuilderFromExistingWorkload), then call
+// Validate, BuildWorkload, and NewPodGroup.
+type Builder struct { /* unexported fields */ }
+
+// NewBuilder returns a Builder for the given WorkloadItem tree and options.
+func NewBuilder(root *WorkloadItem, opts BuildOptions) *Builder
+
+// NewBuilderFromExistingWorkload returns a Builder that materializes PodGroups
+// from an already-persisted Workload rather than compiling one from a WorkloadItem
+// tree. Use it when a parent controller (or a hand-authored template) owns and
+// compiled the Workload. BuildWorkload is refused and Validate is a no-op; only
+// NewPodGroup is meaningful, using opts.Owner for the PodGroup's controller ownerRef.
+func NewBuilderFromExistingWorkload(workload *schedulingv1alpha3.Workload, opts BuildOptions) *Builder
+
+// ValidationInput carries the parameters Validate only consults when declarative
+// validation is enabled. Its zero value means a create with no previous object,
+// which is the common case; a caller running with DisableDeclarativeValidation can
+// always pass the zero value.
+type ValidationInput struct {
+    // OldRoot is the previously persisted WorkloadItem. It is nil for a create and
+    // non-nil for an update. Validate infers the operation from it, so the
+    // update-time declarative checks run exactly when OldRoot is set. Only
+    // OldRoot.Name (to correlate it with the new root) and OldRoot.Input (the
+    // previous versioned data) are consulted; DefaultConfig, Callbacks, and
+    // Input.*.PathElements are ignored because the resolved config and error paths
+    // always come from the new root.
+    OldRoot *WorkloadItem
+}
+
+// Validate runs declarative validation on the input blocks (unless disabled) plus
+// the controller-policy checks DV cannot express (allow-lists, and cross-field rules
+// such as rejecting `all` disruption with the Basic policy), reporting errors at each
+// block's field path. For a create, pass the zero ValidationInput; for an update, set
+// OldRoot to the previous tree, and Validate runs the update-time checks. A root name
+// mismatch between OldRoot and the new root is an invocation-contract bug and is
+// reported as an InternalError.
+func (b *Builder) Validate(ctx context.Context, rootPath *field.Path, input ValidationInput) field.ErrorList
+
+// BuildWorkload compiles the tree into a Workload, sets its identity and
+// controllerRef, and caches the result so PodGroups can be materialized from it.
+func (b *Builder) BuildWorkload() (*schedulingv1alpha3.Workload, error)
+
+// NewPodGroup materializes a runtime PodGroup from the named PodGroupTemplate of the
+// Builder's Workload (compiled via BuildWorkload or supplied via
+// NewBuilderFromExistingWorkload).
+func (b *Builder) NewPodGroup(podGroupName, templateName string) (*schedulingv1alpha3.PodGroup, error)
 ```
+
+The translation from the versioned building blocks (recorded in each node's `Input`) into the
+polymorphic IR is performed internally by the library while resolving the tree. A leaf node's 
+`WorkloadInput` maps the `WorkloadPodGroup...` blocks into the IR, and a composite node maps its analogous `WorkloadCompositePodGroup...` blocks.
+Keeping the mapping internal means there is a single, consistent translation path (exercised by both
+`Validate` and `BuildWorkload`) rather than a public helper each controller must call correctly.
+
 
 #### 4. Library Usage Example (Job)
 
-This example demonstrates how the core `Job` controller integrates with the `workloadbuilder`
-library to compile its flat `Workload` structure:
+This is how the core `Job` controller integrates with the `workloadbuilder` library to compile its
+flat `Workload` structure:
 
 ```go
 import (
-    "context"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    batchv1 "k8s.io/api/batch/v1"
+    batch "k8s.io/api/batch/v1"
     schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    workloadbuilder "k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder"
     "k8s.io/utils/ptr"
 )
 
-func (r *JobReconciler) generateWorkload(
-    job *batchv1.Job,
-) (*schedulingv1alpha3.Workload, error) {
-    // A Job's context-aware sane default is Basic scheduling (standard Kubernetes pod-by-pod)
-    defaultConfig := &workloadbuilder.SchedulingConfig{
-        Policy: &workloadbuilder.SchedulingPolicy{
-            Basic: &workloadbuilder.BasicSchedulingPolicy{},
+// mapSchedulingInput translates the Job's user-facing spec.scheduling block into
+// a WorkloadInput, pairing each building block with the spec.scheduling sub-path
+// where it lives. It returns the zero value for a nil block so the builder falls
+// back to the controller's default config.
+func mapSchedulingInput(cfg *batch.JobSchedulingConfiguration) workloadbuilder.WorkloadInput {
+    if cfg == nil {
+        return workloadbuilder.WorkloadInput{}
+    }
+    return workloadbuilder.WorkloadInput{
+        Policy: workloadbuilder.PolicyInput{
+            PodGroupData: cfg.SchedulingPolicy,
+            PathElements: []string{"schedulingPolicy"},
+        },
+        Constraints: workloadbuilder.ConstraintsInput{
+            PodGroupData: cfg.SchedulingConstraints,
+            PathElements: []string{"schedulingConstraints"},
+        },
+        DisruptionMode: workloadbuilder.DisruptionModeInput{
+            PodGroupData: cfg.DisruptionMode,
+            PathElements: []string{"disruptionMode"},
+        },
+        ResourceClaims: workloadbuilder.ResourceClaimsInput{
+            PodGroupData: cfg.ResourceClaims,
+            PathElements: []string{"resourceClaims"},
         },
     }
-
-    // 2. Map the public Job.Spec.Scheduling wrapper directly using the library helper
-    var userConfig *workloadbuilder.SchedulingConfig
-    if job.Spec.Scheduling != nil {
-        userConfig = workloadbuilder.MapPodGroupConfig(
-            job.Spec.Scheduling.Policy,
-            job.Spec.Scheduling.Constraints,
-            job.Spec.Scheduling.DisruptionMode,
-            job.Spec.Scheduling.ResourceClaims,
-        )
-    }
-
-    // 3. Create the flat logical tree for Job (root node representing a single PodGroup).
-    //    A callback defaults gang MinCount to the Job's parallelism when the user opts
-    //    into Gang but leaves MinCount unset (see defaultMinCountForJob below).
-    rootNode := &workloadbuilder.WorkloadItem{
-        Name:          "job-root",
-        DefaultConfig: defaultConfig,
-        UserConfig:    userConfig,
-        Callbacks: []workloadbuilder.WorkloadItemFunc{
-            defaultMinCountForJob(job),
-        },
-    }
-
-    // 4. Let the workloadbuilder compile and generate the Workload object
-    builder := workloadbuilder.NewBuilder(rootNode)
-    workloadObj, err := builder.Build(
-        context.Background(),
-        job.Name,
-        job.Namespace,
-        metav1.NewControllerRef(job, jobKind),
-    )
-    if err != nil {
-        return nil, err
-    }
-
-    return workloadObj, nil
 }
-```
 
-The callbacks attached above are ordinary functions the controller can set on 
-a node. Their most common job is defaulting, but because they receive the whole node
-they can also apply arbitrary, controller-specific adjustments:
-
-```go
-// defaultMinCountForJob fills in a sane default for gang MinCount (the Job's
-// parallelism) when the resolved policy is Gang and MinCount was left unset.
-func defaultMinCountForJob(job *batchv1.Job) workloadbuilder.WorkloadItemFunc {
-    return func(item *workloadbuilder.WorkloadItem) {
-        if item.Policy.Gang != nil && 
-          item.Policy.Gang.MinCount == nil {  
-            item.Policy.Gang.MinCount = ptr.To(job.Spec.Parallelism)
+// defaultMinCountForJob returns a callback that defaults an unset gang MinCount
+// to the Job's parallelism, clamped to a minimum of 1 (parallelism may be 0 for
+// a suspended Job, but MinCount must be positive). It mutates only the resolved
+// config, never writing the derived value back onto the Job's spec.
+func defaultMinCountForJob(job *batch.Job) workloadbuilder.SchedulingConfigFunc {
+    return func(cfg *workloadbuilder.SchedulingConfig) {
+        if cfg == nil || cfg.Policy == nil || cfg.Policy.Gang == nil {
+            return
+        }
+        if cfg.Policy.Gang.MinCount == nil {
+            cfg.Policy.Gang.MinCount = new(max(int32(1), ptr.Deref(job.Spec.Parallelism, 1)))
         }
     }
 }
 
 // multiplyMinCountForAdjustedJob is an example of a non-defaulting adjustment: callbacks
 // are free to implement arbitrary, controller-specific logic when needed.
-func multiplyMinCountForAdjustedJob(job *batchv1.Job) workloadbuilder.WorkloadItemFunc {
-    return func(item *workloadbuilder.WorkloadItem) {
+func multiplyMinCountForAdjustedJob(job *batch.Job) workloadbuilder.SchedulingConfigFunc {
+    return func(cfg *workloadbuilder.SchedulingConfig) {
       if job.Annotations["isAdjustedJob.example.com"] == "true" {  
-        if item.Policy.Gang != nil {  
-            item.Policy.Gang.MinCount *= 42  
+        if cfg.Policy.Gang != nil {  
+            cfg.Policy.Gang.MinCount *= 42  
         }  
       }  
     }
 }
+
+// buildWorkloadItem assembles the single-node logical workload tree for a Job.
+// The Job defaults to Basic scheduling; the user's spec.scheduling overrides it.
+func buildWorkloadItem(job *batch.Job) *workloadbuilder.WorkloadItem {
+    return &workloadbuilder.WorkloadItem{
+        Name: podGroupTemplateName(job),
+        DefaultConfig: &workloadbuilder.SchedulingConfig{
+            Policy:            &workloadbuilder.SchedulingPolicy{Basic: &workloadbuilder.BasicSchedulingPolicy{}},
+            PriorityClassName: job.Spec.Template.Spec.PriorityClassName,
+        },
+        Input:     mapSchedulingInput(job.Spec.Scheduling),
+        Callbacks: []workloadbuilder.SchedulingConfigFunc{defaultMinCountForJob(job)},
+    }
+}
+
+// generateWorkload compiles the Job's spec.scheduling into a Workload via the
+// shared workloadbuilder library. BuildWorkload also sets the controller
+// ownerReference and spec.controllerRef pointing at the Job.
+func (jm *Controller) generateWorkload(job *batch.Job) (*schedulingv1alpha3.Workload, error) {
+    return workloadbuilder.NewBuilder(buildWorkloadItem(job), workloadbuilder.BuildOptions{
+        Name:      computeWorkloadName(job),
+        Namespace: job.Namespace,
+        Owner:     metav1.NewControllerRef(job, controllerKind),
+    }).BuildWorkload()
+}
 ```
+
+`Callbacks` are ordinary functions the controller sets on a node; `defaultMinCountForJob` is the
+defaulting one used here, but because a callback receives the resolved config it can apply any
+controller-specific adjustment. Note the allow-lists (`AllowedPolicies`/`AllowedDisruptionModes`)
+are not set on this compile path, they are an apiserver-validation concern applied where the Job's
+validation calls `Validate`.
 
 ### Reference Integration Examples: JobSet (Multi-Level)
 
@@ -847,7 +977,7 @@ apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 spec:
   scheduling: # Global policy: applies to the entire JobSet
-    policy:
+    schedulingPolicy:
       basic: {} # ESCAPE HATCH: Disable global "gang of gangs" so components start independently
   replicatedJobs:
     - name: driver
@@ -863,7 +993,7 @@ spec:
       template:
         spec:
           scheduling: # Leaf-level policy declared inside the nested Job template
-            constraints:
+            schedulingConstraints:
               topology:
                 - level: "topology.kubernetes.io/rack" # Co-locate workers on same rack
           containers:
@@ -885,11 +1015,11 @@ apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 spec:
   scheduling: # All scheduling policies are defined here at the root
-    policy:
+    schedulingPolicy:
       basic: {} # Global policy: components schedule independently
     replicatedJobPolicies:
       - targetReplicatedJob: "workers" # Policy target
-        constraints:
+        schedulingConstraints:
           topology:
             - level: "topology.kubernetes.io/rack" # Co-locate workers on same rack
   replicatedJobs:
@@ -914,8 +1044,28 @@ spec:
 
 #### 3. Controller Integration and workloadbuilder Mapping Go Code
 
-Regardless of which API model `JobSet` adopts, the controller can easily map its structural spec
-into the `workloadbuilder` logical tree. For more details, see [JobSet integration](https://github.com/kubernetes-sigs/jobset/pull/1068).
+Regardless of which API model `JobSet` adopts, the controller maps its structural spec into a
+`workloadbuilder.WorkloadItem` tree: the root is a composite node (its `Children` are the
+`ReplicatedJob` roles) carrying the composite scheduling policy, and each child leaf carries the
+leaf building blocks. The builder then compiles the tree into a `Workload` with a
+`CompositePodGroupTemplate` over the child `PodGroupTemplate`s:
+
+```go
+root := &workloadbuilder.WorkloadItem{
+    Name: "jobset-root",
+    // A composite node: the group-of-groups policy lives in the IR just like a leaf's.
+    DefaultConfig: &workloadbuilder.SchedulingConfig{
+        Policy: &workloadbuilder.SchedulingPolicy{Gang: &workloadbuilder.GangSchedulingPolicy{}},
+    },
+    // Input maps the JobSet's composite WorkloadCompositePodGroup* building block(s).
+    Input: mapJobSetSchedulingInput(jobSet),
+    Children: []*workloadbuilder.WorkloadItem{
+        leafItemForReplicatedJob(jobSet, "driver"),
+        leafItemForReplicatedJob(jobSet, "workers"),
+    },
+}
+workload, err := workloadbuilder.NewBuilder(root, opts).BuildWorkload()
+```
 
 ### Recommendations for Multi-Level Composite Controllers
 
@@ -971,11 +1121,16 @@ controller sets these annotations on each standard `Job` resource it creates):
   * **Annotation Key:** `scheduling.k8s.io/group-template-name`
   * **Value:** The unique name of the target `PodGroupTemplate` or `CompositePodGroupTemplate`
     defined inside the parent `Workload` resource (ensuring direct mapping, as all template
-    names inside a Workload are guaranteed to be unique).
+    names inside a Workload are guaranteed to be unique). For example, in a
+    `TrainJob -> JobSet -> Job` hierarchy this tells the child `Job` which template from the root
+    `Workload` to use to create its `PodGroup`.
 * **Parent Instance Linkage Annotation:**
-  * **Annotation Key:** `scheduling.k8s.io/parent-composite-podgroup`
+  * **Annotation Key:** `scheduling.k8s.io/parent-compositepodgroup`
   * **Value:** The exact resource name of the parent `CompositePodGroup` object in the same
-    namespace that the child's newly created group must connect to.
+    namespace that the child's newly created group must attach to. This is required only in the
+    delegated lifecycle model (the parent creates the `Workload` and `CompositePodGroup`, but the
+    child creates its own `PodGroup`); when the parent centrally manages both the `CompositePodGroup`
+    and the `PodGroup`s, this annotation is unnecessary.
 
 We strictly use **unstructured metadata annotations** rather than introducing new structural fields
 in the child's API schemas for this coordination. These mappings are transient, internal, and
@@ -1031,12 +1186,12 @@ Job-specific test plans are tracked in [KEP-5547].
     fills `gang.minCount` (e.g. from a Job's parallelism) when omitted
   - `workloadbuilder` `Validate` rejects semantically invalid configurations
   - Single-level `WorkloadItem` (flat, no children) produces a leaf `PodGroup` only
-  - Multi-level `WorkloadItem` tree (with children) produces a `CompositePodGroup` with correct
-    parent–child structure
-  - `MapPodGroupConfig` and `MapCompositeGroupConfig` correctly translate API types into the
-    library IR
-- Reference integration tests for multi-level controllers (e.g. `JobSet`) verify that the
-  `workloadbuilder` produces the expected `CompositePodGroup` and child `PodGroup` objects from
+  - the library correctly translates the leaf building blocks recorded in a `WorkloadItem.Input`
+    (`WorkloadInput`) into the library IR
+  - Multi-level `WorkloadItem` tree (with children) produces a `CompositePodGroup` with correct 
+    parent–child structure, translating the composite `WorkloadCompositePodGroupSchedulingPolicy` block into the IR
+- Reference integration tests for multi-level controllers (e.g. `JobSet`) verify that the 
+  `workloadbuilder` produces the expected `CompositePodGroup` and child `PodGroup` objects from 
   a composite `WorkloadItem` tree.
 
 ##### Integration tests
@@ -1322,6 +1477,11 @@ No. This feature operates entirely at the control-plane/API level and does not c
 ## Implementation History
 
 - 2026-06-03: KEP Created for alpha release
+- 2026-07-15: Synced the KEP with the implementation of the `workloadbuilder` library, the Job
+  building-block fields and the `workloadbuilder` API (`Validate` with a
+  `ValidationInput` and the `NewBuilderFromExistingWorkload` constructor).
+- 2026-07-18: Synced the `CompositePodGroup` design with the codebase and review feedback from the
+  building-blocks library.
 
 ## Drawbacks
 


### PR DESCRIPTION
- One-line PR description: Update building blocks API and the design of workloadbuilder library according to the current implementation.

- Issue link: https://github.com/kubernetes/enhancements/issues/6089

- Other comments: