### PR TITLE
assigned approvers and reviewers after the planning session

### DIFF
--- a/keps/sig-node/2371-cri-pod-container-stats/OWNERS
+++ b/keps/sig-node/2371-cri-pod-container-stats/OWNERS
@@ -7,3 +7,4 @@ reviewers:
   - haircommander # sig-node-assigned-reviewer
 
 approvers:
+  - haircommander # sig-node-assigned-approver

--- a/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
+++ b/keps/sig-node/2371-cri-pod-container-stats/kep.yaml
@@ -15,6 +15,7 @@ reviewers:
   - "@haircommander" # sig-node-assigned-reviewer
 approvers:
   - "@dchen1107"
+  - "@haircommander" # sig-node-assigned-approver
 see-also:
   - N/A
 replaces:

--- a/keps/sig-node/2535-ensure-secret-pulled-images/OWNERS
+++ b/keps/sig-node/2535-ensure-secret-pulled-images/OWNERS
@@ -3,5 +3,8 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - haircommander # sig-node-assigned-reviewer
+  - mikebrow # sig-node-assigned-reviewer
+
+approvers:
+  - samuelkarp # sig-node-assigned-approver

--- a/keps/sig-node/2535-ensure-secret-pulled-images/kep.yaml
+++ b/keps/sig-node/2535-ensure-secret-pulled-images/kep.yaml
@@ -16,9 +16,12 @@ reviewers:
   - "@mrunalp"
   - "@adisky"
   - "@liggitt"
+  - "@haircommander" # sig-node-assigned-reviewer
+  - "@mikebrow" # sig-node-assigned-reviewer
 approvers:
   - "@dchen1107"
   - "@derekwaynecarr"
+  - "@samuelkarp" # sig-node-assigned-approver
 stage: beta
 latest-milestone: "v1.37"
 milestone:

--- a/keps/sig-node/2837-pod-level-resource-spec/OWNERS
+++ b/keps/sig-node/2837-pod-level-resource-spec/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:
+  - haircommander # sig-node-assigned-approver

--- a/keps/sig-node/2837-pod-level-resource-spec/kep.yaml
+++ b/keps/sig-node/2837-pod-level-resource-spec/kep.yaml
@@ -19,6 +19,7 @@ reviewers:
 
 approvers:
   - "@dchen1107"
+  - "@haircommander" # sig-node-assigned-approver
 
 see-also: []
  

--- a/keps/sig-node/4438-container-restart-termination/OWNERS
+++ b/keps/sig-node/4438-container-restart-termination/OWNERS
@@ -2,3 +2,4 @@
 
 reviewers:
   - SergeyKanzhelev # sig-node-assigned-reviewer
+  - tallclair # sig-node-assigned-reviewer

--- a/keps/sig-node/4438-container-restart-termination/kep.yaml
+++ b/keps/sig-node/4438-container-restart-termination/kep.yaml
@@ -13,6 +13,7 @@ reviewers:
   - "@mrunalp"      # overall
   - "@ahg-g"        # SIG Scheduling
   - "@SergeyKanzhelev" # sig-node-assigned-reviewer
+  - "@tallclair" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp"
   - "@thockin"

--- a/keps/sig-node/4939-grpc-probe-with-tls/OWNERS
+++ b/keps/sig-node/4939-grpc-probe-with-tls/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:
+  - sergeykanzhelev # sig-node-assigned-approver

--- a/keps/sig-node/4939-grpc-probe-with-tls/kep.yaml
+++ b/keps/sig-node/4939-grpc-probe-with-tls/kep.yaml
@@ -13,6 +13,7 @@ reviewers:
   - "@aojea"
 approvers:
   - "@mrunalp"
+  - "@sergeykanzhelev" # sig-node-assigned-approver
 see-also:
   - "/keps/sig-node/2727-grpc-probe"
 replaces:

--- a/keps/sig-node/5304-dra-attributes-downward-api/OWNERS
+++ b/keps/sig-node/5304-dra-attributes-downward-api/OWNERS
@@ -3,6 +3,8 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
+  - ffromani # sig-node-assigned-reviewer
+  - harche # sig-node-assigned-reviewer
 
 approvers:
-  - mrunalp # sig-node-tl
+  - mrunalp # sig-node-assigned-approver

--- a/keps/sig-node/5304-dra-attributes-downward-api/kep.yaml
+++ b/keps/sig-node/5304-dra-attributes-downward-api/kep.yaml
@@ -10,6 +10,8 @@ reviewers:
   - "@johnbelamaric"
   - "@mortent"
   - "@SergeyKanzhelev"
