### PR TITLE
KEP-5999: update for beta graduation

### DIFF
--- a/keps/prod-readiness/sig-node/5999.yaml
+++ b/keps/prod-readiness/sig-node/5999.yaml
@@ -1,3 +1,5 @@
 kep-number: 5999
 alpha:
   approver: "@soltysh"
+beta:
+  approver: "@soltysh"

--- a/keps/sig-node/5999-h2c-container-probes/README.md
+++ b/keps/sig-node/5999-h2c-container-probes/README.md
@@ -53,7 +53,7 @@
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
 - [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
-- [ ] (R) KEP approvers have approved the KEP status as `implementable`
+- [x] (R) KEP approvers have approved the KEP status as `implementable`
 - [x] (R) Design details are appropriately documented
 - [x] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
   - [ ] e2e Tests for all Beta API Operations (endpoints)
@@ -360,8 +360,18 @@ No prerequisite test updates are expected.
 
 #### Beta
 
-- No major bugs reported during alpha
-- Gather feedback from users
+- No major bugs reported during alpha; any bugs found during Beta hardening
+  are fixed and verified before graduation.
+- `H2CContainerProbe` feature gate defaults to `true`. This is opt-in
+  per-probe (only pods explicitly setting `protocol: HTTP2` are affected), so
+  enabling by default carries no behavior change for existing workloads.
+- e2e tests promoted and consistently flake-free in CI for at least two weeks.
+- `prober_probe_total` gains a `protocol` label (e.g. `protocol="HTTP2"`) so
+  usage and failure rates for h2c probes can be observed independently of
+  HTTP/1.1 probes.
+- The `scheme: HTTP`-only and empty-`host` restrictions on `protocol: HTTP2`
+  remain in place for Beta; revisit only if a concrete use case emerges.
+- Gather feedback from users running the feature in Alpha.
 
 #### GA
 
@@ -449,7 +459,10 @@ Yes. Unit tests in `pkg/apis/core/validation` and `pkg/kubelet/prober` cover:
 
 ###### How can a rollout or rollback fail? Can it impact already running workloads?
 
-
+Rollback (disabling the gate) causes the kubelet to silently probe over
+HTTP/1.1 instead of h2c. Pods whose server only speaks h2c will start
+failing their probe and restart. Pods not using `protocol: HTTP2` are
+unaffected.
 
 ###### What specific metrics should inform a rollback?
 
@@ -463,8 +476,10 @@ No.
 
 ###### Were upgrade and rollback tested? Was the upgrade->downgrade->upgrade path tested?
 
-
-
+Yes, gate enable/disable was tested on both kube-apiserver and kubelet:
+field admission/drop/preservation on the apiserver, and probe fallback +
+recovery on the kubelet. Binary-level version skew (old kubelet/new
+apiserver) has not yet been tested.
 
 ### Monitoring Requirements
 
@@ -479,11 +494,13 @@ make this easier to observe.
 
 ###### How can someone using this feature know that it is working for their instance?
 
-
+Their pod stays healthy (no probe-triggered restarts) and
+`prober_probe_total` shows successful results for the pod's probe.
 
 ###### What are the reasonable SLOs (Service Level Objectives) for the enhancement?
 
-
+h2c probe success rate should match HTTP/1.1 probe success rate for an
+equivalently healthy backend; no added probe latency.
 
 ###### What are the SLIs (Service Level Indicators) an operator can use to determine the health of the service?
 
@@ -494,7 +511,8 @@ make this easier to observe.
 
 ###### Are there any missing metrics that would be useful to have to improve observability of this feature?
 
-
+A `protocol` label on `prober_probe_total` (planned for Beta, see
+Graduation Criteria) to distinguish h2c from HTTP/1.1 probe results.
 
 ### Dependencies
 
@@ -542,18 +560,29 @@ No. The feature uses the same one-connection-per-probe model as existing HTTP pr
 
 ###### How does this feature react if the API server and/or etcd is unavailable?
 
-
+No impact. Kubelet executes probes directly against the pod IP; it does
+not contact the API server or etcd to run a probe.
 
 ###### What are other known failure modes?
 
-
+Target server doesn't speak h2c: probe fails with a connection/protocol
+error, visible in pod events (`Liveness/Readiness probe failed`), and the
+container restarts per normal probe semantics.
 
 ###### What steps should be taken if SLOs are not being met to determine the problem?
+
+Check `prober_probe_total{result="failure"}` and pod events for the
+probe's error message; confirm the target container actually serves h2c
+on the probed port.
 
 
 ## Implementation History
 
 - 2026-04-07: KEP created
+- 2026-09-09: Beta manual testing on kind — feature-gate enable/disable
+  verified on kube-apiserver and kubelet (field admission/drop/preservation,
+  probe fallback and recovery), happy-path and failure-path probe scenarios
+  verified. 
 
 
 ## Drawbacks

--- a/keps/sig-node/5999-h2c-container-probes/kep.yaml
+++ b/keps/sig-node/5999-h2c-container-probes/kep.yaml
@@ -15,11 +15,11 @@ approvers:
   - "@mrunalp"
 see-also:
   - https://github.com/kubernetes/kubernetes/issues/125599
-replaces: 
+replaces:
 
-stage: alpha
+stage: beta
 
-latest-milestone: "v1.37"
+latest-milestone: "v1.38"
 milestone:
   alpha: "v1.37"
   beta: "v1.38"


### PR DESCRIPTION
<!-- 
	Please use the following format when naming your PR
	< Issue Number >:< Issue Description >
	e.g. KEP-000: adding beta graduation criteria
	
	Avoid using phrases like `fixes #NNNN` in the description
	unless the pull request is to change the KEP status to 
	implemented or KEP has been deprecated.
-->

<!-- short description of work done in PR e.g. updating milestone, adding new KEP, adding test requirements… -->  
- One-line PR description: Bump KEP-5999 (HTTP/2 cleartext (h2c) container probes) to beta targeting v1.38.

<!-- link to the k/enhancements issue -->
- Issue link: https://github.com/kubernetes/enhancements/issues/5999

<!-- other comments or additional information -->
- Other comments: