### PR TITLE
KEP-6012: Update CompositePodGroup API KEP for beta in v1.38

### DIFF
--- a/keps/prod-readiness/sig-scheduling/6012.yaml
+++ b/keps/prod-readiness/sig-scheduling/6012.yaml
@@ -1,3 +1,5 @@
 kep-number: 6012
 alpha:
   approver: "@wojtek-t"
+beta:
+  approver: "@wojtek-t"

--- a/keps/sig-scheduling/6012-composite-podgroup-api/README.md
+++ b/keps/sig-scheduling/6012-composite-podgroup-api/README.md
@@ -84,6 +84,10 @@ tags, and then generate with `hack/update-toc.sh`.
     - [<code>PodSubGroup</code> and <code>PodSet</code>](#podsubgroup-and-podset)
   - [Naming of the new API](#naming-of-the-new-api)
   - [Validation of <code>CompositePodGroup</code>](#validation-of-compositepodgroup)
+  - [Mitigations for resource stealing](#mitigations-for-resource-stealing)
+    - [Double-pass evaluation within a single scheduling cycle](#double-pass-evaluation-within-a-single-scheduling-cycle)
+    - [Decoupled passes across distinct scheduling cycles](#decoupled-passes-across-distinct-scheduling-cycles)
+  - [Backtracking in the scheduling algorithm](#backtracking-in-the-scheduling-algorithm)
 - [Infrastructure Needed (Optional)](#infrastructure-needed-optional)
 <!-- /toc -->
 
@@ -105,7 +109,7 @@ checklist items _must_ be updated for the enhancement to be released.
 
 Items marked with (R) are required *prior to targeting to a milestone / release*.
 
-- [ ] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
+- [X] (R) Enhancement issue in release milestone, which links to KEP dir in [kubernetes/enhancements] (not the initial KEP PR)
 - [ ] (R) KEP approvers have approved the KEP status as `implementable`
 - [ ] (R) Design details are appropriately documented
 - [ ] (R) Test plan is in place, giving consideration to SIG Architecture and SIG Testing input (including test refactors)
@@ -116,9 +120,9 @@ Items marked with (R) are required *prior to targeting to a milestone / release*
   - [ ] (R) [all GA Endpoints](https://github.com/kubernetes/community/pull/1806) must be hit by [Conformance Tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) within one minor version of promotion to GA
 - [ ] (R) Production readiness review completed
 - [ ] (R) Production readiness review approved
-- [ ] "Implementation History" section is up-to-date for milestone
-- [ ] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
-- [ ] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
+- [X] "Implementation History" section is up-to-date for milestone
+- [X] User-facing documentation has been created in [kubernetes/website], for publication to [kubernetes.io]
+- [X] Supporting documentation—e.g., additional design documents, links to mailing list discussions/SIG meetings, relevant PRs/issues, release notes
 
 <!--
 **Note:** This checklist is iterative and should be reviewed and updated every time this enhancement is being considered for a milestone.
@@ -212,7 +216,9 @@ upon accordingly.
 - Guarantee an optimal result of multi-level scheduling algorithms.
   - Bin packing is inherently an NP-hard problem and it becomes even more
     complex for multi-level structures. While we aim to design efficient
-	heuristics, guaranteeing an optimal placement is out of scope.
+    heuristics, guaranteeing an optimal placement is out of scope.
+- Support differing group-level priorities across a single hierarchy tree.
+- Separate queueing priority from preemption priority.
 
 ## Proposal
 
@@ -617,7 +623,6 @@ information.
 // CompositePodGroups are created by workload controllers (LWS, JobSet, etc...) from
 // Workload.compositePodGroupTemplates.
 // CompositePodGroup API enablement is toggled by the CompositePodGroup feature gate.
-// FOR API REVIEW: Alternative Names: CompositeGroup
 type CompositePodGroup struct {
 	metav1.TypeMeta
 
@@ -788,7 +793,6 @@ type GangGroupSchedulingPolicy struct {
 	// +optional
 	// +k8s:required
 	// +k8s:minimum=1
-	// +k8s:immutable
 	MinGroupCount int32
 }
 ```
@@ -832,7 +836,6 @@ API:
 // DisruptionMode defines how individual entities within a composite pod group can be disrupted.
 // Exactly one mode must be set.
 // +union
-// FOR API REVIEW: Alternative Names: GroupDisruptionMode
 type CompositeDisruptionMode struct {
 	// Single specifies that children can be disrupted independently from each other.
 	//
@@ -851,14 +854,12 @@ type CompositeDisruptionMode struct {
 
 // SingleCompositeDisruptionMode means that individual children of a CompositePodGroup
 // can be disrupted or preempted independently.
-// FOR API REVIEW: Alternative Names: SingleGroupDisruptionMode
 type SingleCompositeDisruptionMode struct {
 	// This is intentionally empty.
 }
 
 // AllCompositeDisruptionMode means that children of a CompositePodGroup can only be
 // disrupted or preempted together.
-// FOR API REVIEW: Alternative Names: AllGroupDisruptionMode
 type AllCompositeDisruptionMode struct {
 	// This is intentionally empty.
 }
@@ -894,11 +895,11 @@ way as they already are for Pods and `PodGroups` - specifically, the `Priority`
 admission controller gets extended to additionally support the
 `CompositePodGroup` API.
 
-For the **Alpha** release, we enforce a strict single-priority constraint: all
-member groups and pods within a single group hierarchy tree **must share the exact
-same priority and PriorityClassName**. Support for differing group-level
-priorities under basic scheduling policies will be explored for the **Beta**
-release.
+We enforce a strict single-priority constraint: all member groups and pods
+within a single group hierarchy tree **must share the exact same priority and
+PriorityClassName**. Support for differing group-level priorities under basic
+scheduling policies could be explored independently of KEP-6012 and could be
+added in a backward-compatible way in the future, should such a use case emerge.
 
 The value of the `Priority` field is being used in the following two contexts:
 
@@ -1082,16 +1083,20 @@ points:
    generalized polymorphically to wrap either a standalone Pod, a standalone
    `PodGroupInfo`, or a nested parent `CompositePodGroup` hierarchy, allowing
    the queue to sort and pop them uniformly. To preserve this root-only
-   queue property in the presence of unsynchronized object arrivals:
-   * Unobserved groups are tracked in a dedicated `pendingPodGroups`
-     structure and only moved into the active scheduling queue when the root of
-     their hierarchy (having no parent reference) is successfully observed and
-     cached.
-   * Member pods belonging to any nested child groups inside an unobserved
-     hierarchy are placed and held inside the queue's `pendingPodGroupMembers`
-     cache. These pods are blocked from active scheduling passes and only
-     promoted when the root of their hierarchy (a PG or CPG without a parent
-     reference) is successfully observed and enqueued.
+   queue property in the presence of asynchronous, potentially out-of-order
+   object arrivals:
+   * Observed groups are stored in a dedicated `workloadForest` structure. When
+     a child group is added, it proactively registers itself in a `children` map
+     under its parent key even if the parent has not yet been observed, avoiding
+     retroactive scans. A group with any ancestor missing cannot resolve a root
+     and stays in `workloadForest` without entering the active, backoff or
+     unschedulable queue.
+   * Member pods whose root group cannot be resolved are held in the
+     `incompletePodGroupPods` structure. These pods are bypassed during
+     scheduling passes while remaining receptive to informer updates and
+     deletions. Once the root group arrives and the hierarchy is complete, leaf
+     pods are drained from `incompletePodGroupPods` and dispatched to join the
+     queued root entity (or grafted into an already-queued root subtree).
 3. **`PreEnqueue` Extension Point:** Currently, this extension point is
    defined strictly at the individual `Pod` level. Under KEP-6012, this
    prerequisite remains unchanged: `PreEnqueue` will operate strictly at the
@@ -1101,10 +1106,10 @@ points:
    *(Note: Alternatively, one could introduce a group-level PreEnqueue
    extension point. However, this would require adding support for group-level
    queuing hints in the scheduler queue backend to react only to relevant
-   events. This adds substantial complexity, making it too risky to deliver in
-   the v1.37 milestone. We therefore select the Pod-level PreEnqueue as the
-   preferred choice for Alpha, and will explore group-level abstractions in
-   Beta).*
+   events. Due to high complexity of this approach, we stick to the Pod-level
+   PreEnqueue given it was deemed sufficient in Alpha. At the same time, this
+   design choice can be revisited in the future independently of the KEP if
+   needed).*
 4. **`PlacementFeasible` Extension Point:** Currently, this extension point exists
    at the `PodGroup` level (introduced in
    [PR #138643](https://github.com/kubernetes/kubernetes/pull/138643)).
@@ -1145,20 +1150,6 @@ points:
 
    For the exact algorithm determining how these statuses are returned and evaluated
    during recursive scheduling, see [GangScheduling Plugin Changes](#gangscheduling-plugin-changes).
-5. **`Permit` Extension Point:** Currently, the `Permit` extension point is defined
-   strictly at the `Pod` level. Under KEP-6012, this remains unchanged for Alpha: we
-   do not introduce any group-level Permit extension points at the framework level.
-   Instead, we reuse the existing Pod-level `Permit` extension point to implement
-   hierarchical checks within the `GangScheduling` plugin.
-   We recognize that this Pod-level approach is suboptimal for nested hierarchies
-   since it requires recursively validating the entire parent CPG tree structure
-   for every individual member pod. Furthermore, following the introduction of
-   the `PlacementFeasible` check, it is no longer clear whether a `Permit`-stage
-   verification is strictly necessary at all. During the Beta phase, we will
-   re-evaluate this requirement; if a `Permit`-stage check remains necessary, we
-   will explore introducing a dedicated, framework-level group/hierarchy
-   `Permit` extension point (operating at the `PodGroup` or `CompositePodGroup`
-   level) to optimize and deduplicate these validations.
 
 ##### GangScheduling Plugin Changes
 
@@ -1222,39 +1213,18 @@ points:
      and their status is checked recursively using the returned `PlacementFeasible`
      values.
 
-3. **`Permit`:**
-   Executed at the Permit stage of the scheduling cycle strictly at the
-   individual `Pod` level. We extend the implementation of the existing
-   `Permit` plugin to climb the parent group references and traverse the tree
-   structure to verify constraints before releasing member pods for final
-   binding:
-   * **If the Pod belongs to a standalone group (not part of a hierarchy):**
-     We do not introduce any changes. The plugin relies on the pre-existing
-     behavior to hold member pods in a waiting state and release them once
-     the group's `minCount` member pods are successfully scheduled.
-   * **If the Pod belongs to a group hierarchy tree (nested under a parent
-     CPG):**
-     We override the flat group-level checks. When a member pod is evaluated,
-     the plugin climbs parent references up to the root CPG ancestor. It
-     traverses the entire hierarchy tree structure in the permit cache
-     (ensuring all nested child groups satisfy parent `minGroupCount` and
-     child `minCount` thresholds) starting at this root level, releasing the
-     waiting member pods for final binding only when the entire tree's
-     constraints are satisfied.
-
-4. **`EventsToRegister`:**
+3. **`EventsToRegister`:**
    Currently, the flat `GangScheduling` plugin's `EventsToRegister` method
    registers a subscription for `PodGroup` ADD events to promote blocked units.
    To support multi-level hierarchies, we extend this method to additionally
    subscribe to `CompositePodGroup` ADD events.
 
-   Even though the scheduling specs (such as `minGroupCount`) are immutable under
-   Alpha to limit design complexity, subscribing to `CompositePodGroup` Add
-   events remains strictly required: as a controller dynamically creates and adds
-   new nested child `CompositePodGroup` objects to the API server, their arrival
-   modifies the runtime hierarchy tree structure, satisfying the parent CPG's
-   `minGroupCount` threshold and promoting blocked root CPGs from the
-   unschedulable queue.
+   In Beta, we are going to support elastic multi-level workloads by making the
+   `minGroupCount` field mutable. In case of a group hierarchy held in the
+   unschedulable queue, decreasing the value of `minGroupCount` for one of its
+   groups might make the whole group admissible to the active queue. Because of
+   that, the `GangScheduling` plugin will also subscribe to the
+   `CompositePodGroup` UPDATE events.
 
 ##### Recursive Scheduling Cycle Execution
 In `schedule_one_podgroup.go`, the scheduler processes a popped root unit (a root
@@ -1297,17 +1267,16 @@ before final binding:
 > simulated sequentially in their pre-sorted order without backtracking. If a
 > child group placement (e.g. `PG-1`) consumes resources in a way that
 > subsequently blocks its sibling (e.g. `PG-2`) from meeting its `minCount`
-> minimum requirement, which in turn prevents the parent CPG from satisfying
-> its `minGroupCount` threshold, the scheduler does not retroactively
-> evaluate alternative placements for the earlier child group.
+> requirement, which in turn prevents the parent CPG from satisfying its
+> `minGroupCount` threshold, the scheduler does not retroactively evaluate
+> alternative placements or orderings for the earlier child group.
 >
-> Enforcing a greedy recursive choice without backtracking prevents exponential
-> scheduling complexity at the cost of sub-optimal decisions that may trigger
-> preemption. While sufficient for the **Alpha** phase, these greedy
-> scheduling algorithm trade-offs will be re-evaluated for the **Beta**
-> release to explore bounded backtracking heuristics (such as restricted
-> search depth or bounded branches) that optimize overall scheduling success
-> rates.
+> While we considered bounded backtracking heuristics for **Beta**, we decided
+> against implementing it in the scope of this KEP. Because search heuristics
+> can be introduced in a backward-compatible manner, this decision can be
+> revisited in future releases if production demand arises. See
+> [Backtracking in the scheduling algorithm](#backtracking-in-the-scheduling-algorithm)
+> for further details.
 
 ###### In-memory simulation state revert across the recursion stack
 
@@ -1326,15 +1295,13 @@ To resolve this, the recursive algorithm does not defer execution of the
 revert closures locally. Instead, as each child group runs its in-memory
 simulation, the registered `revertFn` closures are returned and accumulated
 (`[]revertFn`) up the recursion stack to the root CPG. Upon exit from the
-root-level `groupRecursiveSchedulingDefaultAlgorithm` execution pass, the
-accumulated revert closures are always executed all-at-once, cleanly
-restoring the shared `nodeInfoSnapshot` to its pre-execution state before the
-separate, asynchronous binding cycle triggers. To preserve the cache's
-transactional integrity, these accumulated reverts must be executed in the
-exact reverse order of their registration (matching how native deferred
-execution operates), ensuring the last registered revert is called first to
-cleanly roll back node allocations.
-
+top-level `runRootSchedulingAlgorithm` execution pass, the accumulated revert
+closures are always executed all-at-once, cleanly restoring the shared
+`nodeInfoSnapshot` to its pre-execution state before the separate, asynchronous
+binding cycle triggers. To preserve the cache's transactional integrity, these
+accumulated reverts must be executed in the exact reverse order of their
+registration (matching how native deferred execution operates), ensuring the
+last registered revert is called first to cleanly roll back node allocations.
 
 ##### Scheduling sequence for PodGroups
 
@@ -1343,9 +1310,9 @@ To ensure a deterministic processing sequence, child groups under a
 group objects are added to queue memory. During the scheduling cycle, the
 scheduler evaluates descendant child groups in this pre-sorted order.
 
-For the **Alpha** release, we can start with something simple, like e.g. sorting
-`PodGroups` / `CompositePodGroups` by their creation timestamp, and changing that
-that logic in beta if necessary.
+Since Alpha, the order of evaluation of child groups is induced by their
+creation timestamps which is consistent with the order in which Pods in leaf
+`PodGroups` are evaluated in the scheduling algorithm.
 
 ###### Preemption triggering rules
 Preemption is strictly evaluated and executed only at the root level of the
@@ -1422,73 +1389,36 @@ already handled correctly in these scenarios: the status evaluation will natural
 resolve to `UnschedulableAndUnresolvable` once it determines that the minimum
 threshold cannot be satisfied, preventing futile preemption loops entirely.
 
-However, as a performance optimization, we can skip evaluating the simulation
-of inadmissible branches entirely:
-* **Alpha:** Pre-simulation feasibility is not executed in the Alpha phase.
-  The scheduler performs the sequential child group simulations, relying on the
-  post-evaluation `PlacementFeasible` check to trigger early aborts.
-* **Beta:** We will implement an optimized pre-simulation check. The scheduler
-  will invoke the `PlacementFeasible` checker *before* starting the recursive
-  in-memory simulation of child groups. If the pre-simulation check determines
-  that a subtree is inadmissible (e.g., a nested child group is missing too many
-  member pods to ever satisfy its `minCount`), it immediately returns
-  `UnschedulableAndUnresolvable` early, bypassing all child pod placements
-  entirely and saving costly CPU cycles.
+In addition, as a performance optimization, we can skip evaluating the simulation
+of inadmissible branches entirely. In v1.37, we implemented an optimized
+pre-simulation check which invokes the `PlacementFeasible` checker *before*
+starting the recursive in-memory simulation of child groups. If the
+pre-simulation check determines that a subtree is inadmissible (e.g., a nested
+child group is missing too many member pods to ever satisfy its `minCount`), it
+immediately returns `UnschedulableAndUnresolvable` early, bypassing all child
+pod placements entirely and saving costly CPU cycles.
 
 ###### Resource stealing under greedy evaluation
-When a CPG is evaluated, child groups are processed sequentially in their
-pre-sorted order. Under the greedy evaluation, child groups try to
-schedule as many member pods as possible (potentially exceeding their `minCount`
-requirements).
+
+When a `CompositePodGroup` is evaluated, child groups are processed sequentially
+in their pre-sorted order. Under greedy evaluation, child groups attempt to
+schedule as many member pods as possible, potentially exceeding their `minCount`
+requirements.
 
 This can lead to **resource stealing** in capacity-constrained clusters: an
 early, greedy child group consumes all available slots, preventing a sibling
 child group from reaching its `minCount` and causing the entire root CPG gang
 to fail scheduling.
 
-For the **Alpha** phase, we do not optimize or solve this resource stealing
-challenge for complex, constrained layouts. Instead, we focus on ensuring that
-the most common and typical use-cases work out-of-the-box: scenarios
-where the minimum constraints equal the actual size (`minCount = actualCount`
-and `minGroupCount` equals the total child group count). Under this standard
-baseline, this problem doesn't exist.
+To mitigate this problem, we initially planned to introduce a non-greedy mode to
+the scheduling algorithm in Beta. After exploring this direction more deeply, we
+decided to retain the greedy evaluation for the time being and to defer the
+prospect of adjusting the evaluation logic in the algorithm to the future
+releases.
 
-For the **Beta** release, we will evaluate two distinct alternatives to solve
-resource stealing for arbitrary, multi-level layouts:
-
-* **Double-run in a single cycle:** The scheduler runs the recursive algorithm
-  twice within a single scheduling cycle: a non-greedy pass first to place the
-  minimal gang, followed by a greedy pass for extra pods. This approach is highly
-  responsive; if active member pods are deleted and cause a scheduled CPG to
-  fall below its minimum thresholds, a single active cycle can immediately
-  recover the gang via a non-greedy pass. In terms of complexity, running two
-  passes in a single cycle does not significantly degrade latency, since the CPU
-  cost is strictly dominated by individual pod schedulings (each pod is
-  still evaluated exactly once end-to-end in both models).
-* **Distinct scheduling cycles:** The scheduler runs a single non-greedy pass in the
-  active cycle, commits the minimal gang, and lets extra pending member pods
-  trigger separate, subsequent scheduling cycles (running in greedy mode) to
-  place the remaining pods. This approach reduces scheduling latency under single
-  passes and mitigates Head-of-Line (HoL) queue blocking by allowing
-  higher-priority workloads to interleave and schedule in between the separate
-  greedy passes. A potential drawback is that cycle mode is not a one-off
-  transition from non-greedy to greedy. If active member pods are deleted (e.g. due to
-  node failures) and cause the CPG tree to drop below its
-  `minGroupCount` threshold, the scheduling policy is no longer satisfied. The
-  scheduler must then dynamically oscillate the cycle mode back to non-greedy
-  to re-secure the minimal gang. Coordinating this behavior
-  across separate, decoupled scheduling passes in the queue introduces
-  complexity in the code.
-
-Under topology-aware scheduling, a multi-pass approach also introduces 
-a key trade-off: a non-greedy first pass may select and lock in an optimal 
-topology placement for the minimal gang that subsequently prevents the second 
-greedy pass from placing optional pods (whereas a single pass could identify
-a globally feasible topology for all pods). This trade-off is unavoidable and
-would occur even in single-pass models when optional pods are added later,
-representing a fundamental trade-off between securing placements for the
-minimal gang and finding the globally optimal topology configuration. We will
-evaluate these topological trade-offs in detail during the Beta phase.
+For a detailed analysis of the possible solutions, their trade-offs, and the
+rationale for deferral, see [this section](#mitigations-for-resource-stealing)
+in the alternatives.
 
 ###### Handling new pods for scheduled hierarchies
 If a controller scales up a scheduled `CompositePodGroup` hierarchy by
@@ -1516,18 +1446,23 @@ essentially a heuristic that relaxes the requirement for global optimum in
 exchange for drastically reduced computational complexity.
 
 In particular, this implies that `kube-scheduler` might fail to find a placement
-for a multi-level gang even despite the sufficiency of resources in the cluster.
-This can be a side effect of suboptimal placement decisions that were made for
-individual Pods, e.g. due to the sequence in which placement for individual Pods
-of a gang was established. This problem already exists in case of scheduling a
-heterogeneous `PodGroup` gang but it might manifest itself to a larger degree.
+for a multi-level gang even when sufficient resources exist in the cluster.
+This can be a side effect of suboptimal placement decisions made for individual
+Pods or child groups—for example, when evaluating heterogeneous sibling child
+groups in a fixed, pre-sorted sequence without exploring alternative orderings.
+While this issue already exists when scheduling a heterogeneous flat `PodGroup`
+gang, it can manifest more acutely in multi-level hierarchies where early child
+group placements consume resources needed by later siblings.
 
-For Beta, we will decide whether or not we need additional heuristics to
-increase the chance of getting a group hierarchy scheduled. That said,
-regardless of what we eventually do, we will not overcome the problem's
-NP-hardness with heuristics. Regardless of the ultimate path taken, we will
-comprehensively document these scheduling limitations to ensure users are fully
-aware of potential sub-optimal placement scenarios.
+That said, we decided not to implement any search heuristics like backtracking
+in the scope of this KEP. Any backtracking mechanism would incur a non-trivial
+overhead to the scheduling latency and substantially complicate the logic of the
+scheduling algorithm. In addition, a potential return on investment seems
+unclear at the moment.
+
+Further rationale for this decision, together with an analysis of trade-offs, is
+covered in the [alternatives section](#backtracking-in-the-scheduling-algorithm)
+about backtracking.
 
 #### Integration with workload-aware preemption
 
@@ -1619,10 +1554,12 @@ the root CPG, the scheduler invokes the preemption algorithm strictly at the roo
 > for placing $C$ child groups, each with $D$ placement options, from
 > exponential ($\mathcal{O}(D^C)$) to linear ($\mathcal{O}(C \cdot D)$).
 >
-> While this greedy search trade-off helps prevent severe scheduling latency
-> degradation in the **Alpha** phase, it increases placement failure rates in
-> capacity-constrained environments. Bounded backtracking heuristics and their
-> latency trade-offs will be thoroughly evaluated for **Beta**.
+> While avoiding backtracking can increase placement failures in the
+> capacity-constrained clusters, we decided not to implement backtracking in
+> the TAS algorithm in scope of this KEP. Adding multi-level topology rollback
+> logic and evaluating domain permutations would cripple scheduler throughput
+> for uncertain gains. Backtracking search heuristics can be introduced in a
+> backward-compatible manner in the future if usage patterns warrant them.
 
 ###### Example
 Consider a workload consisting of a root `CompositePodGroup` (`CPG-root`)
@@ -1723,9 +1660,6 @@ The scheduling algorithm resolves this hierarchy recursively:
    * The scheduler commits the resolved layout and proceeds to bind the pods of
      `PG-1` and `PG-2` to their physical target nodes inside `block-B`.
 
-
-
-
 ##### Preemption in topology-aware scheduling
 
 Workload preemption under topology constraints is the domain of [KEP-5710]
@@ -1786,9 +1720,8 @@ suite in `test/integration/scheduler/`) to cover the hierarchical and multi-leve
 the CPG API and the recursive scheduling resolutions:
 
 - **CPG Queueing and Requeueing:**
-  - Verify that CPG hierarchies with unobserved parents are buffered inside
-    `pendingPodGroups` and not promoted to the active scheduling queue until
-    the root CPG object is observed.
+  - Verify that CPG hierarchies with unobserved parents are not promoted to the
+    active scheduling queue until the root CPG object is observed.
   - Verify that the arrival of cluster events successfully triggers queueing
     hints to move blocked CPG hierarchies from the unschedulable queue back
     to the active queue (`activeQ`) or backoff queue (`backoffQ`).
@@ -1854,8 +1787,8 @@ More tests will be added for beta release.
 
 - `CompositePodGroup` object is protected against deletion if any group refers
   to it.
-- At least one true workload controller (e.g. `JobSet`) is integrated with the
-  `CompositePodGroup` API.
+- At least one true workload controller (e.g. `JobSet`) is planned to be
+  integrated with the `CompositePodGroup` API.
 - Scheduler detects invalid runtime group hierarchies (i.e. hierarchies which
   are too deep, have a cycle, refer to two or more Workloads, or have an
   invalid combination of scheduling policies or disruption modes at different
@@ -1868,19 +1801,13 @@ More tests will be added for beta release.
   groups during recursion by extending `PlacementFeasible` to execute checks
   prior to in-memory scheduling (to protect performance and avoid redundant
   preemption passes).
-- A non-greedy `CompositePodGroup` scheduling cycle mode is introduced and
-  re-evaluated to mitigate resource stealing and gang deadlock occurrences
-  among sibling child groups in capacity-constrained environments.
-- Support for differing group-level priorities across a single hierarchy tree
-  under basic scheduling policies and separating queueing priority from
-  preemption priority is re-evaluated.
+- Resource stealing-related tradeoffs are analyzed and a decision about
+  adjustments to the greedy scheduling cycle algorithm is made.
 - The `minGroupCount` field of the `CompositePodGroup` objects becomes
   mutable at runtime (aligning with the pre-existing mutable `minCount` field
   in `PodGroup` objects).
 - Scheduler diagnostics and recommendations with regards to the scheduling order
   are re-evaluated to improve troubleshooting and scheduling success rates.
-- GangScheduling's `PlacementFeasible` extension point is changed to propagate
-  pod-level `UnschedulableAndUnresolvable`, making the logic identical across all levels.
 - The logic for triggering preemption for subsequent scheduling is re-evaluated in case
   the scheduling policy is not initially satisfied (e.g., PG has been disrupted or `minCount`
   has changed).
@@ -1889,7 +1816,7 @@ More tests will be added for beta release.
 
 - All e2e tests for the `CompositePodGroup` API are added and graduated to
   conformance tests.
-- TBD in for Beta release
+- All issues identified during Beta are resolved.
 
 ### Upgrade / Downgrade Strategy
 
@@ -1976,7 +1903,6 @@ This section must be completed when targeting alpha to a release.
     - This dependency is programmatically verified during component initialization (the
       components will log a configuration error and disable `CompositePodGroup` processing
       if any required dependency gate is missing).
-    - We will re-evaluate this simplified feature gate dependency model in Beta if needed.
 
 ###### Does enabling the feature change any default behavior?
 
@@ -2127,20 +2053,8 @@ This section must be completed when targeting beta to a release.
 
 ###### Does this feature depend on any specific services running in the cluster?
 
-<!--
-Think about both cluster-level services (e.g. metrics-server) as well
-as node-level agents (e.g. specific version of CRI). Focus on external or
-optional services that are needed. For example, if this feature depends on
-a cloud provider API, or upon an external software-defined storage or network
-control plane.
-
-For each of these, fill in the following—thinking about running existing user workloads
-and creating new ones, as well as about cluster-level services (e.g. DNS):
-  - [Dependency name]
-    - Usage description:
-      - Impact of its outage on the feature:
-      - Impact of its degraded performance or high-error rates on the feature:
--->
+No dependencies other than the components where the feature is implemented
+(kube-apiserver and kube-scheduler).
 
 ### Scalability
 
@@ -2164,15 +2078,15 @@ Watching for CompositePodGroups:
   - originating component: kube-scheduler, kube-controller-manager (GC
     controller, PodGroup protection controller)
 
-Status updates (potentially not in Alpha):
+Status updates:
   - API call type: PUT/PATCH CompositePodGroups status
-  - estimated throughput < XX/s
+  - estimated throughput: < XX/s
   - originating component: kube-scheduler
 
-Watching for Workloads for validation (Beta):
+Watching for Workloads:
   - API call type: LIST+WATCH Workloads
-  - estimated throughput < XX/s
-  - originating component: kube-scheduler
+  - estimated throughput: < XX/s
+  - originating component: kube-controller-manager (GC controller)
 
 ###### Will enabling / using this feature result in introducing new API types?
 
@@ -2381,6 +2295,117 @@ analogous checks for the incoming `CompositePodGroups`. However, this plugin was
 removed in the early stage of the 1.37 release cycle[^9] because of the
 performance-related concerns and the fact that cross-object admission
 enforcement is always best effort.
+
+### Mitigations for resource stealing
+
+To mitigate the issue of resource stealing in greedy child groups evaluation in
+the recursive scheduling algorithm, we considered two distinct approaches that
+were already described in the initial version of the proposal.
+
+#### Double-pass evaluation within a single scheduling cycle
+
+We prototyped this model in [PR #141472](https://github.com/kubernetes/kubernetes/pull/141472).
+The idea is to run the recursive simulation twice within a single scheduling cycle:
+
+1. **Non-greedy first pass:** Evaluates child groups strictly up to their
+   `minCount` and `minGroupCount` thresholds, ensuring the minimal viable gang
+   can fit without starving any sibling groups.
+2. **Greedy second pass:** If the first pass succeeds, a second pass evaluates
+   any remaining optional pods against the remaining cluster capacity.
+
+While the POC verified that this approach works for initial placement, there are
+a couple of drawbacks that make it undesirable for the scheduler's core loop:
+
+- **High complexity of implementation:** Coordinating speculative simulation
+  state across two sequential passes in a single cycle substantially complicates
+  the scheduling logic. Managing partial rollbacks, resetting plugin state, and
+  keeping the cache synchronized across multiple recursive levels increases
+  maintenance overhead and introduces fragile failure paths.
+- **No support for scale-up:** If a controller creates new member pods or child
+  groups for an already scheduled hierarchy, those pods are handled in separate,
+  subsequent scheduling cycles. Because running pods cannot be displaced without
+  preemption, the double-pass algorithm provides no mechanism to rebalance
+  capacity among groups after initial binding.
+- **Topology reservation conflicts:** Under topology-aware scheduling, the
+  initial non-greedy pass locks in a topological placement for the minimal gang.
+  This placement can inadvertently fragment the remaining topology domain such
+  that optional pods cannot fit—even in scenarios where a unified single-pass
+  greedy evaluation could have found a valid topology for all pods.
+
+#### Decoupled passes across distinct scheduling cycles
+
+An alternative design runs a single non-greedy pass during the active cycle to
+bind the minimal gang, leaving any surplus pods in the scheduling queue. These
+remaining pods then trigger subsequent, separate scheduling cycles running in
+greedy mode. While this approach reduces the scheduling latency by avoiding
+running two passes within a single scheduling cycle, it would introduce
+significant challenges:
+
+- **Mode oscillation:** The transition from non-greedy to greedy cannot be a
+  one-time switch. If running pods are deleted (due to node failure or eviction)
+  and the hierarchy drops below its `minCount` or `minGroupCount`, the scheduler
+  must detect this condition and dynamically revert the group back to non-greedy
+  mode in future cycles to guarantee recovery of the minimal gang. Managing this
+  mode switching across decoupled queue passes introduces complex race
+  conditions.
+- **Interleaving and unpredictability:** Because subsequent passes are
+  decoupled, other workloads in the queue can interleave and consume remaining
+  capacity between passes, leading to non-deterministic, partial scheduling of
+  optional pods.
+- **Topology reservation conflicts:** Same as in the first approach, the
+  non-greedy pass might lock in a topological placement that is suboptimal for
+  the set of all pods in the hierarchy, possibly resulting in failing to
+  schedule optional pods even in the presence of sufficient capacity.
+
+### Backtracking in the scheduling algorithm
+
+Both the standard recursive scheduling algorithm and the multi-level
+topology-aware scheduling algorithm iterate over sibling child groups in a
+pre-sorted order and do not perform backtracking. If an early child group
+placement consumes resources or locks in topology domains in a manner that
+subsequently blocks a sibling from meeting its `minCount`, the scheduler
+terminates the group simulation instead of exploring alternative placements or
+evaluating different sibling orderings.
+
+This can result in failing to find a placement for heterogeneous multi-level
+groups even when the cluster possesses enough aggregate capacity to host the
+entire workload. The scheduler fails to find a placement because it evaluates
+siblings in a single, pre-determined order, disregarding other possible
+permutations rather than facing a fundamental lack of capacity.
+
+During the Alpha phase, this behavior was documented as an intended initial
+simplification, with plans to evaluate bounded backtracking heuristics (such as
+restricted search depth or bounded branches) during Beta phase. However, we
+decided **not to implement backtracking in the scheduling algorithm** in scope
+of this proposal.
+
+This decision is based on several architectural and operational factors:
+
+- **Increased scheduling latency:** Exploring alternative sibling orderings
+  or candidate placements shifts the algorithmic complexity from linear to
+  combinatorial. Even with bounded search heuristics, backtracking inside the
+  scheduling cycle would increase the number of simulated pod placements and
+  plugin executions at the cost of spikes in the scheduling latency and
+  head-of-line blocking in high-throughput clusters.
+- **High implementation complexity:** Implementing transactional rollback across
+  arbitrary depths of a recursive hierarchy is exceptionally complex. The
+  scheduler would need to track and revert not only pod-to-node assignments in
+  the `nodeInfoSnapshot`, but also plugin cycle states, topology domain
+  assumptions, and preemption estimations across multiple backtrack points. The
+  architectural overhead and maintenance burden of this machinery would be
+  substantially higher than introducing a non-greedy evaluation mode.
+- **Unclear return on investment:** Real-world composite workloads (such as
+  distributed training jobs composed of parameter servers and workers, or
+  disaggregated serving pipelines) are predominantly scheduled in provisioned
+  environments where inter-sibling contention within the same gang is rare.
+  Placement failures caused strictly by the absence of sibling backtracking
+  represent a narrow edge case, making the massive code complexity difficult to
+  justify.
+
+In addition, any future search heuristics or backtracking strategies can be
+introduced in the scheduling algorithm in a fully backward-compatible manner.
+Because of this, this decision can be safely revisited in future releases if
+production use cases and concrete workload patterns warrant it.
 
 ## Infrastructure Needed (Optional)
 

--- a/keps/sig-scheduling/6012-composite-podgroup-api/kep.yaml
+++ b/keps/sig-scheduling/6012-composite-podgroup-api/kep.yaml
@@ -22,9 +22,9 @@ see-also:
   - "/keps/sig-scheduling/5729-resourceclaim-support-for-workloads"
   - "/keps/sig-scheduling/5732-topology-aware-workload-scheduling"
 
-stage: alpha
+stage: beta
 
-latest-milestone: "v1.37"
+latest-milestone: "v1.38"
 
 milestone:
   alpha: "v1.37"


### PR DESCRIPTION
- One-line PR description: Update CompositePodGroup API KEP for beta in v1.38

- Issue link: https://github.com/kubernetes/enhancements/issues/6012

- Other comments:
  - Dropped `Permit`-specific changes since it got removed from the `GangScheduling` plugin in https://github.com/kubernetes/kubernetes/pull/141182.
  - TODO: Align on the preemption triggering logic beta requirement.
  - TODO: Align on the runtime validation of group hierarchies.