+  - "@ffromani" # sig-node-assigned-reviewer
+  - "@harche" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp" # sig-node-assigned-approver
 

--- a/keps/sig-node/5365-ImageVolume-with-image-digest/OWNERS
+++ b/keps/sig-node/5365-ImageVolume-with-image-digest/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:
+  - haircommander # sig-node-assigned-approver

--- a/keps/sig-node/5365-ImageVolume-with-image-digest/kep.yaml
+++ b/keps/sig-node/5365-ImageVolume-with-image-digest/kep.yaml
@@ -11,6 +11,7 @@ reviewers:
   - "@haircommander"
 approvers:
   - "@mrunalp"
+  - "@haircommander" # sig-node-assigned-approver
 
 see-also:
   - "keps/sig-node/4639-oci-volume-source/README.md"

--- a/keps/sig-node/5474-enable-writable-cgroups/OWNERS
+++ b/keps/sig-node/5474-enable-writable-cgroups/OWNERS
@@ -3,5 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - chris # sig-node-assigned-reviewer
+  - haircommander # sig-node-assigned-reviewer
+
+approvers:

--- a/keps/sig-node/5474-enable-writable-cgroups/OWNERS
+++ b/keps/sig-node/5474-enable-writable-cgroups/OWNERS
@@ -3,7 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - chris # sig-node-assigned-reviewer
+  - chrishenzie # sig-node-assigned-reviewer
   - haircommander # sig-node-assigned-reviewer
 
 approvers:

--- a/keps/sig-node/5474-enable-writable-cgroups/kep.yaml
+++ b/keps/sig-node/5474-enable-writable-cgroups/kep.yaml
@@ -12,7 +12,7 @@ creation-date: 2025-08-25
 approvers:
   - "@dchen1107"
 reviewers:
-  - "@chris" # sig-node-assigned-reviewer
+  - "@chrishenzie" # sig-node-assigned-reviewer
   - "@haircommander" # sig-node-assigned-reviewer
 replaces: []
 

--- a/keps/sig-node/5474-enable-writable-cgroups/kep.yaml
+++ b/keps/sig-node/5474-enable-writable-cgroups/kep.yaml
@@ -11,6 +11,9 @@ status: implementable
 creation-date: 2025-08-25
 approvers:
   - "@dchen1107"
+reviewers:
+  - "@chris" # sig-node-assigned-reviewer
+  - "@haircommander" # sig-node-assigned-reviewer
 replaces: []
 
 # Features and stages

--- a/keps/sig-node/5554-in-place-update-pod-resources-alongside-static-cpu-manager-policy/kep.yaml
+++ b/keps/sig-node/5554-in-place-update-pod-resources-alongside-static-cpu-manager-policy/kep.yaml
@@ -11,7 +11,7 @@ reviewers:
   - "@pravk03"
   - "@ffromani" # sig-node-assigned-reviewer
   - "@tallclair"
-  - "@natasha41575"
+  - "@natasha41575" # sig-node-assigned-reviewer
   - "@dchen1107"
   - "@SergeyKanzhelev"
   - "@jeremyrickard"

--- a/keps/sig-node/5677-dra-resource-availability-visibility/OWNERS
+++ b/keps/sig-node/5677-dra-resource-availability-visibility/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:
+  - harche # sig-node-assigned-approver

--- a/keps/sig-node/5677-dra-resource-availability-visibility/kep.yaml
+++ b/keps/sig-node/5677-dra-resource-availability-visibility/kep.yaml
@@ -16,6 +16,7 @@ reviewers:
   - "@pohly"
 approvers:
   - "@mrunalp"
+  - "@harche" # sig-node-assigned-approver
 
 see-also:
   - "/keps/sig-node/4381-dra-structured-parameters"

--- a/keps/sig-node/5683-lifecycle-conditions/OWNERS
+++ b/keps/sig-node/5683-lifecycle-conditions/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:
+  - sergeykanzhelev # sig-node-assigned-approver

--- a/keps/sig-node/5683-lifecycle-conditions/kep.yaml
+++ b/keps/sig-node/5683-lifecycle-conditions/kep.yaml
@@ -16,6 +16,7 @@ reviewers:
 approvers:
   - johnbelamaric
   - mrunalp
+  - "@sergeykanzhelev" # sig-node-assigned-approver
 
 see-also:
   - "/keps/sig-node/5394-psi-node-conditions"

