### PR TITLE
KEP-1645: Fix the cluster name in the conflict message example

### DIFF
--- a/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
+++ b/keps/sig-multicluster/1645-multi-cluster-services-api/README.md
@@ -457,7 +457,7 @@ status:
     status: "True"
     lastTransitionTime: "2020-03-30T01:33:55Z"
     reason: TypeConflict
-    message: "Conflicting type. Using \"ClusterSetIP\" from oldest service export in \"cluster-1\". 2/5 clusters disagree."
+    message: "Conflicting type. Using \"ClusterSetIP\" from oldest service export in \"cluster-b\". 2/5 clusters disagree."
 ```
 
 To export a service, a `ServiceExport` should be created within the cluster and


### PR DESCRIPTION
Use `cluster-b` in the conflict message example so it matches the cluster names used elsewhere in the KEP.