### PR TITLE
KEP-2033: KubeletInUserNamespace: drop unneeded label

### DIFF
--- a/keps/sig-node/2033-kubelet-in-userns-aka-rootless/README.md
+++ b/keps/sig-node/2033-kubelet-in-userns-aka-rootless/README.md
@@ -728,8 +728,7 @@ in back-to-back releases.
   - https://github.com/GoogleCloudPlatform/anthos-samples/blob/8aff62c3f0bd835bda7479a01a591e1849c48fe9/anthos-attached-clusters/kind/main.tf#L37
   - https://github.com/GoogleCloudPlatform/cloud-solutions/blob/pino-logging-gcp-config-v1.1.0/projects/k8s-hybrid-neg-controller/hack/kind-cluster-config.yaml#L24
   - https://github.com/GoogleCloudPlatform/solutions-workshops/blob/grpc-xds/v0.5.0/grpc-xds/hack/kind-cluster-config-2.yaml#L24
-  In beta, nodes will have `node.kubernetes.io/running-in-user-namespace: <BOOL>` labels.
-  [`NodeSystemInfo`](https://pkg.go.dev/k8s.io/api/core/v1#NodeSystemInfo) will be updated too to have `RunningInUserNamespace *bool`.
+  In beta, [`NodeSystemInfo`](https://pkg.go.dev/k8s.io/api/core/v1#NodeSystemInfo) will be updated to have `RunningInUserNamespace *bool`.
 
 - GA: Assuming no negative user feedback based on production experience, promote after >= 2 releases in beta.
   Requirements:
@@ -944,11 +943,10 @@ checking if there are objects with field X set) may be a last resort. Avoid
 logs or events for this purpose.
 -->
 
-Nodes will have `node.kubernetes.io/running-in-user-namespace: <BOOL>` labels.
-An operator may utilize this label to avoid scheduling workloads that require real root privileges (e.g., CNI plugin installer)
+[`NodeSystemInfo`](https://pkg.go.dev/k8s.io/api/core/v1#NodeSystemInfo) will be updated to have `RunningInUserNamespace *bool`.
+An operator may utilize this property to set custom labels so as to avoid scheduling workloads that require real root privileges (e.g., CNI plugin installer)
 on nodes running in user namespaces.
 
-[`NodeSystemInfo`](https://pkg.go.dev/k8s.io/api/core/v1#NodeSystemInfo) will be updated too to have `RunningInUserNamespace *bool`.
 
 ###### How can someone using this feature know that it is working for their instance?
 
@@ -964,7 +962,7 @@ Recall that end users cannot usually observe component logs or access metrics.
 - [ ] Events
   - Event Reason:
 - [X] API .status
-  - Condition name: Nodes will have `node.kubernetes.io/running-in-user-namespace: <BOOL>` labels. [`NodeSystemInfo`](https://pkg.go.dev/k8s.io/api/core/v1#NodeSystemInfo)` will be updated to have `RunningInUserNamespace *bool`.
+  - Condition name: [`NodeSystemInfo`](https://pkg.go.dev/k8s.io/api/core/v1#NodeSystemInfo)` will be updated to have `RunningInUserNamespace *bool`.
   - Other field: 
 - [ ] Other (treat as last resort)
   - Details:


### PR DESCRIPTION

<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: KEP-2033: KubeletInUserNamespace: drop unneeded label

<!-- link to the k/enhancements issue -->
- Issue link: #2033 

<!-- other comments or additional information -->
- Other comments:
It turned out that nodes do not need to have `node.kubernetes.io/running-in-user-namespace: <BOOL>` labels.
  - https://github.com/kubernetes/kubernetes/pull/134639#issuecomment-5061245296

Partially revert:
 - #5694
 - #6114