--- a/keps/sig-node/5823-pod-level-checkpoint-restore/OWNERS
+++ b/keps/sig-node/5823-pod-level-checkpoint-restore/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - mikebrow # sig-node-assigned-reviewer
+
+approvers:

--- a/keps/sig-node/5823-pod-level-checkpoint-restore/kep.yaml
+++ b/keps/sig-node/5823-pod-level-checkpoint-restore/kep.yaml
@@ -14,6 +14,7 @@ reviewers:
   - "@tallclair"
   - "@haircommander"
   - "@kannon92"
+  - "@mikebrow" # sig-node-assigned-reviewer
 approvers:
   - "@dchen1107"
 

--- a/keps/sig-node/5855-noexec-emptyDir/OWNERS
+++ b/keps/sig-node/5855-noexec-emptyDir/OWNERS
@@ -3,5 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - harche # sig-node-assigned-reviewer
+
+approvers:
+  - haircommander # sig-node-assigned-approver

--- a/keps/sig-node/5855-noexec-emptyDir/kep.yaml
+++ b/keps/sig-node/5855-noexec-emptyDir/kep.yaml
@@ -13,8 +13,10 @@ creation-date: 2026-01-30
 reviewers:
   - "@haircommander"
   - "@jsafrane"
+  - "@harche" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp"
+  - "@haircommander" # sig-node-assigned-approver
 see-also:
 replaces:
 stage: alpha

--- a/keps/sig-node/5894-node-system-partition/OWNERS
+++ b/keps/sig-node/5894-node-system-partition/OWNERS
@@ -3,5 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
+  - fromani # sig-node-assigned-reviewer
   - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:

--- a/keps/sig-node/5894-node-system-partition/OWNERS
+++ b/keps/sig-node/5894-node-system-partition/OWNERS
@@ -3,7 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - fromani # sig-node-assigned-reviewer
   - ffromani # sig-node-assigned-reviewer
 
 approvers:

--- a/keps/sig-node/5894-node-system-partition/kep.yaml
+++ b/keps/sig-node/5894-node-system-partition/kep.yaml
@@ -9,6 +9,8 @@ status: implementable # provisional|implementable|implemented|deferred|rejected|
 creation-date: 2026-02-01
 reviewers:
   - "@tallclair"
+  - "@fromani" # sig-node-assigned-reviewer
+  - "@ffromani" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp"
 

--- a/keps/sig-node/5894-node-system-partition/kep.yaml
+++ b/keps/sig-node/5894-node-system-partition/kep.yaml
@@ -9,7 +9,6 @@ status: implementable # provisional|implementable|implemented|deferred|rejected|
 creation-date: 2026-02-01
 reviewers:
   - "@tallclair"
-  - "@fromani" # sig-node-assigned-reviewer
   - "@ffromani" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp"

--- a/keps/sig-node/5945-dra-optional-node-preparation/OWNERS
+++ b/keps/sig-node/5945-dra-optional-node-preparation/OWNERS
@@ -3,5 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - pravk03 # sig-node-assigned-reviewer
+
+approvers:
+  - harche # sig-node-assigned-approver

--- a/keps/sig-node/5945-dra-optional-node-preparation/kep.yaml
+++ b/keps/sig-node/5945-dra-optional-node-preparation/kep.yaml
@@ -8,10 +8,12 @@ status: implementable
 creation-date: 2026-05-21
 reviewers:
   - "@mortent"
+  - "@pravk03" # sig-node-assigned-reviewer
 approvers:
   - "@pohly"
   - "@johnbelamaric"
   - "@mrunalp"
+  - "@harche" # sig-node-assigned-approver
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: alpha

--- a/keps/sig-node/5996-default-pod-sysctls/OWNERS
+++ b/keps/sig-node/5996-default-pod-sysctls/OWNERS
@@ -3,5 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - haircommander # sig-node-assigned-reviewer
+
+approvers:
+  - sergeykanzhelev # sig-node-assigned-approver

--- a/keps/sig-node/5996-default-pod-sysctls/kep.yaml
+++ b/keps/sig-node/5996-default-pod-sysctls/kep.yaml
@@ -7,8 +7,10 @@ status: implementable
 creation-date: 2026-04-06
 reviewers:
   - "@SergeyKanzhelev"
+  - "@haircommander" # sig-node-assigned-reviewer
 approvers:
   - "@dchen1107"
+  - "@sergeykanzhelev" # sig-node-assigned-approver
 
 # The target maturity stage in the current dev cycle for this KEP.
 # If the purpose of this KEP is to deprecate a user-visible feature

