### PR TITLE
Add the 1.37 & 1.38 Milestone links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Procedure:
 
 ### Current Release Cycle
 
-[Dates and further information for the 1.34 Release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.34)
+[Dates and further information for the 1.38 Release](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.38)
 
 ## Exceptions to Enhancement Milestone Dates
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ As of the 1.26 release, enhancements from this repo are visualized in the Enhanc
 
 Links:
 
+- [1.38 Milestone](https://rel.k8s.io/v138/enhancements)
+- [1.37 Milestone](https://rel.k8s.io/v137/enhancements)
 - [1.36 Milestone](https://rel.k8s.io/v136/enhancements)
 - [1.35 Milestone](https://bit.ly/k8s135-enhancements)
 - [1.34 Milestone](https://bit.ly/k8s134-enhancements)


### PR DESCRIPTION
- One-line PR description: Add the 1.37 & 1.38 Milestone links

<!-- link to the k/enhancements issue -->
- Issue link: N/A

<!-- other comments or additional information -->
- Other comments:
  - Follow #5804 PR
  - The 1.38 link will be active after https://github.com/kubernetes/sig-release/pull/3089 is merged.