### PR TITLE
KEP-1645: Rename id.k8s.io to cluster.clusterset.k8s.io in the DNS spec

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/specification.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/specification.md
@@ -74,12 +74,13 @@ consistent for the life of a ServiceImport from the perspective of the importing
 cluster. Requests to this IP from within a cluster will route to backends for
 the aggregated Service.”
 
-Cluster ID / `<clusterid>` = the cluster id stored in the `id.k8s.io
-ClusterProperty` as described in [KEP-2149: ClusterId for ClusterSet
-identification](../2149-clusterid/README.md). The recommended value is a
-kube-system namespace uid ( such as `721ab723-13bc-11e5-aec2-42010af0021e`). For
-ease of KEP readability, this document uses human readable names `cluster-a` and
-`cluster-b` to represent the cluster IDs of two clusters in a ClusterSet.
+Cluster ID / `<clusterid>` = the cluster id stored in the
+`cluster.clusterset.k8s.io ClusterProperty` as described in [KEP-2149:
+ClusterId for ClusterSet identification](../2149-clusterid/README.md). The
+recommended value is a kube-system namespace uid ( such as
+`721ab723-13bc-11e5-aec2-42010af0021e`). For ease of KEP readability, this
+document uses human readable names `cluster-a` and `cluster-b` to represent the
+cluster IDs of two clusters in a ClusterSet.
 
 
 ### 2.2 - Record for Schema Version

--- a/keps/sig-multicluster/1645-multi-cluster-services-api/specification.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/specification.md
@@ -77,7 +77,7 @@ the aggregated Service.”
 Cluster ID / `<clusterid>` = the cluster id stored in the
 `cluster.clusterset.k8s.io ClusterProperty` as described in [KEP-2149:
 ClusterId for ClusterSet identification](../2149-clusterid/README.md). The
-recommended value is a kube-system namespace uid ( such as
+recommended value is a kube-system namespace uid (such as
 `721ab723-13bc-11e5-aec2-42010af0021e`). For ease of KEP readability, this
 document uses human readable names `cluster-a` and `cluster-b` to represent the
 cluster IDs of two clusters in a ClusterSet.


### PR DESCRIPTION
Follow the KEP-2149 rename of the `id.k8s.io ClusterProperty` to `cluster.clusterset.k8s.io`.