--- a/keps/sig-node/5999-h2c-container-probes/OWNERS
+++ b/keps/sig-node/5999-h2c-container-probes/OWNERS
@@ -3,5 +3,7 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+  - haircommander # sig-node-assigned-reviewer
+
+approvers:
+  - sergeykanzhelev # sig-node-assigned-approver

--- a/keps/sig-node/5999-h2c-container-probes/kep.yaml
+++ b/keps/sig-node/5999-h2c-container-probes/kep.yaml
@@ -11,8 +11,10 @@ creation-date: 2026-04-07
 reviewers:
   - "@SergeyKanzhelev"
   - "@aojea"
+  - "@haircommander" # sig-node-assigned-reviewer
 approvers:
   - "@mrunalp"
+  - "@sergeykanzhelev" # sig-node-assigned-approver
 see-also:
   - https://github.com/kubernetes/kubernetes/issues/125599
 replaces: 

--- a/keps/sig-node/6063-pod-pid-limit/OWNERS
+++ b/keps/sig-node/6063-pod-pid-limit/OWNERS
@@ -3,5 +3,6 @@
 # Scaling up SIG Node KEP approvers: https://github.com/kubernetes/community/blob/master/sig-node/CONTRIBUTING.md#scaling-up-kep-approvers
 
 reviewers:
-  - ffromani # sig-node-assigned-reviewer
-  - natasha41575 # sig-node-assigned-reviewer
+
+approvers:
+  - mrunalp # sig-node-assigned-approver

--- a/keps/sig-node/6063-pod-pid-limit/kep.yaml
+++ b/keps/sig-node/6063-pod-pid-limit/kep.yaml
@@ -11,7 +11,7 @@ creation-date: 2026-05-06
 reviewers:
   - "@haircommander"
 approvers:
-  - "@mrunalp"
+  - "@mrunalp" # sig-node-assigned-approver
 
 see-also:
 

--- a/pkg/nodeapprovers/testdata/techleads/alpha-alias-invalid/kep.yaml
+++ b/pkg/nodeapprovers/testdata/techleads/alpha-alias-invalid/kep.yaml
@@ -4,4 +4,4 @@ owning-sig: sig-node
 stage: alpha
 approvers:
   - "@sig-node-tech-leads"
-latest-milestone: "v1.37"
+latest-milestone: "v1.99"

--- a/pkg/nodeapprovers/testdata/techleads/alpha-marker-not-allowed/kep.yaml
+++ b/pkg/nodeapprovers/testdata/techleads/alpha-marker-not-allowed/kep.yaml
@@ -5,4 +5,4 @@ stage: alpha
 approvers:
   - "@dchen1107"
   - "@tallclair" # sig-node-assigned-approver
-latest-milestone: "v1.37"
+latest-milestone: "v1.99"

--- a/pkg/nodeapprovers/testdata/techleads/alpha-missing-techlead/kep.yaml
+++ b/pkg/nodeapprovers/testdata/techleads/alpha-missing-techlead/kep.yaml
@@ -4,4 +4,4 @@ owning-sig: sig-node
 stage: alpha
 approvers:
   - "@someoneelse"
-latest-milestone: "v1.37"
+latest-milestone: "v1.99"

--- a/pkg/nodeapprovers/testdata/techleads/alpha-valid/kep.yaml
+++ b/pkg/nodeapprovers/testdata/techleads/alpha-valid/kep.yaml
@@ -5,4 +5,4 @@ stage: alpha
 approvers:
   - "@dchen1107"
   - "@someoneelse"
-latest-milestone: "v1.37"
+latest-milestone: "v1.99"

--- a/pkg/nodeapprovers/verify.go
+++ b/pkg/nodeapprovers/verify.go
@@ -498,45 +498,73 @@ func VerifyAllTechLeadApprovers(kepsRootDir, ownersAliasesPath string, upcomingM
 	})
 }
 
-// sigReleaseContentsURL is the GitHub API endpoint for listing the releases
-// directory in the kubernetes/sig-release repository.
-const sigReleaseContentsURL = "https://api.github.com/repos/kubernetes/sig-release/contents/releases"
+// k8sTagsURL is the GitHub API endpoint for listing tags in the
+// kubernetes/kubernetes repository. We request 100 tags sorted by version
+// descending so the newest tags come first.
+const k8sTagsURL = "https://api.github.com/repos/kubernetes/kubernetes/tags?per_page=100"
 
