### PR TITLE
KEP-6132: downgrade to alpha for v1.37

### DIFF
--- a/keps/prod-readiness/sig-scheduling/6132.yaml
+++ b/keps/prod-readiness/sig-scheduling/6132.yaml
@@ -1,3 +1,5 @@
 kep-number: 6132
+alpha:
+  approver: "@johnbelamaric"
 beta:
   approver: "@johnbelamaric"

--- a/keps/sig-scheduling/6132-prequeueing-hints/kep.yaml
+++ b/keps/sig-scheduling/6132-prequeueing-hints/kep.yaml
@@ -17,12 +17,13 @@ approvers:
 see-also:
   - "/keps/sig-scheduling/624-scheduling-framework"
 
-stage: beta
+stage: alpha
 
 latest-milestone: "v1.37"
 
 milestone:
-  beta: "v1.37"
+  alpha: "v1.37"
+  beta: "v1.38"
   stable: "v1.39"
 
 feature-gates:


### PR DESCRIPTION
Feature will stay alpha in v1.37 (default=false, opt-in via feature gate). Beta promotion planned for v1.38.

cc @sanposhiho @pohly