-// FetchUpcomingMinor queries the kubernetes/sig-release GitHub repository to
-// determine the upcoming Kubernetes minor version. It lists the release-X.Y
-// directories and returns the highest minor version found.
+// FetchUpcomingMinor queries the kubernetes/kubernetes GitHub repository tags
+// to determine the upcoming Kubernetes minor version. It finds the highest
+// minor version N that has a v1.N.0 or v1.N.0-rc.* tag (meaning that release
+// is done) and returns N+1. If the highest minor only has alpha/beta tags,
+// it is the upcoming release itself.
 func FetchUpcomingMinor() (int, error) {
-	resp, err := http.Get(sigReleaseContentsURL)
+	resp, err := http.Get(k8sTagsURL)
 	if err != nil {
-		return 0, fmt.Errorf("fetching sig-release contents: %w", err)
+		return 0, fmt.Errorf("fetching kubernetes tags: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("fetching sig-release contents: HTTP %d", resp.StatusCode)
+		return 0, fmt.Errorf("fetching kubernetes tags: HTTP %d", resp.StatusCode)
 	}
 
-	var entries []struct {
+	var tags []struct {
 		Name string `json:"name"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
-		return 0, fmt.Errorf("decoding sig-release contents: %w", err)
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return 0, fmt.Errorf("decoding kubernetes tags: %w", err)
 	}
 
-	maxMinor := 0
-	for _, e := range entries {
-		name := strings.TrimPrefix(e.Name, "release-")
-		if name == e.Name {
-			continue // not a release-X.Y directory
+	// Track which minor versions exist and which are "released" (have
+	// v1.X.0 or v1.X.0-rc.* tags).
+	seen := map[int]bool{}
+	released := map[int]bool{}
+	for _, t := range tags {
+		name := strings.TrimPrefix(t.Name, "v")
+		if name == t.Name {
+			continue // not a vX.Y.Z tag
 		}
-		if minor := parseMilestoneMinor(name); minor > maxMinor {
-			maxMinor = minor
+		minor := parseMilestoneMinor(name)
+		if minor == 0 {
+			continue
+		}
+		seen[minor] = true
+
+		// Check for v1.X.0 or v1.X.0-rc.* — these indicate the release
+		// is done.
+		suffix := strings.TrimPrefix(name, fmt.Sprintf("1.%d.", minor))
+		if suffix == "0" || strings.HasPrefix(suffix, "0-rc.") {
+			released[minor] = true
+		}
+	}
+
+	// Find the highest minor version seen.
+	maxMinor := 0
+	for m := range seen {
+		if m > maxMinor {
+			maxMinor = m
 		}
 	}
 
 	if maxMinor == 0 {
-		return 0, fmt.Errorf("no release-X.Y directories found in sig-release")
+		return 0, fmt.Errorf("no v1.X.Y tags found in kubernetes/kubernetes")
 	}
 
+	// If the highest minor is already released, upcoming is the next one.
+	// Otherwise the highest minor itself is the upcoming release.
+	if released[maxMinor] {
+		return maxMinor + 1, nil
+	}
 	return maxMinor, nil
 }

--- a/pkg/nodeapprovers/verify_test.go
+++ b/pkg/nodeapprovers/verify_test.go
@@ -329,7 +329,7 @@ func TestVerifyTechLeadApprovers(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			kepPath := filepath.Join("testdata", "techleads", tc.dir, "kep.yaml")
-			violations, err := VerifyTechLeadApprovers(kepPath, techLeadsFixture, 37)
+			violations, err := VerifyTechLeadApprovers(kepPath, techLeadsFixture, 99)
 			require.NoError(t, err)
 			require.ElementsMatch(t, tc.want, violations, "violations: %v", violations)
 		})
@@ -338,7 +338,7 @@ func TestVerifyTechLeadApprovers(t *testing.T) {
 
 func TestVerifyAllTechLeadApprovers(t *testing.T) {
 	root := filepath.Join("testdata", "techleads")
-	violations, err := VerifyAllTechLeadApprovers(root, filepath.Join(root, "OWNERS_ALIASES"), 37)
+	violations, err := VerifyAllTechLeadApprovers(root, filepath.Join(root, "OWNERS_ALIASES"), 99)
 	require.NoError(t, err)
 
 	want := make([]Violation, 0, 7)


### PR DESCRIPTION
/sig node

Assigned approvers and reviewers after the planning session.

(synchronized from https://github.com/orgs/kubernetes/projects/270/views/2)